### PR TITLE
Use `require` to fail tests fast

### DIFF
--- a/cmd/app_test.go
+++ b/cmd/app_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"github.com/data-preservation-programs/singularity/handler/deal/schedule"
 	"io"
 	"net/http"
 	"os"
@@ -18,6 +17,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/data-preservation-programs/singularity/handler/deal/schedule"
+	"github.com/stretchr/testify/require"
 
 	"filippo.io/age"
 	"github.com/data-preservation-programs/singularity/database"
@@ -36,7 +38,6 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/parnurzeal/gorequest"
 	"github.com/rjNemo/underscore"
-	"github.com/stretchr/testify/assert"
 	"golang.org/x/exp/slices"
 	"gorm.io/gorm"
 )
@@ -49,25 +50,25 @@ func generateRandomBytes(n int) []byte {
 
 func decrypt(t *testing.T, key string, encrypted []byte) []byte {
 	recipient, err := age.ParseX25519Identity(key)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	decrypted, err := age.Decrypt(bytes.NewReader(encrypted), recipient)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	buf := new(bytes.Buffer)
 	_, err = io.Copy(buf, decrypted)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return buf.Bytes()
 }
 
 func loadCars(t *testing.T, path string) blockstore.Blockstore {
 	files, err := os.ReadDir(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
 	for _, file := range files {
 		f, err := os.Open(path + "/" + file.Name())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		reader := bufio.NewReader(f)
 		_, err = car.ReadHeader(reader)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		for {
 			c, data, err := util.ReadNode(reader)
 			if err == io.EOF {
@@ -75,7 +76,7 @@ func loadCars(t *testing.T, path string) blockstore.Blockstore {
 			}
 			blk, _ := blocks.NewBlockWithCid(data, c)
 			err = bs.Put(context.TODO(), blk)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 	}
 	return bs
@@ -86,23 +87,23 @@ func getFileFromRootNode(t *testing.T, dagServ format.DAGService, path string, r
 	segments := strings.Split(path, "/")
 	for _, segment := range segments {
 		rootNode, err := dagServ.Get(context.Background(), rootCID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		rootDir, err := uio.NewDirectoryFromNode(dagServ, rootNode)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		links, err := rootDir.Links(ctx)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		link, err := underscore.Find(links, func(link *format.Link) bool {
 			return link.Name == segment
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		rootCID = link.Cid
 	}
 	fileNode, err := dagServ.Get(ctx, rootCID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	dagReader, err := uio.NewDagReader(ctx, fileNode, dagServ)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	content, err := io.ReadAll(dagReader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return content
 }
 func listDirsFromRootNode(t *testing.T, dagServ format.DAGService, path string, rootCID cid.Cid) []string {
@@ -113,24 +114,24 @@ func listDirsFromRootNode(t *testing.T, dagServ format.DAGService, path string, 
 	}
 	for _, segment := range segments {
 		rootNode, err := dagServ.Get(context.Background(), rootCID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		rootDir, err := uio.NewDirectoryFromNode(dagServ, rootNode)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		links, err := rootDir.Links(ctx)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		link, err := underscore.Find(links, func(link *format.Link) bool {
 			return link.Name == segment
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		rootCID = link.Cid
 	}
 
 	rootNode, err := dagServ.Get(context.Background(), rootCID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	rootDir, err := uio.NewDirectoryFromNode(dagServ, rootNode)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	links, err := rootDir.Links(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return underscore.Map(links, func(link *format.Link) string {
 		return link.Name
 	})
@@ -150,10 +151,10 @@ func testWithAllBackendWithResetArg(t *testing.T, testFunc func(ctx context.Cont
 		os.Setenv("DATABASE_CONNECTION_STRING", backend[1])
 		if reset {
 			_, _, err := RunArgsInTest(context.Background(), "singularity admin reset")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 		db, err := database.Open(backend[1], &gorm.Config{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 		defer cancel()
 		t.Run(backend[0], func(t *testing.T) {
@@ -169,9 +170,9 @@ func testWithAllBackend(t *testing.T, testFunc func(ctx context.Context, t *test
 func TestHelpPage(t *testing.T) {
 	testWithAllBackendWithoutReset(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
 		_, _, err := RunArgsInTest(ctx, "singularity help")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity download -h")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -180,7 +181,7 @@ func TestDealTracker(t *testing.T) {
 		ctx2, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
 		_, _, err := RunArgsInTest(ctx2, "singularity run deal-tracker")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -190,7 +191,7 @@ func TestRunAPI(t *testing.T) {
 		defer cancel()
 		go func() {
 			_, _, err := RunArgsInTest(ctx2, "singularity run api")
-			assert.ErrorContains(t, err, "Server closed")
+			require.ErrorContains(t, err, "Server closed")
 		}()
 		time.Sleep(time.Second)
 		var resp *http.Response
@@ -198,96 +199,96 @@ func TestRunAPI(t *testing.T) {
 		var errs []error
 		resp, body, errs = gorequest.New().
 			Post("http://127.0.0.1:9090/api/admin/init").End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-		assert.Equal(t, "", body)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusNoContent, resp.StatusCode)
+		require.Equal(t, "", body)
 
 		resp, body, errs = gorequest.New().
 			Post("http://127.0.0.1:9090/api/admin/reset").End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-		assert.Equal(t, "", body)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusNoContent, resp.StatusCode)
+		require.Equal(t, "", body)
 
 		resp, body, errs = gorequest.New().Post("http://127.0.0.1:9090/api/dataset").
 			Send(`{"name":"test","maxSize":"31.5GiB"}`).End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `"name": "test"`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `"name": "test"`)
 
 		defer func() {
 			resp, body, errs = gorequest.New().Delete("http://127.0.0.1:9090/api/dataset/test").End()
-			assert.Len(t, errs, 0)
-			assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-			assert.Equal(t, "", body)
+			require.Len(t, errs, 0)
+			require.Equal(t, http.StatusNoContent, resp.StatusCode)
+			require.Equal(t, "", body)
 		}()
 
 		resp, body, errs = gorequest.New().Post("http://127.0.0.1:9090/api/dataset").
 			Send(`{"name":"test"}`).End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		assert.Contains(t, body, `"err":`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.Contains(t, body, `"err":`)
 
 		resp, body, errs = gorequest.New().Patch("http://127.0.0.1:9090/api/dataset/test").
 			Send(`{"maxSize":"30.5GiB"}`).End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `"name": "test"`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `"name": "test"`)
 
 		resp, body, errs = gorequest.New().Get("http://127.0.0.1:9090/api/dataset").End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `"name": "test"`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `"name": "test"`)
 
 		resp, body, errs = gorequest.New().Post("http://127.0.0.1:9090/api/dataset/test/piece").
 			Send(`{"pieceCid":"baga6ea4seaqdyupo27fj2fk2mtefzlxvrbf6kdi4twdpccdzbyqrbpsvfsh5ula","pieceSize":"1024","rootCid":"bafy2bzacecq55ww767qv2r3cvlorjxhcvn3dglccajiicsqgctpm7qfrtncw4"}`).End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `"pieceSize": 1024`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `"pieceSize": 1024`)
 
 		resp, body, errs = gorequest.New().Get("http://127.0.0.1:9090/api/dataset/test/piece").End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `"pieceSize": 1024`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `"pieceSize": 1024`)
 
 		godotenv.Load("../.env", ".env")
 		key := os.Getenv("TEST_WALLET_KEY")
 		resp, body, errs = gorequest.New().Post("http://127.0.0.1:9090/api/wallet").
 			Send(`{"privateKey":"` + key + `"}`).End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, key)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, key)
 
 		resp, body, errs = gorequest.New().Post("http://127.0.0.1:9090/api/wallet/remote").
 			Send(`{"remotePeer":"12D3KooWD3eckifWpRn9wQpMG9R9hX3sD158z7EqHWmweQAJU5SA","address":"f1ys5qqiciehcml3sp764ymbbytfn3qoar5fo3iwy"}`).End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, "12D3KooWD3eckifWpRn9wQpMG9R9hX3sD158z7EqHWmweQAJU5SA")
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, "12D3KooWD3eckifWpRn9wQpMG9R9hX3sD158z7EqHWmweQAJU5SA")
 
 		resp, body, errs = gorequest.New().Delete("http://127.0.0.1:9090/api/wallet/f1ys5qqiciehcml3sp764ymbbytfn3qoar5fo3iwy").End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-		assert.Equal(t, ``, body)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusNoContent, resp.StatusCode)
+		require.Equal(t, ``, body)
 
 		resp, body, errs = gorequest.New().Get("http://127.0.0.1:9090/api/wallet").End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, key)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, key)
 
 		resp, body, errs = gorequest.New().Post("http://127.0.0.1:9090/api/dataset/test/wallet/f01074655").End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `"datasetId": 1`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `"datasetId": 1`)
 
 		resp, body, errs = gorequest.New().Get("http://127.0.0.1:9090/api/dataset/test/wallet").End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `"address": "`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `"address": "`)
 
 		defer func() {
 			resp, body, errs = gorequest.New().Delete("http://127.0.0.1:9090/api/dataset/test/wallet/f01074655").End()
-			assert.Len(t, errs, 0)
-			assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-			assert.Equal(t, ``, body)
+			require.Len(t, errs, 0)
+			require.Equal(t, http.StatusNoContent, resp.StatusCode)
+			require.Equal(t, ``, body)
 		}()
 
 		createSchedule := schedule.CreateRequest{
@@ -301,124 +302,124 @@ func TestRunAPI(t *testing.T) {
 			MaxPendingDealSize: "1P",
 		}
 		createScheduleBody, err := json.Marshal(createSchedule)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		resp, body, errs = gorequest.New().Post("http://127.0.0.1:9090/api/deal/schedule").Send(string(createScheduleBody)).End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `"id": 1`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `"id": 1`)
 
 		resp, body, errs = gorequest.New().Post("http://127.0.0.1:9090/api/source/local/dataset/test").
 			Send(`{"sourcePath":"/tmp","caseInsensitive":"false","deleteAfterExport":false,"rescanInterval":"1h"}`).End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `"id": 1`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `"id": 1`)
 
 		resp, body, errs = gorequest.New().Get("http://127.0.0.1:9090/api/source").End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `"id": 1`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `"id": 1`)
 
 		resp, body, errs = gorequest.New().Patch("http://127.0.0.1:9090/api/source/1").
 			Send(`{"deleteAfterExport": true, "rescanInterval": "12h", "localCaseInsensitive":"true"}`).End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `"id": 1`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `"id": 1`)
 
 		defer func() {
 			resp, body, errs = gorequest.New().Delete("http://127.0.0.1:9090/api/source/1").End()
-			assert.Len(t, errs, 0)
-			assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-			assert.Equal(t, ``, body)
+			require.Len(t, errs, 0)
+			require.Equal(t, http.StatusNoContent, resp.StatusCode)
+			require.Equal(t, ``, body)
 		}()
 
 		resp, body, errs = gorequest.New().Post("http://127.0.0.1:9090/api/source/1/rescan").End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `"id": 1`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `"id": 1`)
 
 		resp, body, errs = gorequest.New().Post("http://127.0.0.1:9090/api/source/1/check").
 			Send(`{"path":""}`).End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `[`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `[`)
 
 		resp, body, errs = gorequest.New().Get("http://127.0.0.1:9090/api/source/1/summary").End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `{`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `{`)
 
 		resp, body, errs = gorequest.New().Get("http://127.0.0.1:9090/api/source/1/chunks").End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `[`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `[`)
 
 		resp, body, errs = gorequest.New().Get("http://127.0.0.1:9090/api/source/1/items").End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `[`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `[`)
 
 		resp, body, errs = gorequest.New().Get("http://127.0.0.1:9090/api/source/1/dags").End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `[`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `[`)
 
 		resp, body, errs = gorequest.New().Get("http://127.0.0.1:9090/api/source/1/path").
 			Send(`{"path":""}`).End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `[`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `[`)
 
 		resp, body, errs = gorequest.New().Get("http://127.0.0.1:9090/api/item/1").End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 		resp, body, errs = gorequest.New().Get("http://127.0.0.1:9090/api/chunk/1").End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 		resp, body, errs = gorequest.New().Post("http://127.0.0.1:9090/api/deal/send_manual").Send(`{}`).End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		assert.Contains(t, body, `client address not found`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.Contains(t, body, `client address not found`)
 
 		resp, body, errs = gorequest.New().Post("http://127.0.0.1:9090/api/deal/list").Send(`{}`).End()
-		assert.Len(t, errs, 0)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Contains(t, body, `[`)
+		require.Len(t, errs, 0)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Contains(t, body, `[`)
 	})
 }
 
 func TestListDeals(t *testing.T) {
 	testWithAllBackend(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
 		_, _, err := RunArgsInTest(ctx, "singularity deal list --dataset test --schedule 1 --provider f01 --state active")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
 func TestResetDatabase(t *testing.T) {
 	testWithAllBackendWithoutReset(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
 		_, _, err := RunArgsInTest(ctx, "singularity admin reset")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
 func TestInitDatabase(t *testing.T) {
 	testWithAllBackendWithoutReset(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
 		_, _, err := RunArgsInTest(ctx, "singularity admin init")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
 func TestDealScheduleCrud(t *testing.T) {
 	testWithAllBackend(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
 		_, _, err := RunArgsInTest(ctx, "singularity dataset create test")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity wallet add-remote f1l2cc5vuw5moppwsjd3b7cjtwa2exowqo36esklq 12D3KooWD3eckifWpRn9wQpMG9R9hX3sD158z7EqHWmweQAJU5SA")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity dataset add-wallet test f02170643")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity deal schedule create test f022352")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -427,92 +428,92 @@ func TestWalletCrud(t *testing.T) {
 	testWithAllBackend(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
 		key := os.Getenv("TEST_WALLET_KEY")
 		_, _, err := RunArgsInTest(ctx, "singularity dataset create test")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity wallet import "+key)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		out, _, err := RunArgsInTest(ctx, "singularity wallet list ")
-		assert.NoError(t, err)
-		assert.Contains(t, out, "f01074655")
+		require.NoError(t, err)
+		require.Contains(t, out, "f01074655")
 		_, _, err = RunArgsInTest(ctx, "singularity wallet add-remote f1l2cc5vuw5moppwsjd3b7cjtwa2exowqo36esklq 12D3KooWD3eckifWpRn9wQpMG9R9hX3sD158z7EqHWmweQAJU5SA")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		out, _, err = RunArgsInTest(ctx, "singularity wallet list ")
-		assert.NoError(t, err)
-		assert.Contains(t, out, "f02170643")
+		require.NoError(t, err)
+		require.Contains(t, out, "f02170643")
 		out, _, err = RunArgsInTest(ctx, "singularity dataset add-wallet test f01074655")
-		assert.NoError(t, err)
-		assert.Contains(t, out, "f01074655")
+		require.NoError(t, err)
+		require.Contains(t, out, "f01074655")
 		out, _, err = RunArgsInTest(ctx, "singularity dataset list-wallet test")
-		assert.NoError(t, err)
-		assert.Contains(t, out, "f01074655")
+		require.NoError(t, err)
+		require.Contains(t, out, "f01074655")
 		_, _, err = RunArgsInTest(ctx, "singularity dataset remove-wallet test f01074655")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		out, _, err = RunArgsInTest(ctx, "singularity dataset list-wallet test")
-		assert.NoError(t, err)
-		assert.NotContains(t, out, "f01074655")
+		require.NoError(t, err)
+		require.NotContains(t, out, "f01074655")
 		_, _, err = RunArgsInTest(ctx, "singularity wallet remove f01074655")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		out, _, err = RunArgsInTest(ctx, "singularity wallet list ")
-		assert.NoError(t, err)
-		assert.NotContains(t, out, "f01074655")
+		require.NoError(t, err)
+		require.NotContains(t, out, "f01074655")
 	})
 }
 
 func TestDatasetAddPiece(t *testing.T) {
 	testWithAllBackend(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
 		_, _, err := RunArgsInTest(ctx, "singularity dataset create test")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		temp := t.TempDir()
 		newFile, err := os.Create(temp + "/test.car")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		blk := blocks.NewBlock([]byte("test"))
 		root := blk.Cid()
 		_, err = pack.WriteCarHeader(newFile, root)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, err = pack.WriteCarBlock(newFile, blk)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		newFile.Close()
 		content, err := os.ReadFile(temp + "/test.car")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		commp := calculateCommp(t, content, 1048576)
 		// Add as path
 		_, _, err = RunArgsInTest(ctx, fmt.Sprintf("singularity dataset add-piece -p \"%s\" test %s %d",
 			temp+"/test.car", commp, 1048576))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		out, _, err := RunArgsInTest(ctx, "singularity dataset list-pieces test")
-		assert.NoError(t, err)
-		assert.Contains(t, out, commp)
+		require.NoError(t, err)
+		require.Contains(t, out, commp)
 		// Add as known root
 		_, _, err = RunArgsInTest(ctx, fmt.Sprintf("singularity dataset add-piece -r %s test %s %d",
 			root.String(), commp, 1048576))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity dataset list-pieces test")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		// Add as unknown root
 		_, _, err = RunArgsInTest(ctx, fmt.Sprintf("singularity dataset add-piece test %s %d",
 			commp, 1048576))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity dataset list-pieces test")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
 func TestDatasetCrud(t *testing.T) {
 	testWithAllBackend(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
 		out, _, err := RunArgsInTest(ctx, "singularity dataset create test")
-		assert.NoError(t, err)
-		assert.Contains(t, out, "test")
+		require.NoError(t, err)
+		require.Contains(t, out, "test")
 		out, _, err = RunArgsInTest(ctx, "singularity dataset list")
-		assert.NoError(t, err)
-		assert.Contains(t, out, "test")
+		require.NoError(t, err)
+		require.Contains(t, out, "test")
 		out, _, err = RunArgsInTest(ctx, "singularity dataset update --output-dir /tmp --max-size 1000 test")
-		assert.NoError(t, err)
-		assert.Contains(t, out, "/tmp")
-		assert.Contains(t, out, "1000")
+		require.NoError(t, err)
+		require.Contains(t, out, "/tmp")
+		require.Contains(t, out, "1000")
 		_, _, err = RunArgsInTest(ctx, "singularity dataset remove test")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		out, _, err = RunArgsInTest(ctx, "singularity dataset list")
-		assert.NoError(t, err)
-		assert.NotContains(t, out, "test")
+		require.NoError(t, err)
+		require.NotContains(t, out, "test")
 	})
 }
 
@@ -521,10 +522,10 @@ func TestEzPrepBenchmark(t *testing.T) {
 	exec.Command("truncate", "-s", "1G", temp+"/test.img").Run()
 	ctx := context.Background()
 	out, _, err := RunArgsInTest(ctx, "singularity ez-prep --output-dir '' --database-file '' -j 8 "+temp)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// contains two CARs, one for the file and another one for the dag
-	assert.Contains(t, out, "1073833069")
-	assert.Contains(t, out, "156")
+	require.Contains(t, out, "1073833069")
+	require.Contains(t, out, "156")
 }
 
 func TestDatasourceCrud(t *testing.T) {
@@ -533,33 +534,33 @@ func TestDatasourceCrud(t *testing.T) {
 		os.Mkdir(temp+"/sub", 0777)
 		os.WriteFile(temp+"/sub/test.txt", []byte("hello world"), 0777)
 		_, _, err := RunArgsInTest(ctx, "singularity dataset create test")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		out, _, err := RunArgsInTest(ctx, "singularity datasource add local test "+temp)
-		assert.NoError(t, err)
-		assert.Contains(t, out, temp)
+		require.NoError(t, err)
+		require.Contains(t, out, temp)
 		out, _, err = RunArgsInTest(ctx, "singularity datasource list")
-		assert.NoError(t, err)
-		assert.Contains(t, out, temp)
+		require.NoError(t, err)
+		require.Contains(t, out, temp)
 		out, _, err = RunArgsInTest(ctx, "singularity datasource list --dataset test")
-		assert.NoError(t, err)
-		assert.Contains(t, out, temp)
+		require.NoError(t, err)
+		require.Contains(t, out, temp)
 		_, _, err = RunArgsInTest(ctx, "singularity datasource list --dataset notexist")
-		assert.Error(t, err)
+		require.Error(t, err)
 		out, _, err = RunArgsInTest(ctx, "singularity datasource check 1")
-		assert.NoError(t, err)
-		assert.Contains(t, out, "sub")
+		require.NoError(t, err)
+		require.Contains(t, out, "sub")
 		out, _, err = RunArgsInTest(ctx, "singularity datasource check 1 sub")
-		assert.NoError(t, err)
-		assert.Contains(t, out, "sub/test.txt")
+		require.NoError(t, err)
+		require.Contains(t, out, "sub/test.txt")
 		out, _, err = RunArgsInTest(ctx, "singularity datasource update --local-case-sensitive=true --rescan-interval 1h 1")
-		assert.NoError(t, err)
-		assert.Contains(t, out, "case_sensitive:true")
-		assert.Contains(t, out, "3600")
+		require.NoError(t, err)
+		require.Contains(t, out, "case_sensitive:true")
+		require.Contains(t, out, "3600")
 		_, _, err = RunArgsInTest(ctx, "singularity datasource remove 1")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		out, _, err = RunArgsInTest(ctx, "singularity datasource list")
-		assert.NoError(t, err)
-		assert.NotContains(t, out, temp)
+		require.NoError(t, err)
+		require.NotContains(t, out, temp)
 	})
 }
 
@@ -574,27 +575,28 @@ func TestEncryption(t *testing.T) {
 		public := "age1th55qj77d32vhumd72de2m3y0nzsxyeahuddz770s8qadz3h6v8quedwf3"
 		private := "AGE-SECRET-KEY-1HZG3ESWDVPE3S4AM8WWCZG3H66A6RVJPXPZZEAC04FWZVT6RJ7XQAUV49J"
 		_, _, err := RunArgsInTest(ctx, "singularity dataset create --max-size 1500000 -o "+carDir+" --encryption-recipient "+public+" test")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity datasource add local test "+temp)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity run dataset-worker --exit-on-complete=true --exit-on-error=true")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		// Run the daggen
 		_, _, err = RunArgsInTest(ctx, "singularity datasource daggen 1")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity run dataset-worker --exit-on-complete=true --exit-on-error=true")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		// Get the root CID
 		out, _, err := RunArgsInTest(ctx, "singularity --json datasource inspect path 1")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		root := strings.Split(strings.Split(out, "\n")[4], "\"")[3]
 		bs := loadCars(t, carDir)
 		dagServ := merkledag.NewDAGService(blockservice.New(bs, nil))
-		rootCID := cid.MustParse(root)
+		rootCID, err := cid.Decode(root)
+		require.NoError(t, err)
 		content1enc := getFileFromRootNode(t, dagServ, "test1.txt", rootCID)
 		content2enc := getFileFromRootNode(t, dagServ, "test2.txt", rootCID)
-		assert.Equal(t, content1, decrypt(t, private, content1enc))
-		assert.Equal(t, content2, decrypt(t, private, content2enc))
+		require.Equal(t, content1, decrypt(t, private, content1enc))
+		require.Equal(t, content2, decrypt(t, private, content2enc))
 	})
 }
 
@@ -622,52 +624,53 @@ func TestDatasourcePacking(t *testing.T) {
 		// file of empty size
 		os.WriteFile(temp+"/test2.txt", []byte{}, 0777)
 		_, _, err := RunArgsInTest(ctx, "singularity dataset create --max-size 1000 -o "+carDir+" test")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity datasource add local test "+temp)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity run dataset-worker --exit-on-complete=true --exit-on-error=true")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		// Check the car folder
 		files, err := os.ReadDir(carDir)
-		assert.NoError(t, err)
-		assert.Equal(t, 131, len(files))
+		require.NoError(t, err)
+		require.Equal(t, 131, len(files))
 		// Run the daggen
 		_, _, err = RunArgsInTest(ctx, "singularity datasource daggen 1")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity run dataset-worker --exit-on-complete=true --exit-on-error=true")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		files, err = os.ReadDir(carDir)
-		assert.NoError(t, err)
-		assert.Equal(t, 132, len(files))
+		require.NoError(t, err)
+		require.Equal(t, 132, len(files))
 		// Get the root CID
 		out, _, err := RunArgsInTest(ctx, "singularity --json datasource inspect path 1")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		root := strings.Split(strings.Split(out, "\n")[4], "\"")[3]
 		// Now load all car files to a block store and check if the resolved directory is same as the original
 		t.Log(root)
 		bs := loadCars(t, carDir)
 		dagServ := merkledag.NewDAGService(blockservice.New(bs, nil))
-		rootCID := cid.MustParse(root)
+		rootCID, err := cid.Decode(root)
+		require.NoError(t, err)
 		entries := listDirsFromRootNode(t, dagServ, "", rootCID)
 		var content []byte
-		assert.Equal(t, 1003, len(entries))
-		assert.True(t, slices.Contains(entries, "sub1"))
-		assert.True(t, slices.Contains(entries, "test1.txt"))
-		assert.True(t, slices.Contains(entries, "test2.txt"))
-		assert.True(t, slices.Contains(entries, "0"))
-		assert.True(t, slices.Contains(entries, "999"))
+		require.Equal(t, 1003, len(entries))
+		require.True(t, slices.Contains(entries, "sub1"))
+		require.True(t, slices.Contains(entries, "test1.txt"))
+		require.True(t, slices.Contains(entries, "test2.txt"))
+		require.True(t, slices.Contains(entries, "0"))
+		require.True(t, slices.Contains(entries, "999"))
 		content, err = os.ReadFile(temp + "/2/test2.txt")
-		assert.NoError(t, err)
-		assert.Equal(t, content, getFileFromRootNode(t, dagServ, "2/test2.txt", rootCID))
+		require.NoError(t, err)
+		require.Equal(t, content, getFileFromRootNode(t, dagServ, "2/test2.txt", rootCID))
 		content, err = os.ReadFile(temp + "/sub1/sub2/sub3/sub4/test2.txt")
-		assert.NoError(t, err)
-		assert.Equal(t, content, getFileFromRootNode(t, dagServ, "sub1/sub2/sub3/sub4/test2.txt", rootCID))
+		require.NoError(t, err)
+		require.Equal(t, content, getFileFromRootNode(t, dagServ, "sub1/sub2/sub3/sub4/test2.txt", rootCID))
 		content, err = os.ReadFile(temp + "/test1.txt")
-		assert.NoError(t, err)
-		assert.Equal(t, content, getFileFromRootNode(t, dagServ, "test1.txt", rootCID))
+		require.NoError(t, err)
+		require.Equal(t, content, getFileFromRootNode(t, dagServ, "test1.txt", rootCID))
 		content, err = os.ReadFile(temp + "/test2.txt")
-		assert.NoError(t, err)
-		assert.Equal(t, content, getFileFromRootNode(t, dagServ, "test2.txt", rootCID))
+		require.NoError(t, err)
+		require.Equal(t, content, getFileFromRootNode(t, dagServ, "test2.txt", rootCID))
 	})
 }
 
@@ -680,64 +683,64 @@ func TestDatasourceRescan(t *testing.T) {
 		os.WriteFile(temp+"/sub/test3.txt", generateRandomBytes(1000), 0777)
 		os.WriteFile(temp+"/sub/test4.txt", generateRandomBytes(10000), 0777)
 		_, _, err := RunArgsInTest(ctx, "singularity dataset create --max-size 1000 test")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity datasource add local test "+temp)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity run dataset-worker --enable-pack=false --enable-dag=false --exit-on-complete=true --exit-on-error=true")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		out, _, err := RunArgsInTest(ctx, "singularity datasource inspect chunks 1")
-		assert.NoError(t, err)
-		assert.Contains(t, out, "ready")
+		require.NoError(t, err)
+		require.Contains(t, out, "ready")
 		// We should get 15 chunks
-		assert.Contains(t, out, "15")
+		require.Contains(t, out, "15")
 		os.WriteFile(temp+"/sub/test5.txt", generateRandomBytes(10000), 0777)
 		_, _, err = RunArgsInTest(ctx, "singularity datasource rescan 1")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity run dataset-worker --enable-pack=false --enable-dag=false --exit-on-complete=true --exit-on-error=true")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		out, _, err = RunArgsInTest(ctx, "singularity datasource inspect chunks 1")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		// We should get 29 chunks
-		assert.Contains(t, out, "29")
+		require.Contains(t, out, "29")
 		_, _, err = RunArgsInTest(ctx, "singularity run dataset-worker --enable-pack=true --enable-dag=false --exit-on-complete=true --exit-on-error=true")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		out, _, err = RunArgsInTest(ctx, "singularity datasource inspect chunks 1")
-		assert.NoError(t, err)
-		assert.NotContains(t, out, "ready")
-		assert.Contains(t, out, "complete")
-		assert.Contains(t, out, "baf")
-		assert.Contains(t, out, "baga")
+		require.NoError(t, err)
+		require.NotContains(t, out, "ready")
+		require.Contains(t, out, "complete")
+		require.Contains(t, out, "baf")
+		require.Contains(t, out, "baga")
 		out, _, err = RunArgsInTest(ctx, "singularity datasource inspect items 1")
-		assert.NoError(t, err)
-		assert.Contains(t, out, "baf")
-		assert.Contains(t, out, "test5.txt")
+		require.NoError(t, err)
+		require.Contains(t, out, "baf")
+		require.Contains(t, out, "test5.txt")
 		out, _, err = RunArgsInTest(ctx, "singularity datasource inspect chunkdetail 1")
-		assert.NoError(t, err)
-		assert.Contains(t, out, "sub/test1.txt")
-		assert.Contains(t, out, "sub/test3.txt")
+		require.NoError(t, err)
+		require.Contains(t, out, "sub/test1.txt")
+		require.Contains(t, out, "sub/test3.txt")
 		out, _, err = RunArgsInTest(ctx, "singularity datasource inspect path 1")
-		assert.NoError(t, err)
-		assert.Contains(t, out, "sub")
+		require.NoError(t, err)
+		require.Contains(t, out, "sub")
 		out, _, err = RunArgsInTest(ctx, "singularity datasource inspect path 1 sub/")
-		assert.NoError(t, err)
-		assert.Contains(t, out, "sub/test1.txt")
-		assert.Contains(t, out, "sub/test3.txt")
+		require.NoError(t, err)
+		require.Contains(t, out, "sub/test1.txt")
+		require.Contains(t, out, "sub/test3.txt")
 		out, _, err = RunArgsInTest(ctx, "singularity datasource daggen 1")
-		assert.NoError(t, err)
-		assert.Contains(t, out, "ready")
+		require.NoError(t, err)
+		require.Contains(t, out, "ready")
 		_, _, err = RunArgsInTest(ctx, "singularity run dataset-worker --enable-pack=false --enable-dag=true --exit-on-complete=true --exit-on-error=true")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		out2, _, err := RunArgsInTest(ctx, "singularity datasource inspect dags 1")
-		assert.NoError(t, err)
-		assert.Contains(t, out2, "baf")
+		require.NoError(t, err)
+		require.Contains(t, out2, "baf")
 		out, _, err = RunArgsInTest(ctx, "singularity datasource daggen 1")
-		assert.NoError(t, err)
-		assert.Contains(t, out, "ready")
+		require.NoError(t, err)
+		require.Contains(t, out, "ready")
 		_, _, err = RunArgsInTest(ctx, "singularity run dataset-worker --enable-pack=false --enable-dag=true --exit-on-complete=true --exit-on-error=true")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		out3, _, err := RunArgsInTest(ctx, "singularity datasource inspect dags 1")
-		assert.NoError(t, err)
-		assert.Equal(t, out3, out2)
+		require.NoError(t, err)
+		require.Equal(t, out3, out2)
 	})
 }
 
@@ -749,21 +752,21 @@ func TestPieceDownload(t *testing.T) {
 		os.WriteFile(temp1+"/test2.txt", generateRandomBytes(10), 0777)
 		os.WriteFile(temp1+"/test3.txt", generateRandomBytes(10_000_000), 0777)
 		_, _, err := RunArgsInTest(ctx, "singularity dataset create --max-size 4MB --output-dir "+temp2+" test")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity datasource add local test "+temp1)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity run dataset-worker --exit-on-complete=true --exit-on-error=true")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity datasource daggen 1")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = RunArgsInTest(ctx, "singularity run dataset-worker --exit-on-complete=true --exit-on-error=true")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		out, _, err := RunArgsInTest(ctx, "singularity dataset list-pieces test")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		pieceCIDs := regexp.MustCompile("baga6ea4sea[0-9a-z]+").FindAllString(out, -1)
-		assert.Len(t, pieceCIDs, 8)
+		require.Len(t, pieceCIDs, 8)
 		pieceCIDs = underscore.Unique(pieceCIDs)
-		assert.Len(t, pieceCIDs, 4)
+		require.Len(t, pieceCIDs, 4)
 		ctx2, cancel := context.WithCancel(ctx)
 		defer cancel()
 		go func() {
@@ -775,30 +778,30 @@ func TestPieceDownload(t *testing.T) {
 		for _, pieceCID := range pieceCIDs {
 			content := downloadPiece(t, ctx, pieceCID)
 			commp := calculateCommp(t, content, 4*1024*1024)
-			assert.Equal(t, pieceCID, commp)
+			require.Equal(t, pieceCID, commp)
 		}
 		// Clean up temp2 and try again
 		os.RemoveAll(temp2)
 		for _, pieceCID := range pieceCIDs {
 			content := downloadPiece(t, ctx, pieceCID)
 			commp := calculateCommp(t, content, 4*1024*1024)
-			assert.Equal(t, pieceCID, commp)
+			require.Equal(t, pieceCID, commp)
 		}
 		// multithread download
 		for _, pieceCID := range pieceCIDs {
 			content := downloadPieceWithThreads(t, ctx, pieceCID, 10)
 			commp := calculateCommp(t, content, 4*1024*1024)
-			assert.Equal(t, pieceCID, commp)
+			require.Equal(t, pieceCID, commp)
 		}
 		// download util
 		temp3 := t.TempDir()
 		for _, pieceCID := range pieceCIDs {
 			_, _, err = RunArgsInTest(ctx, "singularity download --local-links true -o "+temp3+" "+pieceCID)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			content, err := os.ReadFile(temp3 + "/" + pieceCID + ".car")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			commp := calculateCommp(t, content, 4*1024*1024)
-			assert.Equal(t, pieceCID, commp)
+			require.Equal(t, pieceCID, commp)
 		}
 	})
 }
@@ -807,14 +810,14 @@ func downloadPiece(t *testing.T, ctx context.Context, pieceCID string) []byte {
 	t.Log("Downloading piece", pieceCID)
 	url := "http://127.0.0.1:7777/piece/" + pieceCID
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	client := &http.Client{}
 	resp, err := client.Do(req)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer resp.Body.Close()
-	assert.Less(t, resp.StatusCode, 300)
+	require.Less(t, resp.StatusCode, 300)
 	body, err := io.ReadAll(resp.Body)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return body
 }
 
@@ -823,10 +826,10 @@ func downloadPieceWithThreads(t *testing.T, ctx context.Context, pieceCID string
 
 	// Make a HEAD request to get the size of the file
 	req, err := http.NewRequestWithContext(ctx, "HEAD", url, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	client := &http.Client{}
 	resp, err := client.Do(req)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer resp.Body.Close()
 
 	// Get the Content-Length header
@@ -857,17 +860,17 @@ func downloadPieceWithThreads(t *testing.T, ctx context.Context, pieceCID string
 			}
 
 			req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Set the Range header to download a chunk
 			req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
 			t.Log("Downloading piece", pieceCID, "part", i, "bytes", start, "-", end)
 			resp, err := client.Do(req)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			defer resp.Body.Close()
 
 			body, err := io.ReadAll(resp.Body)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Save the part to the slice
 			parts[i] = body
@@ -889,8 +892,8 @@ func downloadPieceWithThreads(t *testing.T, ctx context.Context, pieceCID string
 func calculateCommp(t *testing.T, content []byte, targetPieceSize uint64) string {
 	calc := &commp.Calc{}
 	_, err := bytes.NewBuffer(content).WriteTo(calc)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	c, _, err := pack.GetCommp(calc, targetPieceSize)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return c.String()
 }

--- a/cmd/cliutil/util_test.go
+++ b/cmd/cliutil/util_test.go
@@ -2,6 +2,8 @@ package cliutil
 
 import (
 	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+
 	"testing"
 )
 
@@ -14,7 +16,8 @@ type Widget struct {
 }
 
 func TestPrintSingleObject(t *testing.T) {
-	c := cid.MustParse("QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB")
+	c, err := cid.Decode("QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB")
+	require.NoError(t, err)
 	widget := Widget{ID: 1, Name: "Example", Cost: 3.14, Added: "2023-05-08", CID: c.Bytes()}
 	PrintToConsole(widget, false, nil)
 	PrintToConsole([]Widget{widget}, false, nil)

--- a/database/util_test.go
+++ b/database/util_test.go
@@ -1,11 +1,12 @@
 package database
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestAutoMigrate(t *testing.T) {
 	db := OpenInMemory()
-	assert.NotNil(t, db)
+	require.NotNil(t, db)
 }

--- a/handler/admin/init_test.go
+++ b/handler/admin/init_test.go
@@ -1,16 +1,16 @@
 package admin
 
 import (
+	"testing"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/model"
-	"github.com/stretchr/testify/assert"
-	"testing"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInitHandler(t *testing.T) {
-	assert := assert.New(t)
 	db := database.OpenInMemory()
 	defer model.DropAll(db)
 	err := InitHandler(db)
-	assert.Nil(err)
+	require.NoError(t, err)
 }

--- a/handler/dataset/create_test.go
+++ b/handler/dataset/create_test.go
@@ -1,91 +1,82 @@
 package dataset
 
 import (
+	"testing"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/model"
-	"github.com/stretchr/testify/assert"
-	"testing"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateHandler_NoDatasetName(t *testing.T) {
-	assert := assert.New(t)
 	db := database.OpenInMemory()
 	defer model.DropAll(db)
 	_, err := CreateHandler(db, CreateRequest{})
-	assert.ErrorContains(err, "name is required")
+	require.ErrorContains(t, err, "name is required")
 }
 
 func TestCreateHandler_MaxSizeNotValid(t *testing.T) {
-	assert := assert.New(t)
 	db := database.OpenInMemory()
 	defer model.DropAll(db)
 	_, err := CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "not valid"})
-	assert.ErrorContains(err, "invalid value for max-size")
+	require.ErrorContains(t, err, "invalid value for max-size")
 }
 
 func TestCreateHandler_PieceSizeNotValid(t *testing.T) {
-	assert := assert.New(t)
 	db := database.OpenInMemory()
 	defer model.DropAll(db)
 	_, err := CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", PieceSizeStr: "not valid"})
-	assert.ErrorContains(err, "invalid value for piece-size")
+	require.ErrorContains(t, err, "invalid value for piece-size")
 }
 
 func TestCreateHandler_PieceSizeNotPowerOfTwo(t *testing.T) {
-	assert := assert.New(t)
 	db := database.OpenInMemory()
 	defer model.DropAll(db)
 	_, err := CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", PieceSizeStr: "3GB"})
-	assert.ErrorContains(err, "piece size must be a power of two")
+	require.ErrorContains(t, err, "piece size must be a power of two")
 }
 
 func TestCreateHandler_PieceSizeTooLarge(t *testing.T) {
-	assert := assert.New(t)
 	db := database.OpenInMemory()
 	defer model.DropAll(db)
 	_, err := CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", PieceSizeStr: "128GiB"})
-	assert.ErrorContains(err, "piece size cannot be larger than 64 GiB")
+	require.ErrorContains(t, err, "piece size cannot be larger than 64 GiB")
 }
 
 func TestCreateHandler_MaxSizeTooLarge(t *testing.T) {
-	assert := assert.New(t)
 	db := database.OpenInMemory()
 	defer model.DropAll(db)
 	_, err := CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "63.9GiB"})
-	assert.ErrorContains(err, "max size needs to be reduced to leave space for padding")
+	require.ErrorContains(t, err, "max size needs to be reduced to leave space for padding")
 }
 
 func TestCreateHandler_OutDirDoesNotExist(t *testing.T) {
-	assert := assert.New(t)
 	db := database.OpenInMemory()
 	defer model.DropAll(db)
 	_, err := CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", OutputDirs: []string{"not exist"}})
-	assert.ErrorContains(err, "output directory does not exist")
+	require.ErrorContains(t, err, "output directory does not exist")
 }
 
 func TestCreateHandler_RecipientsScriptCannotBeUsedTogether(t *testing.T) {
-	assert := assert.New(t)
 	db := database.OpenInMemory()
 	defer model.DropAll(db)
 	_, err := CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", EncryptionRecipients: []string{"test"}, EncryptionScript: "test"})
-	assert.ErrorContains(err, "encryption recipients and script cannot be used together")
+	require.ErrorContains(t, err, "encryption recipients and script cannot be used together")
 }
 
 func TestCreateHandler_EncryptionNeedsOutputDir(t *testing.T) {
-	assert := assert.New(t)
 	db := database.OpenInMemory()
 	defer model.DropAll(db)
 	_, err := CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", EncryptionRecipients: []string{"test"}})
-	assert.ErrorContains(err, "encryption is not compatible with inline preparation")
+	require.ErrorContains(t, err, "encryption is not compatible with inline preparation")
 }
 
 func TestCreateHandler_Success(t *testing.T) {
-	assert := assert.New(t)
 	db := database.OpenInMemory()
 	defer model.DropAll(db)
 	_, err := CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB"})
-	assert.Nil(err)
+	require.NoError(t, err)
 	dataset := model.Dataset{}
 	db.Where("name = ?", "test").First(&dataset)
-	assert.Equal("test", dataset.Name)
+	require.Equal(t, "test", dataset.Name)
 }

--- a/handler/deal/schedule/create_test.go
+++ b/handler/deal/schedule/create_test.go
@@ -2,13 +2,14 @@ package schedule
 
 import (
 	"context"
+	"testing"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/ybbus/jsonrpc/v3"
-	"testing"
 )
 
 type MockRPCClient struct {
@@ -74,121 +75,121 @@ var createRequest = CreateRequest{
 func TestCreateHandler_DatasetNotFound(t *testing.T) {
 	db := database.OpenInMemory()
 	_, err := CreateHandler(db, context.Background(), getMockLotusClient(), createRequest)
-	assert.ErrorContains(t, err, "dataset not found")
+	require.ErrorContains(t, err, "dataset not found")
 }
 
 func TestCreateHandler_InvalidStartDelay(t *testing.T) {
 	db := database.OpenInMemory()
 	err := db.Create(&model.Dataset{Name: "test"}).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	badRequest := createRequest
 	badRequest.StartDelay = "1year"
 	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
-	assert.ErrorContains(t, err, "invalid start delay")
+	require.ErrorContains(t, err, "invalid start delay")
 }
 
 func TestCreateHandler_InvalidDuration(t *testing.T) {
 	db := database.OpenInMemory()
 	err := db.Create(&model.Dataset{Name: "test"}).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	badRequest := createRequest
 	badRequest.Duration = "1year"
 	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
-	assert.ErrorContains(t, err, "invalid duration")
+	require.ErrorContains(t, err, "invalid duration")
 }
 
 func TestCreateHandler_InvalidScheduleInterval(t *testing.T) {
 	db := database.OpenInMemory()
 	err := db.Create(&model.Dataset{Name: "test"}).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	badRequest := createRequest
 	badRequest.ScheduleInterval = "1year"
 	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
-	assert.ErrorContains(t, err, "invalid schedule interval")
+	require.ErrorContains(t, err, "invalid schedule interval")
 }
 
 func TestCreateHandler_InvalidScheduleDealSize(t *testing.T) {
 	db := database.OpenInMemory()
 	err := db.Create(&model.Dataset{Name: "test"}).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	badRequest := createRequest
 	badRequest.ScheduleDealSize = "One PB"
 	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
-	assert.ErrorContains(t, err, "invalid schedule deal size")
+	require.ErrorContains(t, err, "invalid schedule deal size")
 }
 
 func TestCreateHandler_InvalidTotalDealSize(t *testing.T) {
 	db := database.OpenInMemory()
 	err := db.Create(&model.Dataset{Name: "test"}).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	badRequest := createRequest
 	badRequest.TotalDealSize = "One PB"
 	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
-	assert.ErrorContains(t, err, "invalid total deal size")
+	require.ErrorContains(t, err, "invalid total deal size")
 }
 
 func TestCreateHandler_InvalidPendingDealSize(t *testing.T) {
 	db := database.OpenInMemory()
 	err := db.Create(&model.Dataset{Name: "test"}).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	badRequest := createRequest
 	badRequest.MaxPendingDealSize = "One PB"
 	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
-	assert.ErrorContains(t, err, "invalid pending deal size")
+	require.ErrorContains(t, err, "invalid pending deal size")
 }
 
 func TestCreateHandler_InvalidAllowedPieceCID_NotCID(t *testing.T) {
 	db := database.OpenInMemory()
 	err := db.Create(&model.Dataset{Name: "test"}).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	badRequest := createRequest
 	badRequest.AllowedPieceCIDs = []string{"not a cid"}
 	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
-	assert.ErrorContains(t, err, "it's not a CID")
+	require.ErrorContains(t, err, "it's not a CID")
 }
 
 func TestCreateHandler_InvalidAllowedPieceCID_NotCommp(t *testing.T) {
 	db := database.OpenInMemory()
 	err := db.Create(&model.Dataset{Name: "test"}).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	badRequest := createRequest
 	badRequest.AllowedPieceCIDs = []string{"bafybeiejlvvmfokp5c6q2eqgbfjeaokz3nqho5c7yy3ov527vsatgsqfma"}
 	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
-	assert.ErrorContains(t, err, "it's not a commp")
+	require.ErrorContains(t, err, "it's not a commp")
 }
 
 func TestCreateHandler_NoAssociatedWallet(t *testing.T) {
 	db := database.OpenInMemory()
 	err := db.Create(&model.Dataset{Name: "test"}).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), createRequest)
-	assert.ErrorContains(t, err, "no wallet")
+	require.ErrorContains(t, err, "no wallet")
 }
 
 func TestCreateHandler_InvalidProvider(t *testing.T) {
 	db := database.OpenInMemory()
 	err := db.Create(&model.Dataset{Name: "test"}).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = db.Create(&model.Wallet{ID: "f01"}).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = db.Create(&model.WalletAssignment{WalletID: "f01", DatasetID: 1}).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	lotusClient := new(MockRPCClient)
 	lotusClient.On("CallFor", mock.Anything, mock.Anything, "Filecoin.StateLookupID", mock.Anything).
 		Return(errors.New("Some provider error"))
 	_, err = CreateHandler(db, context.Background(), lotusClient, createRequest)
-	assert.ErrorContains(t, err, "Some provider error")
+	require.ErrorContains(t, err, "Some provider error")
 }
 
 func TestCreateHandler_Success(t *testing.T) {
 	db := database.OpenInMemory()
 	err := db.Create(&model.Dataset{Name: "test"}).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = db.Create(&model.Wallet{ID: "f01"}).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = db.Create(&model.WalletAssignment{WalletID: "f01", DatasetID: 1}).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	schedule, err := CreateHandler(db, context.Background(), getMockLotusClient(), createRequest)
-	assert.NoError(t, err)
-	assert.NotNil(t, schedule)
+	require.NoError(t, err)
+	require.NotNil(t, schedule)
 }

--- a/handler/deal/send-manual_test.go
+++ b/handler/deal/send-manual_test.go
@@ -2,12 +2,13 @@ package deal
 
 import (
 	"context"
+	"testing"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/replication"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"testing"
+	"github.com/stretchr/testify/require"
 )
 
 type MockDealMaker struct {
@@ -43,13 +44,13 @@ func TestSendManualHandler_WalletNotFound(t *testing.T) {
 
 	db := database.OpenInMemory()
 	err := db.Create(&wallet).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx := context.Background()
 
 	mockDealMaker := new(MockDealMaker)
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return("dealID", nil)
 	_, err = SendManualHandler(db, ctx, proposal, mockDealMaker)
-	assert.ErrorContains(t, err, "client address not found")
+	require.ErrorContains(t, err, "client address not found")
 }
 
 func TestSendManualHandler_InvalidPieceCID(t *testing.T) {
@@ -60,7 +61,7 @@ func TestSendManualHandler_InvalidPieceCID(t *testing.T) {
 
 	db := database.OpenInMemory()
 	err := db.Create(&wallet).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx := context.Background()
 
 	mockDealMaker := new(MockDealMaker)
@@ -68,7 +69,7 @@ func TestSendManualHandler_InvalidPieceCID(t *testing.T) {
 	badProposal := proposal
 	badProposal.PieceCID = "bad"
 	_, err = SendManualHandler(db, ctx, badProposal, mockDealMaker)
-	assert.ErrorContains(t, err, "invalid piece CID")
+	require.ErrorContains(t, err, "invalid piece CID")
 }
 
 func TestSendManualHandler_InvalidPieceCID_NOTCOMMP(t *testing.T) {
@@ -79,7 +80,7 @@ func TestSendManualHandler_InvalidPieceCID_NOTCOMMP(t *testing.T) {
 
 	db := database.OpenInMemory()
 	err := db.Create(&wallet).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx := context.Background()
 
 	mockDealMaker := new(MockDealMaker)
@@ -87,7 +88,7 @@ func TestSendManualHandler_InvalidPieceCID_NOTCOMMP(t *testing.T) {
 	badProposal := proposal
 	badProposal.PieceCID = proposal.RootCID
 	_, err = SendManualHandler(db, ctx, badProposal, mockDealMaker)
-	assert.ErrorContains(t, err, "piece CID must be commp")
+	require.ErrorContains(t, err, "piece CID must be commp")
 }
 
 func TestSendManualHandler_InvalidPieceSize(t *testing.T) {
@@ -98,7 +99,7 @@ func TestSendManualHandler_InvalidPieceSize(t *testing.T) {
 
 	db := database.OpenInMemory()
 	err := db.Create(&wallet).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx := context.Background()
 
 	mockDealMaker := new(MockDealMaker)
@@ -106,7 +107,7 @@ func TestSendManualHandler_InvalidPieceSize(t *testing.T) {
 	badProposal := proposal
 	badProposal.PieceSize = "aaa"
 	_, err = SendManualHandler(db, ctx, badProposal, mockDealMaker)
-	assert.ErrorContains(t, err, "invalid piece size")
+	require.ErrorContains(t, err, "invalid piece size")
 }
 
 func TestSendManualHandler_InvalidPieceSize_NotPowerOfTwo(t *testing.T) {
@@ -117,7 +118,7 @@ func TestSendManualHandler_InvalidPieceSize_NotPowerOfTwo(t *testing.T) {
 
 	db := database.OpenInMemory()
 	err := db.Create(&wallet).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx := context.Background()
 
 	mockDealMaker := new(MockDealMaker)
@@ -125,7 +126,7 @@ func TestSendManualHandler_InvalidPieceSize_NotPowerOfTwo(t *testing.T) {
 	badProposal := proposal
 	badProposal.PieceSize = "31GiB"
 	_, err = SendManualHandler(db, ctx, badProposal, mockDealMaker)
-	assert.ErrorContains(t, err, "piece size must be a power of 2")
+	require.ErrorContains(t, err, "piece size must be a power of 2")
 }
 
 func TestSendManualHandler_InvalidRootCID(t *testing.T) {
@@ -136,7 +137,7 @@ func TestSendManualHandler_InvalidRootCID(t *testing.T) {
 
 	db := database.OpenInMemory()
 	err := db.Create(&wallet).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx := context.Background()
 
 	mockDealMaker := new(MockDealMaker)
@@ -144,7 +145,7 @@ func TestSendManualHandler_InvalidRootCID(t *testing.T) {
 	badProposal := proposal
 	badProposal.RootCID = "xxxx"
 	_, err = SendManualHandler(db, ctx, badProposal, mockDealMaker)
-	assert.ErrorContains(t, err, "invalid root CID")
+	require.ErrorContains(t, err, "invalid root CID")
 }
 
 func TestSendManualHandler_InvalidDuration(t *testing.T) {
@@ -155,7 +156,7 @@ func TestSendManualHandler_InvalidDuration(t *testing.T) {
 
 	db := database.OpenInMemory()
 	err := db.Create(&wallet).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx := context.Background()
 
 	mockDealMaker := new(MockDealMaker)
@@ -163,7 +164,7 @@ func TestSendManualHandler_InvalidDuration(t *testing.T) {
 	badProposal := proposal
 	badProposal.Duration = "xxxx"
 	_, err = SendManualHandler(db, ctx, badProposal, mockDealMaker)
-	assert.ErrorContains(t, err, "invalid duration")
+	require.ErrorContains(t, err, "invalid duration")
 }
 
 func TestSendManualHandler_InvalidStartDelay(t *testing.T) {
@@ -174,7 +175,7 @@ func TestSendManualHandler_InvalidStartDelay(t *testing.T) {
 
 	db := database.OpenInMemory()
 	err := db.Create(&wallet).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx := context.Background()
 
 	mockDealMaker := new(MockDealMaker)
@@ -182,7 +183,7 @@ func TestSendManualHandler_InvalidStartDelay(t *testing.T) {
 	badProposal := proposal
 	badProposal.StartDelay = "xxxx"
 	_, err = SendManualHandler(db, ctx, badProposal, mockDealMaker)
-	assert.ErrorContains(t, err, "invalid start delay")
+	require.ErrorContains(t, err, "invalid start delay")
 }
 
 func TestSendManualHandler(t *testing.T) {
@@ -193,12 +194,12 @@ func TestSendManualHandler(t *testing.T) {
 
 	db := database.OpenInMemory()
 	err := db.Create(&wallet).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx := context.Background()
 
 	mockDealMaker := new(MockDealMaker)
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return("dealID", nil)
 	resp, err := SendManualHandler(db, ctx, proposal, mockDealMaker)
-	assert.NoError(t, err)
-	assert.Equal(t, "dealID", resp)
+	require.NoError(t, err)
+	require.Equal(t, "dealID", resp)
 }

--- a/pack/daggen/directory_test.go
+++ b/pack/daggen/directory_test.go
@@ -7,31 +7,31 @@ import (
 	"github.com/ipfs/go-cid"
 	util "github.com/ipfs/go-ipfs-util"
 	format "github.com/ipfs/go-ipld-format"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMarshalling(t *testing.T) {
 	var initial []byte
 	dirData := &DirectoryData{}
 	err := dirData.UnmarshallBinary(initial)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	for i := 0; i < 10000; i++ {
 		err = dirData.AddItem(strconv.Itoa(i), cid.NewCidV1(cid.Raw, util.Hash([]byte(strconv.Itoa(i)))), 4)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 	initial, err = dirData.MarshalBinary()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	t.Log(len(initial))
 }
 
 func TestDirectoryData(t *testing.T) {
 	d := NewDirectoryData()
 	binary, err := d.MarshalBinary()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = d.UnmarshallBinary(binary)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = d.AddItem("test", cid.NewCidV1(cid.Raw, util.Hash([]byte("test"))), 4)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = d.AddItemFromLinks("test2", []format.Link{
 		{
 			Cid:  cid.NewCidV1(cid.Raw, util.Hash([]byte("test2"))),
@@ -42,15 +42,15 @@ func TestDirectoryData(t *testing.T) {
 			Size: 5,
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	binary, err = d.MarshalBinary()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = d.UnmarshallBinary(binary)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = d.AddItem("test4", cid.NewCidV1(cid.Raw, util.Hash([]byte("test4"))), 5)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = d.MarshalBinary()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestResolveDirectoryTree(t *testing.T) {
@@ -59,10 +59,10 @@ func TestResolveDirectoryTree(t *testing.T) {
 	root := NewDirectoryData()
 	root.Directory.ID = 1
 	err := root.AddItem("test", cid.NewCidV1(cid.Raw, util.Hash([]byte("test"))), 4)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	dir := NewDirectoryData()
 	err = dir.AddItem("test2", cid.NewCidV1(cid.Raw, util.Hash([]byte("test2"))), 5)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	dir.Directory.ID = 2
 	dir.Directory.Name = "name"
 	parentID := uint64(1)
@@ -71,8 +71,8 @@ func TestResolveDirectoryTree(t *testing.T) {
 	dirCache[1] = &root
 	childrenCache[1] = []uint64{2}
 	_, err = ResolveDirectoryTree(1, dirCache, childrenCache)
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(root.Node.Links()))
-	assert.Equal(t, "name", root.Node.Links()[0].Name)
-	assert.Equal(t, "test", root.Node.Links()[1].Name)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(root.Node.Links()))
+	require.Equal(t, "name", root.Node.Links()[0].Name)
+	require.Equal(t, "test", root.Node.Links()[1].Name)
 }

--- a/pack/device/device_test.go
+++ b/pack/device/device_test.go
@@ -1,15 +1,14 @@
 package device
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetPathWithMostSpace(t *testing.T) {
-	assert := assert.New(t)
-
 	paths := []string{"/", "/tmp", "/var"}
 	path, err := GetPathWithMostSpace(paths)
-	assert.NoError(err)
-	assert.NotEmpty(path)
+	require.NoError(t, err)
+	require.NotEmpty(t, path)
 }

--- a/pack/encryption/age_test.go
+++ b/pack/encryption/age_test.go
@@ -2,29 +2,30 @@ package encryption
 
 import (
 	"bytes"
-	"filippo.io/age"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"filippo.io/age"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEncryptionFullPiece(t *testing.T) {
 	state, err := NewAgeEncryptor([]string{"age1th55qj77d32vhumd72de2m3y0nzsxyeahuddz770s8qadz3h6v8quedwf3"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	input := bytes.NewReader([]byte("This is a test"))
 	reader, err := state.Encrypt(input)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	buf := new(bytes.Buffer)
 	_, err = buf.ReadFrom(reader)
-	assert.NoError(t, err)
-	assert.Equal(t, 214, len(buf.Bytes()))
+	require.NoError(t, err)
+	require.Equal(t, 214, len(buf.Bytes()))
 
 	identity, err := age.ParseX25519Identity("AGE-SECRET-KEY-1HZG3ESWDVPE3S4AM8WWCZG3H66A6RVJPXPZZEAC04FWZVT6RJ7XQAUV49J")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	decrypted, err := age.Decrypt(buf, identity)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	decryptedBuf := new(bytes.Buffer)
 	_, err = decryptedBuf.ReadFrom(decrypted)
-	assert.NoError(t, err)
-	assert.Equal(t, "This is a test", decryptedBuf.String())
+	require.NoError(t, err)
+	require.Equal(t, "This is a test", decryptedBuf.String())
 }

--- a/pack/encryption/custom_test.go
+++ b/pack/encryption/custom_test.go
@@ -1,11 +1,12 @@
 package encryption
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io"
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCustomEncryptor_Encrypt(t *testing.T) {
@@ -17,17 +18,17 @@ func TestCustomEncryptor_Encrypt(t *testing.T) {
 	rc, err := encryptor.Encrypt(strings.NewReader(""))
 
 	// Assert that the call to Encrypt does not return an error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Create a buffer to store the output
 	buffer := new(strings.Builder)
 
 	// Read the output from the reader
 	_, err = io.Copy(buffer, rc)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Assert that the output is as expected
-	assert.Equal(t, "Hello, World!\n", buffer.String())
+	require.Equal(t, "Hello, World!\n", buffer.String())
 }
 
 func TestCustomEncryptor_FailedCommand(t *testing.T) {
@@ -38,9 +39,9 @@ func TestCustomEncryptor_FailedCommand(t *testing.T) {
 	// Call Encrypt with an empty reader
 	rc, err := encryptor.Encrypt(strings.NewReader(""))
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = io.ReadFull(rc, make([]byte, 10))
-	assert.Equal(t, "EOF", err.Error())
+	require.Equal(t, "EOF", err.Error())
 	err = rc.Close()
-	assert.Equal(t, "exit status 1", err.Error())
+	require.Equal(t, "exit status 1", err.Error())
 }

--- a/pack/pack_test.go
+++ b/pack/pack_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"github.com/data-preservation-programs/singularity/model"
-	"github.com/multiformats/go-varint"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"io"
 	"testing"
+
+	"github.com/data-preservation-programs/singularity/model"
+	"github.com/multiformats/go-varint"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAssembleCar_LargeItems(t *testing.T) {
@@ -38,13 +39,13 @@ func TestAssembleCar_LargeItems(t *testing.T) {
 		},
 	}
 	result, err := AssembleCar(ctx, handler, model.Dataset{}, items, "", 1<<30)
-	assert.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Equal(t, "", result.CarResults[0].CarFilePath)
-	assert.EqualValues(t, 10486793, result.CarResults[0].CarFileSize)
-	assert.EqualValues(t, 1<<30, result.CarResults[0].PieceSize)
-	assert.Len(t, result.CarResults[0].Header, 59)
-	assert.Len(t, result.CarResults[0].CarBlocks, 12)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "", result.CarResults[0].CarFilePath)
+	require.EqualValues(t, 10486793, result.CarResults[0].CarFileSize)
+	require.EqualValues(t, 1<<30, result.CarResults[0].PieceSize)
+	require.Len(t, result.CarResults[0].Header, 59)
+	require.Len(t, result.CarResults[0].CarBlocks, 12)
 }
 
 func TestAssembleCar_NoEncryption(t *testing.T) {
@@ -62,21 +63,21 @@ func TestAssembleCar_NoEncryption(t *testing.T) {
 		},
 	}
 	result, err := AssembleCar(ctx, handler, model.Dataset{}, items, "", 1<<20)
-	assert.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Equal(t, "", result.CarResults[0].CarFilePath)
-	assert.EqualValues(t, 101, result.CarResults[0].CarFileSize)
-	assert.Equal(t, "baga6ea4seaqddc4kqdxmnglxhmrfxkx2cd7hl6kounifgewgb2hdthmeddfe4hy", result.CarResults[0].PieceCID.String())
-	assert.EqualValues(t, 1<<20, result.CarResults[0].PieceSize)
-	assert.Len(t, result.CarResults[0].Header, 59)
-	assert.Equal(t, "bafkreibm6jg3ux5qumhcn2b3flc3tyu6dmlb4xa7u5bf44yegnrjhc4yeq", result.CarResults[0].RootCID.String())
-	assert.Equal(t, "bafkreibm6jg3ux5qumhcn2b3flc3tyu6dmlb4xa7u5bf44yegnrjhc4yeq", result.ItemPartCIDs[0].String())
-	assert.Len(t, result.CarResults[0].CarBlocks, 1)
-	assert.Equal(t, "bafkreibm6jg3ux5qumhcn2b3flc3tyu6dmlb4xa7u5bf44yegnrjhc4yeq", result.CarResults[0].CarBlocks[0].CID.String())
-	assert.EqualValues(t, 59, result.CarResults[0].CarBlocks[0].CarOffset)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "", result.CarResults[0].CarFilePath)
+	require.EqualValues(t, 101, result.CarResults[0].CarFileSize)
+	require.Equal(t, "baga6ea4seaqddc4kqdxmnglxhmrfxkx2cd7hl6kounifgewgb2hdthmeddfe4hy", result.CarResults[0].PieceCID.String())
+	require.EqualValues(t, 1<<20, result.CarResults[0].PieceSize)
+	require.Len(t, result.CarResults[0].Header, 59)
+	require.Equal(t, "bafkreibm6jg3ux5qumhcn2b3flc3tyu6dmlb4xa7u5bf44yegnrjhc4yeq", result.CarResults[0].RootCID.String())
+	require.Equal(t, "bafkreibm6jg3ux5qumhcn2b3flc3tyu6dmlb4xa7u5bf44yegnrjhc4yeq", result.ItemPartCIDs[0].String())
+	require.Len(t, result.CarResults[0].CarBlocks, 1)
+	require.Equal(t, "bafkreibm6jg3ux5qumhcn2b3flc3tyu6dmlb4xa7u5bf44yegnrjhc4yeq", result.CarResults[0].CarBlocks[0].CID.String())
+	require.EqualValues(t, 59, result.CarResults[0].CarBlocks[0].CarOffset)
 	v, _, _ := varint.FromUvarint(result.CarResults[0].CarBlocks[0].Varint)
-	assert.EqualValues(t, 41, v)
-	assert.EqualValues(t, 1, result.CarResults[0].CarBlocks[0].ItemOffset)
+	require.EqualValues(t, 41, v)
+	require.EqualValues(t, 1, result.CarResults[0].CarBlocks[0].ItemOffset)
 }
 
 func TestAssembleCar_WithEncryption(t *testing.T) {
@@ -96,11 +97,11 @@ func TestAssembleCar_WithEncryption(t *testing.T) {
 	result, err := AssembleCar(ctx, handler, model.Dataset{
 		EncryptionRecipients: []string{"age1th55qj77d32vhumd72de2m3y0nzsxyeahuddz770s8qadz3h6v8quedwf3"},
 	}, items, t.TempDir(), 1<<20)
-	assert.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.NotEmpty(t, result.CarResults[0].CarFilePath)
-	assert.EqualValues(t, 302, result.CarResults[0].CarFileSize)
-	assert.EqualValues(t, 1<<20, result.CarResults[0].PieceSize)
-	assert.Len(t, result.CarResults[0].Header, 59)
-	assert.Len(t, result.CarResults[0].CarBlocks, 0)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.CarResults[0].CarFilePath)
+	require.EqualValues(t, 302, result.CarResults[0].CarFileSize)
+	require.EqualValues(t, 1<<20, result.CarResults[0].PieceSize)
+	require.Len(t, result.CarResults[0].Header, 59)
+	require.Len(t, result.CarResults[0].CarBlocks, 0)
 }

--- a/pack/util_test.go
+++ b/pack/util_test.go
@@ -3,16 +3,17 @@ package pack
 import (
 	"bytes"
 	"context"
+	"io"
+	"testing"
+
 	"github.com/data-preservation-programs/singularity/model"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	util "github.com/ipfs/go-ipfs-util"
 	format "github.com/ipfs/go-ipld-format"
 	"github.com/rclone/rclone/fs"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"io"
-	"testing"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateParentNode(t *testing.T) {
@@ -30,19 +31,19 @@ func TestCreateParentNode(t *testing.T) {
 	}
 
 	node, size, err := createParentNode(links)
-	assert.NoError(t, err)
-	assert.Equal(t, uint64(10), size)
-	assert.NotNil(t, node)
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), size)
+	require.NotNil(t, node)
 	size, err = node.Size()
-	assert.NoError(t, err)
-	assert.Equal(t, uint64(108), size)
-	assert.Equal(t, "bafybeiejlvvmfokp5c6q2eqgbfjeaokz3nqho5c7yy3ov527vsatgsqfma", node.String())
+	require.NoError(t, err)
+	require.Equal(t, uint64(108), size)
+	require.Equal(t, "bafybeiejlvvmfokp5c6q2eqgbfjeaokz3nqho5c7yy3ov527vsatgsqfma", node.String())
 }
 
 func TestMind(t *testing.T) {
-	assert.Equal(t, 1, Min(1, 2))
-	assert.Equal(t, 1, Min(2, 1))
-	assert.Equal(t, 1, Min(1, 1))
+	require.Equal(t, 1, Min(1, 2))
+	require.Equal(t, 1, Min(2, 1))
+	require.Equal(t, 1, Min(1, 1))
 }
 
 func TestAssembleItemFromLinks(t *testing.T) {
@@ -60,14 +61,14 @@ func TestAssembleItemFromLinks(t *testing.T) {
 	}
 
 	blocks, node, err := AssembleItemFromLinks(links)
-	assert.NoError(t, err)
-	assert.NotNil(t, node)
+	require.NoError(t, err)
+	require.NotNil(t, node)
 	size, err := node.Size()
-	assert.NoError(t, err)
-	assert.Equal(t, uint64(108), size)
-	assert.Equal(t, "bafybeiejlvvmfokp5c6q2eqgbfjeaokz3nqho5c7yy3ov527vsatgsqfma", node.String())
-	assert.Len(t, blocks, 1)
-	assert.Equal(t, "bafybeiejlvvmfokp5c6q2eqgbfjeaokz3nqho5c7yy3ov527vsatgsqfma", blocks[0].Cid().String())
+	require.NoError(t, err)
+	require.Equal(t, uint64(108), size)
+	require.Equal(t, "bafybeiejlvvmfokp5c6q2eqgbfjeaokz3nqho5c7yy3ov527vsatgsqfma", node.String())
+	require.Len(t, blocks, 1)
+	require.Equal(t, "bafybeiejlvvmfokp5c6q2eqgbfjeaokz3nqho5c7yy3ov527vsatgsqfma", blocks[0].Cid().String())
 }
 
 func TestAssembleItemFromLinks_LargeFile(t *testing.T) {
@@ -81,37 +82,37 @@ func TestAssembleItemFromLinks_LargeFile(t *testing.T) {
 	}
 
 	blocks, node, err := AssembleItemFromLinks(links)
-	assert.NoError(t, err)
-	assert.NotNil(t, node)
+	require.NoError(t, err)
+	require.NotNil(t, node)
 	size, err := node.Size()
-	assert.NoError(t, err)
-	assert.Equal(t, uint64(10000113), size)
-	assert.Equal(t, "bafybeidd6nph3lz2c34mvxoqsaxx6er2au7c73j32yfs6rhmiqeh35ko6m", node.String())
-	assert.Len(t, blocks, 1957)
-	assert.Equal(t, "bafybeidci5xcdskgvefhv3x6kp6zpyxkbiqshqjbpsdgmk2k3mexzaggwi", blocks[0].Cid().String())
+	require.NoError(t, err)
+	require.Equal(t, uint64(10000113), size)
+	require.Equal(t, "bafybeidd6nph3lz2c34mvxoqsaxx6er2au7c73j32yfs6rhmiqeh35ko6m", node.String())
+	require.Len(t, blocks, 1957)
+	require.Equal(t, "bafybeidci5xcdskgvefhv3x6kp6zpyxkbiqshqjbpsdgmk2k3mexzaggwi", blocks[0].Cid().String())
 }
 
 func TestGenerateCarHeader(t *testing.T) {
 	header, err := GenerateCarHeader(cid.NewCidV1(cid.Raw, util.Hash([]byte("hello"))))
-	assert.NoError(t, err)
-	assert.Len(t, header, 59)
+	require.NoError(t, err)
+	require.Len(t, header, 59)
 }
 
 func TestWriteCarHeader(t *testing.T) {
 	buf := new(bytes.Buffer)
 	header, err := WriteCarHeader(buf, cid.NewCidV1(cid.Raw, util.Hash([]byte("hello"))))
-	assert.NoError(t, err)
-	assert.Len(t, header, 59)
-	assert.Equal(t, buf.Bytes(), header)
+	require.NoError(t, err)
+	require.Len(t, header, 59)
+	require.Equal(t, buf.Bytes(), header)
 }
 
 func TestWriteCarBlock(t *testing.T) {
 	buf := new(bytes.Buffer)
 	block := blocks.NewBlock([]byte("hello"))
 	n, err := WriteCarBlock(buf, block)
-	assert.NoError(t, err)
-	assert.Equal(t, int64(40), n)
-	assert.Equal(t, 40, buf.Len())
+	require.NoError(t, err)
+	require.Equal(t, int64(40), n)
+	require.Equal(t, 40, buf.Len())
 }
 
 type MockReadHandler struct {
@@ -136,13 +137,13 @@ func TestGetBlockStreamFromItem(t *testing.T) {
 		},
 	}
 	blockResultChan, _, err := GetBlockStreamFromItem(ctx, handler, item, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	blockResults := make([]BlockResult, 0)
 	for r := range blockResultChan {
 		blockResults = append(blockResults, r)
 	}
-	assert.Len(t, blockResults, 1)
-	assert.EqualValues(t, 0, blockResults[0].Offset)
-	assert.Equal(t, []byte("hello"), blockResults[0].Raw)
-	assert.Equal(t, "bafkreibm6jg3ux5qumhcn2b3flc3tyu6dmlb4xa7u5bf44yegnrjhc4yeq", blockResults[0].CID.String())
+	require.Len(t, blockResults, 1)
+	require.EqualValues(t, 0, blockResults[0].Offset)
+	require.Equal(t, []byte("hello"), blockResults[0].Raw)
+	require.Equal(t, "bafkreibm6jg3ux5qumhcn2b3flc3tyu6dmlb4xa7u5bf44yegnrjhc4yeq", blockResults[0].CID.String())
 }

--- a/replication/internal/proposal110/types_test.go
+++ b/replication/internal/proposal110/types_test.go
@@ -2,22 +2,25 @@ package proposal110
 
 import (
 	"bytes"
+	"math/big"
+	"testing"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/ipfs/go-cid"
-	"github.com/stretchr/testify/assert"
-	"math/big"
-	"testing"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProposalMarshalCBOR(t *testing.T) {
-	pieceCID := cid.MustParse("baga6ea4seaqdyupo27fj2fk2mtefzlxvrbf6kdi4twdpccdzbyqrbpsvfsh5ula")
+	pieceCID, err := cid.Decode("baga6ea4seaqdyupo27fj2fk2mtefzlxvrbf6kdi4twdpccdzbyqrbpsvfsh5ula")
+	require.NoError(t, err)
 	client, err := address.NewFromString("f01000")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	provider, err := address.NewFromString("f01001")
-	assert.NoError(t, err)
-	rootCID := cid.MustParse("bafy2bzaceczlclcg4notjmrz4ayenf7fi4mngnqbgjs27r3resyhzwxjnviay")
+	require.NoError(t, err)
+	rootCID, err := cid.Decode("bafy2bzaceczlclcg4notjmrz4ayenf7fi4mngnqbgjs27r3resyhzwxjnviay")
+	require.NoError(t, err)
 	proposal := Proposal{
 		DealProposal: &ClientDealProposal{
 			Proposal: DealProposal{
@@ -58,9 +61,9 @@ func TestProposalMarshalCBOR(t *testing.T) {
 	}
 	buf := bytes.NewBuffer([]byte{})
 	err = proposal.MarshalCBOR(buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	unmarshalled := Proposal{}
 	err = unmarshalled.UnmarshalCBOR(buf)
-	assert.NoError(t, err)
-	assert.Equal(t, proposal, unmarshalled)
+	require.NoError(t, err)
+	require.Equal(t, proposal, unmarshalled)
 }

--- a/replication/internal/proposal120/types_test.go
+++ b/replication/internal/proposal120/types_test.go
@@ -2,26 +2,29 @@ package proposal120
 
 import (
 	"bytes"
+	"math/big"
+	"testing"
+
 	"github.com/data-preservation-programs/singularity/replication/internal/proposal110"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
-	"github.com/stretchr/testify/assert"
-	"math/big"
-	"testing"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProposalMarshalCBOR(t *testing.T) {
-	pieceCID := cid.MustParse("baga6ea4seaqdyupo27fj2fk2mtefzlxvrbf6kdi4twdpccdzbyqrbpsvfsh5ula")
+	pieceCID, err := cid.Decode("baga6ea4seaqdyupo27fj2fk2mtefzlxvrbf6kdi4twdpccdzbyqrbpsvfsh5ula")
+	require.NoError(t, err)
 	client, err := address.NewFromString("f01000")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	provider, err := address.NewFromString("f01001")
-	assert.NoError(t, err)
-	rootCID := cid.MustParse("bafy2bzaceczlclcg4notjmrz4ayenf7fi4mngnqbgjs27r3resyhzwxjnviay")
+	require.NoError(t, err)
+	rootCID, err := cid.Decode("bafy2bzaceczlclcg4notjmrz4ayenf7fi4mngnqbgjs27r3resyhzwxjnviay")
+	require.NoError(t, err)
 	label, err := proposal110.NewLabelFromString("hello")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	proposal_110 := proposal110.ClientDealProposal{
 		Proposal: proposal110.DealProposal{
 			PieceCID:     pieceCID,
@@ -63,9 +66,9 @@ func TestProposalMarshalCBOR(t *testing.T) {
 	}
 	buf := bytes.NewBuffer([]byte{})
 	err = proposal.MarshalCBOR(buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	unmarshalled := DealParams{}
 	err = unmarshalled.UnmarshalCBOR(buf)
-	assert.NoError(t, err)
-	assert.Equal(t, proposal, unmarshalled)
+	require.NoError(t, err)
+	require.Equal(t, proposal, unmarshalled)
 }

--- a/replication/wallet_test.go
+++ b/replication/wallet_test.go
@@ -2,14 +2,15 @@ package replication
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/ybbus/jsonrpc/v3"
-	"testing"
-	"time"
 )
 
 type MockRPCClient struct {
@@ -78,28 +79,28 @@ func TestDatacapWalletChooser_Choose(t *testing.T) {
 	chooser.lotusClient = lotusClient
 
 	err := db.Create(&wallets).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = db.Create(&model.Deal{
 		ClientID:  "3",
 		Verified:  true,
 		State:     model.DealProposed,
 		PieceSize: 500000,
 	}).Error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("Choose wallet with empty wallet", func(t *testing.T) {
 		_, err := chooser.Choose(context.Background(), []model.Wallet{})
-		assert.ErrorAs(t, err, &ErrNoWallet)
+		require.ErrorAs(t, err, &ErrNoWallet)
 	})
 
 	t.Run("Choose wallet with sufficient datacap", func(t *testing.T) {
 		chosenWallet, err := chooser.Choose(context.Background(), []model.Wallet{wallets[0], wallets[1]})
-		assert.NoError(t, err)
-		assert.Equal(t, "address1", chosenWallet.Address)
+		require.NoError(t, err)
+		require.Equal(t, "address1", chosenWallet.Address)
 	})
 
 	t.Run("Choose wallet with insufficient datacap", func(t *testing.T) {
 		_, err := chooser.Choose(context.Background(), []model.Wallet{wallets[2], wallets[3]})
-		assert.ErrorAs(t, err, &ErrNoDatacap)
+		require.ErrorAs(t, err, &ErrNoDatacap)
 	})
 }

--- a/store/item_reference_test.go
+++ b/store/item_reference_test.go
@@ -4,15 +4,15 @@ package store
 
 import (
 	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/datasource"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/ipfs/go-cid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
-	"os"
-	"testing"
 )
 
 func TestItemReferenceBlockStore(t *testing.T) {
@@ -39,7 +39,7 @@ func TestItemReferenceBlockStore(t *testing.T) {
 	source := model.Source{
 		Type: model.Local,
 	}
-	assert.NoError(t, db.Create(&source).Error)
+	require.NoError(t, db.Create(&source).Error)
 
 	item := model.Item{
 		SourceID: source.ID,
@@ -49,23 +49,24 @@ func TestItemReferenceBlockStore(t *testing.T) {
 		Offset:   0,
 		Length:   11,
 	}
-	assert.NoError(t, db.Create(&item).Error)
+	require.NoError(t, db.Create(&item).Error)
 
-	c := cid.MustParse("bafy2bzaceajbdbdel5jjeehkborcsrub5cyrq4om3ee5umomqd323ynkpyjh4")
+	c := cid.Decode("bafy2bzaceajbdbdel5jjeehkborcsrub5cyrq4om3ee5umomqd323ynkpyjh4")
+	require.NoError(t, err)
 	// Test Has method with a non-existent CID
 	has, err := store.Has(context.Background(), c)
-	assert.NoError(t, err)
-	assert.False(t, has)
+	require.NoError(t, err)
+	require.False(t, has)
 
 	// Test Get method with a non-existent CID
 	_, err = store.Get(context.Background(), c)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "could not find")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "could not find")
 
 	// Test GetSize method with a non-existent CID
 	_, err = store.GetSize(context.Background(), c)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "could not find")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "could not find")
 
 	// Create a new CarBlock record in the database referencing the CID of the test data
 	cb := model.ItemBlock{
@@ -79,11 +80,11 @@ func TestItemReferenceBlockStore(t *testing.T) {
 
 	// Test GetSize method with an existing CID
 	size, err := store.GetSize(context.Background(), c)
-	assert.NoError(t, err)
-	assert.Equal(t, 5, size)
+	require.NoError(t, err)
+	require.Equal(t, 5, size)
 
 	// Test Get method with an existing CID
 	block, err := store.Get(context.Background(), c)
-	assert.NoError(t, err)
-	assert.Equal(t, " worl", string(block.RawData()))
+	require.NoError(t, err)
+	require.Equal(t, " worl", string(block.RawData()))
 }

--- a/store/piece_store_test.go
+++ b/store/piece_store_test.go
@@ -3,13 +3,14 @@
 package store
 
 import (
+	"testing"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/model"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/multiformats/go-varint"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"testing"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadAt2(t *testing.T) {
@@ -19,7 +20,7 @@ func TestReadAt2(t *testing.T) {
 	car := model.Car{
 		Header: []byte("car-Header"),
 	}
-	assert.NoError(t, db.Create(&car).Error)
+	require.NoError(t, db.Create(&car).Error)
 
 	block1 := blocks.NewBlock([]byte("block-data"))
 	varint1 := uint64(block1.Cid().ByteLen() + len(block1.RawData()))
@@ -30,7 +31,7 @@ func TestReadAt2(t *testing.T) {
 		CarBlockLength: varint1 + uint64(varint.UvarintSize(varint1)),
 		Varint:         varint1,
 	}
-	assert.NoError(t, db.Create(&carBlock1).Error)
+	require.NoError(t, db.Create(&carBlock1).Error)
 
 	// Create an instance of the PieceReader
 	pieceReader := NewPieceReader2(db, &car)
@@ -41,19 +42,19 @@ func TestReadAt2(t *testing.T) {
 	// Test the ReadAt method
 	buf := make([]byte, 10)
 	n, err := pieceReader.ReadAt(buf, 0)
-	assert.NoError(t, err)
-	assert.Equal(t, 10, n)
-	assert.Equal(t, "car-Header", string(buf))
+	require.NoError(t, err)
+	require.Equal(t, 10, n)
+	require.Equal(t, "car-Header", string(buf))
 
 	buf = make([]byte, 10)
 	n, err = pieceReader.ReadAt(buf, 5)
-	assert.NoError(t, err)
-	assert.Equal(t, 5, n)
-	assert.Equal(t, "eader", string(buf[:n]))
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, "eader", string(buf[:n]))
 
 	buf = make([]byte, 100)
 	n, err = pieceReader.ReadAt(buf, 10)
-	assert.NoError(t, err)
-	assert.Equal(t, 45, n)
-	assert.Equal(t, "block-data", string(buf[35:45]))
+	require.NoError(t, err)
+	require.Equal(t, 45, n)
+	require.Equal(t, "block-data", string(buf[35:45]))
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,19 +1,19 @@
 package util
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNextPowerOfTwo(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal(uint64(1), NextPowerOfTwo(0))
-	assert.Equal(uint64(1), NextPowerOfTwo(1))
-	assert.Equal(uint64(2), NextPowerOfTwo(2))
-	assert.Equal(uint64(4), NextPowerOfTwo(3))
-	assert.Equal(uint64(4), NextPowerOfTwo(4))
-	assert.Equal(uint64(8), NextPowerOfTwo(5))
-	assert.Equal(uint64(16), NextPowerOfTwo(9))
-	assert.Equal(uint64(32), NextPowerOfTwo(17))
-	assert.Equal(uint64(64), NextPowerOfTwo(33))
+	require.Equal(t, uint64(1), NextPowerOfTwo(0))
+	require.Equal(t, uint64(1), NextPowerOfTwo(1))
+	require.Equal(t, uint64(2), NextPowerOfTwo(2))
+	require.Equal(t, uint64(4), NextPowerOfTwo(3))
+	require.Equal(t, uint64(4), NextPowerOfTwo(4))
+	require.Equal(t, uint64(8), NextPowerOfTwo(5))
+	require.Equal(t, uint64(16), NextPowerOfTwo(9))
+	require.Equal(t, uint64(32), NextPowerOfTwo(17))
+	require.Equal(t, uint64(64), NextPowerOfTwo(33))
 }


### PR DESCRIPTION
Instead of `assert`, use `require` in order to fail fast when an error occurs during testing.

Fix error checks to use `NoError(err)` instead of `Nil(err)`.

Avoid panicking during tests, by replacing the `cid.MustParse` calls with `cid.Decode` and error check.