### PR TITLE
Do not panic in normal code execution path

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -3,6 +3,15 @@ package api
 import (
 	"context"
 	"fmt"
+	"io/fs"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"time"
+	"unicode"
+
 	"github.com/data-preservation-programs/singularity/handler/admin"
 	"github.com/data-preservation-programs/singularity/handler/dataset"
 	"github.com/data-preservation-programs/singularity/handler/datasource/inspect"
@@ -15,14 +24,6 @@ import (
 	"github.com/data-preservation-programs/singularity/util"
 	fs2 "github.com/rclone/rclone/fs"
 	"github.com/ybbus/jsonrpc/v3"
-	"io/fs"
-	"net/http"
-	"net/url"
-	"path/filepath"
-	"reflect"
-	"strconv"
-	"time"
-	"unicode"
 
 	_ "github.com/data-preservation-programs/singularity/api/docs"
 	"github.com/data-preservation-programs/singularity/cmd/embed"
@@ -154,9 +155,11 @@ func (s Server) pushItem(c echo.Context, sourceID uint32, itemInfo ItemInfo) err
 }
 
 func Run(c *cli.Context) error {
-	db := database.MustOpenFromCLI(c)
-	err := model.AutoMigrate(db)
+	db, err := database.OpenFromCLI(c)
 	if err != nil {
+		return err
+	}
+	if err := model.AutoMigrate(db); err != nil {
 		return handler.NewHandlerError(err)
 	}
 	bind := c.String("bind")

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -16,7 +16,8 @@ import (
 )
 
 func TestHandlePostSource(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/dataset/test/source/local", bytes.NewBuffer([]byte(
 		`{"deleteAfterExport":true,"sourcePath":"/tmp","rescanInterval":"1h","caseInsensitive":"false"}`,
@@ -31,7 +32,7 @@ func TestHandlePostSource(t *testing.T) {
 		db:                        db,
 		datasourceHandlerResolver: &datasource.DefaultHandlerResolver{},
 	}
-	err := db.Create(&model.Dataset{
+	err = db.Create(&model.Dataset{
 		Name:      "test",
 		MaxSize:   3 * 1024 * 1024,
 		PieceSize: 4 * 1024 * 1024,
@@ -51,7 +52,8 @@ func TestHandlePostSource(t *testing.T) {
 }
 
 func TestPushItem_InvalidID(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/source/1/push", bytes.NewBuffer([]byte(`{"path":"test.txt"}`)))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -64,14 +66,15 @@ func TestPushItem_InvalidID(t *testing.T) {
 		db:                        db,
 		datasourceHandlerResolver: &datasource.DefaultHandlerResolver{},
 	}
-	err := server.PushItem(c)
+	err = server.PushItem(c)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 	require.Contains(t, rec.Body.String(), "Invalid source ID")
 }
 
 func TestPushItem_InvalidPayload(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/source/1/push", bytes.NewBuffer([]byte(`invalid payload`)))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -84,14 +87,15 @@ func TestPushItem_InvalidPayload(t *testing.T) {
 		db:                        db,
 		datasourceHandlerResolver: &datasource.DefaultHandlerResolver{},
 	}
-	err := server.PushItem(c)
+	err = server.PushItem(c)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 	require.Contains(t, rec.Body.String(), "Syntax error")
 }
 
 func TestPushItem_SourceNotFound(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/source/1/push", bytes.NewBuffer([]byte(`{"path":"test.txt"}`)))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -104,14 +108,15 @@ func TestPushItem_SourceNotFound(t *testing.T) {
 		db:                        db,
 		datasourceHandlerResolver: &datasource.DefaultHandlerResolver{},
 	}
-	err := server.PushItem(c)
+	err = server.PushItem(c)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 	require.Contains(t, rec.Body.String(), "source 1 not found")
 }
 
 func TestPushItem_EntryNotFound(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/source/1/push", bytes.NewBuffer([]byte(`{"path":"test.txt"}`)))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -124,7 +129,7 @@ func TestPushItem_EntryNotFound(t *testing.T) {
 		db:                        db,
 		datasourceHandlerResolver: &datasource.DefaultHandlerResolver{},
 	}
-	err := db.Create(&model.Dataset{
+	err = db.Create(&model.Dataset{
 		Name:      "test",
 		MaxSize:   3 * 1024 * 1024,
 		PieceSize: 4 * 1024 * 1024,
@@ -146,7 +151,8 @@ func TestPushItem_EntryNotFound(t *testing.T) {
 }
 
 func TestPushItem_DuplicateItem(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/source/1/push", bytes.NewBuffer([]byte(`{"path":"test.txt"}`)))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -159,7 +165,7 @@ func TestPushItem_DuplicateItem(t *testing.T) {
 		db:                        db,
 		datasourceHandlerResolver: &datasource.DefaultHandlerResolver{},
 	}
-	err := db.Create(&model.Dataset{
+	err = db.Create(&model.Dataset{
 		Name:      "test",
 		MaxSize:   3 * 1024 * 1024,
 		PieceSize: 4 * 1024 * 1024,
@@ -199,7 +205,8 @@ func TestPushItem_DuplicateItem(t *testing.T) {
 }
 
 func TestPushItem(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/source/1/push", bytes.NewBuffer([]byte(`{"path":"test.txt"}`)))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -212,7 +219,7 @@ func TestPushItem(t *testing.T) {
 		db:                        db,
 		datasourceHandlerResolver: &datasource.DefaultHandlerResolver{},
 	}
-	err := db.Create(&model.Dataset{
+	err = db.Create(&model.Dataset{
 		Name:      "test",
 		MaxSize:   3 * 1024 * 1024,
 		PieceSize: 4 * 1024 * 1024,

--- a/cmd/admin/init.go
+++ b/cmd/admin/init.go
@@ -10,7 +10,10 @@ var InitCmd = &cli.Command{
 	Name:  "init",
 	Usage: "Initialize the database",
 	Action: func(context *cli.Context) error {
-		db := database.MustOpenFromCLI(context)
+		db, err := database.OpenFromCLI(context)
+		if err != nil {
+			return err
+		}
 		return admin.InitHandler(db)
 	},
 }

--- a/cmd/admin/reset.go
+++ b/cmd/admin/reset.go
@@ -10,7 +10,10 @@ var ResetCmd = &cli.Command{
 	Name:  "reset",
 	Usage: "Reset the database",
 	Action: func(context *cli.Context) error {
-		db := database.MustOpenFromCLI(context)
+		db, err := database.OpenFromCLI(context)
+		if err != nil {
+			return err
+		}
 		return admin.ResetHandler(db)
 	},
 }

--- a/cmd/dataset/addpiece.go
+++ b/cmd/dataset/addpiece.go
@@ -31,7 +31,10 @@ var AddPieceCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 
 		car, err := dataset.AddPieceHandler(
 			db, c.Args().Get(0), dataset.AddPieceRequest{

--- a/cmd/dataset/addwallet.go
+++ b/cmd/dataset/addwallet.go
@@ -12,7 +12,10 @@ var AddWalletCmd = &cli.Command{
 	Usage:     "Associate a wallet with the dataset. The wallet needs to be imported first using the `singularity wallet import` command.",
 	ArgsUsage: "DATASET_NAME WALLET_ADDRESS",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		wallet, err := wallet.AddWalletHandler(db, c.Args().Get(0), c.Args().Get(1))
 		if err != nil {
 			return err

--- a/cmd/dataset/create.go
+++ b/cmd/dataset/create.go
@@ -47,7 +47,10 @@ var CreateCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		dataset, err := dataset.CreateHandler(
 			db,
 			dataset.CreateRequest{

--- a/cmd/dataset/list.go
+++ b/cmd/dataset/list.go
@@ -11,7 +11,10 @@ var ListDatasetCmd = &cli.Command{
 	Name:  "list",
 	Usage: "List all datasets",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		datasets, err := dataset.ListHandler(
 			db,
 		)

--- a/cmd/dataset/listpieces.go
+++ b/cmd/dataset/listpieces.go
@@ -12,7 +12,10 @@ var ListPiecesCmd = &cli.Command{
 	Usage:     "List all pieces for the dataset that are available for deal making",
 	ArgsUsage: "<dataset_name>",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 
 		car, err := dataset.ListPiecesHandler(
 			db, c.Args().Get(0),

--- a/cmd/dataset/listwallet.go
+++ b/cmd/dataset/listwallet.go
@@ -12,7 +12,10 @@ var ListWalletCmd = &cli.Command{
 	Usage:     "List all associated wallets with the dataset",
 	ArgsUsage: "DATASET_NAME",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		wallets, err := wallet.ListWalletHandler(db, c.Args().Get(0))
 		if err != nil {
 			return err

--- a/cmd/dataset/remove.go
+++ b/cmd/dataset/remove.go
@@ -12,14 +12,13 @@ var RemoveDatasetCmd = &cli.Command{
 	Description: "Important! If the dataset is large, this command will take some time to remove all relevant data.",
 	ArgsUsage:   "<dataset_name>",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
-		err := dataset.RemoveHandler(
-			db,
-			c.Args().Get(0),
-		)
+		db, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
-		return nil
+		return dataset.RemoveHandler(
+			db,
+			c.Args().Get(0),
+		)
 	},
 }

--- a/cmd/dataset/removewallet.go
+++ b/cmd/dataset/removewallet.go
@@ -11,11 +11,10 @@ var RemoveWalletCmd = &cli.Command{
 	Usage:     "Remove an associated wallet from the dataset",
 	ArgsUsage: "DATASET_NAME WALLET_ADDRESS",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
-		err := wallet.RemoveWalletHandler(db, c.Args().Get(0), c.Args().Get(1))
+		db, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
-		return nil
+		return wallet.RemoveWalletHandler(db, c.Args().Get(0), c.Args().Get(1))
 	},
 }

--- a/cmd/dataset/update.go
+++ b/cmd/dataset/update.go
@@ -45,7 +45,10 @@ var UpdateCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		var maxSizeStr *string
 		if c.IsSet("max-size") {
 			s := c.String("max-size")

--- a/cmd/datasource/add.go
+++ b/cmd/datasource/add.go
@@ -1,6 +1,9 @@
 package datasource
 
 import (
+	"path/filepath"
+	"strings"
+
 	"github.com/data-preservation-programs/singularity/cmd/cliutil"
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/datasource"
@@ -12,8 +15,6 @@ import (
 	"github.com/urfave/cli/v2"
 	"golang.org/x/exp/slices"
 	"gorm.io/gorm"
-	"path/filepath"
-	"strings"
 )
 
 var exclude = []string{
@@ -40,7 +41,10 @@ var AddCmd = &cli.Command{
 		cmd.Action = func(c *cli.Context) error {
 			datasetName := c.Args().Get(0)
 			path := c.Args().Get(1)
-			db := database.MustOpenFromCLI(c)
+			db, err := database.OpenFromCLI(c)
+			if err != nil {
+				return err
+			}
 			dataset, err := database.FindDatasetByName(db, datasetName)
 			if err != nil {
 				return handler.NewBadRequestError(err)

--- a/cmd/datasource/check.go
+++ b/cmd/datasource/check.go
@@ -14,7 +14,10 @@ var CheckCmd = &cli.Command{
 	Description: "This command will list entries in a data source under <sub_path>. " +
 		"If <sub_path> is not provided, it will use the root directory",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		entries, err := datasource.CheckSourceHandler(
 			db,
 			c.Context,

--- a/cmd/datasource/daggen.go
+++ b/cmd/datasource/daggen.go
@@ -15,7 +15,10 @@ var DagGenCmd = &cli.Command{
 		"  1. Lookup and download files or folders using unixfs path\n" +
 		"  2. Retrieve file that are splited across multiple pieces/deals",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		source, err := datasource.DagGenHandler(db, c.Args().Get(0))
 		if err != nil {
 			return err

--- a/cmd/datasource/inspect/chunkdetail.go
+++ b/cmd/datasource/inspect/chunkdetail.go
@@ -2,6 +2,7 @@ package inspect
 
 import (
 	"fmt"
+
 	"github.com/data-preservation-programs/singularity/cmd/cliutil"
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler/datasource/inspect"
@@ -30,7 +31,10 @@ var ChunkDetailCmd = &cli.Command{
 	Usage:     "Get details about a specific chunk",
 	ArgsUsage: "<chunk_id>",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		result, err := inspect.GetSourceChunkDetailHandler(
 			db,
 			c.Args().Get(0),

--- a/cmd/datasource/inspect/chunks.go
+++ b/cmd/datasource/inspect/chunks.go
@@ -2,6 +2,7 @@ package inspect
 
 import (
 	"fmt"
+
 	"github.com/data-preservation-programs/singularity/cmd/cliutil"
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler/datasource/inspect"
@@ -14,7 +15,10 @@ var ChunksCmd = &cli.Command{
 	Usage:     "Get all chunk details of a data source",
 	ArgsUsage: "<source_id>",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		result, err := inspect.GetSourceChunksHandler(
 			db,
 			c.Args().Get(0),

--- a/cmd/datasource/inspect/dags.go
+++ b/cmd/datasource/inspect/dags.go
@@ -12,7 +12,10 @@ var DagsCmd = &cli.Command{
 	Usage:     "Get all piece details for generated dags",
 	ArgsUsage: "<source_id>",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		cars, err := inspect.GetDagsHandler(
 			db,
 			c.Args().Get(0),

--- a/cmd/datasource/inspect/itemdetail.go
+++ b/cmd/datasource/inspect/itemdetail.go
@@ -2,6 +2,7 @@ package inspect
 
 import (
 	"fmt"
+
 	"github.com/data-preservation-programs/singularity/cmd/cliutil"
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler/datasource/inspect"
@@ -13,7 +14,10 @@ var ItemDetailCmd = &cli.Command{
 	Usage:     "Get details about a specific item",
 	ArgsUsage: "<item_id>",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		result, err := inspect.GetSourceItemDetailHandler(
 			db,
 			c.Args().Get(0),

--- a/cmd/datasource/inspect/items.go
+++ b/cmd/datasource/inspect/items.go
@@ -13,7 +13,10 @@ var ItemsCmd = &cli.Command{
 	ArgsUsage:   "<source_id>",
 	Description: "This command will list all items in a data source. This may be very large list.",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		result, err := inspect.GetSourceItemsHandler(
 			db,
 			c.Args().Get(0),

--- a/cmd/datasource/inspect/path.go
+++ b/cmd/datasource/inspect/path.go
@@ -2,6 +2,7 @@ package inspect
 
 import (
 	"fmt"
+
 	"github.com/data-preservation-programs/singularity/cmd/cliutil"
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler/datasource/inspect"
@@ -13,7 +14,10 @@ var PathCmd = &cli.Command{
 	Usage:     "Get details about a path within a data source",
 	ArgsUsage: "<source_id> <path>",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		result, err := inspect.GetPathHandler(
 			db,
 			c.Args().Get(0),

--- a/cmd/datasource/list.go
+++ b/cmd/datasource/list.go
@@ -17,7 +17,10 @@ var ListCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		datasetName := c.String("dataset")
 		sources, err := datasource.ListSourceByDatasetHandler(
 			db,

--- a/cmd/datasource/remove.go
+++ b/cmd/datasource/remove.go
@@ -11,11 +11,13 @@ var RemoveCmd = &cli.Command{
 	Usage:     "Remove a data source",
 	ArgsUsage: "<source_id>",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
-		err := datasource.RemoveSourceHandler(
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
+		return datasource.RemoveSourceHandler(
 			db,
 			c.Args().Get(0),
 		)
-		return err
 	},
 }

--- a/cmd/datasource/rescan.go
+++ b/cmd/datasource/rescan.go
@@ -13,7 +13,10 @@ var RescanCmd = &cli.Command{
 	ArgsUsage:   "<source_id>",
 	Description: "This command will clear any error of a data source and rescan it",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		source, err := datasource.RescanSourceHandler(
 			db,
 			c.Args().Get(0),

--- a/cmd/datasource/status.go
+++ b/cmd/datasource/status.go
@@ -3,6 +3,7 @@ package datasource
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/data-preservation-programs/singularity/cmd/cliutil"
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler/datasource"
@@ -14,7 +15,10 @@ var StatusCmd = &cli.Command{
 	Usage:     "Get the data preparation summary of a data source",
 	ArgsUsage: "<source_id>",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		result, err := datasource.GetSourceStatusHandler(
 			db,
 			c.Args().Get(0),

--- a/cmd/datasource/update.go
+++ b/cmd/datasource/update.go
@@ -38,7 +38,10 @@ var UpdateCmd = &cli.Command{
 		return newFlags
 	}(),
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		config := map[string]interface{}{}
 		for _, name := range c.LocalFlagNames() {
 			if c.IsSet(name) {

--- a/cmd/deal/list.go
+++ b/cmd/deal/list.go
@@ -29,7 +29,10 @@ var ListCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		deals, err := deal.ListHandler(db, deal.ListDealRequest{})
 		if err != nil {
 			return err

--- a/cmd/deal/schedule/create.go
+++ b/cmd/deal/schedule/create.go
@@ -2,15 +2,18 @@ package schedule
 
 import (
 	"bufio"
+	"os"
+	"regexp"
+
 	"github.com/data-preservation-programs/singularity/cmd/cliutil"
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler/deal/schedule"
 	"github.com/data-preservation-programs/singularity/util"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
-	"os"
-	"regexp"
 )
+
+var re = regexp.MustCompile(`\bbaga[a-z2-7]+\b`)
 
 var CreateCmd = &cli.Command{
 	Name:      "create",
@@ -155,7 +158,10 @@ var CreateCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		cids := map[string]struct{}{}
 		for _, f := range c.StringSlice("allowed-piece-cid-file") {
 			cidsFromFile, err := readCIDsFromFile(f)
@@ -214,7 +220,6 @@ func readCIDsFromFile(f string) ([]string, error) {
 		return nil, errors.Wrap(err, "failed to open file")
 	}
 	defer file.Close()
-	re := regexp.MustCompile(`\bbaga[a-z2-7]+\b`)
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {

--- a/cmd/deal/schedule/list.go
+++ b/cmd/deal/schedule/list.go
@@ -11,7 +11,10 @@ var ListCmd = &cli.Command{
 	Name:  "list",
 	Usage: "List all deal making schedules",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		schedules, err := schedule.ListHandler(db)
 		if err != nil {
 			return err

--- a/cmd/deal/schedule/pause.go
+++ b/cmd/deal/schedule/pause.go
@@ -12,7 +12,10 @@ var PauseCmd = &cli.Command{
 	Usage:     "Pause a specific schedule",
 	ArgsUsage: "SCHEDULE_ID",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		schedule, err := schedule.PauseHandler(db, c.Args().Get(0))
 		if err != nil {
 			return err

--- a/cmd/deal/schedule/resume.go
+++ b/cmd/deal/schedule/resume.go
@@ -12,7 +12,10 @@ var ResumeCmd = &cli.Command{
 	Usage:     "Resume a specific schedule",
 	ArgsUsage: "SCHEDULE_ID",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 		schedule, err := schedule.ResumeHandler(db, c.Args().Get(0))
 		if err != nil {
 			return err

--- a/cmd/deal/send-manual.go
+++ b/cmd/deal/send-manual.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/data-preservation-programs/singularity/replication"
 	"github.com/data-preservation-programs/singularity/util"
 	"github.com/pkg/errors"
-	"time"
 
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler/deal"
@@ -134,7 +135,10 @@ var SendManualCmd = &cli.Command{
 			FileSize:        cctx.Uint64("file-size"),
 		}
 		timeout := cctx.Duration("timeout")
-		db := database.MustOpenFromCLI(cctx)
+		db, err := database.OpenFromCLI(cctx)
+		if err != nil {
+			return err
+		}
 		ctx, cancel := context.WithTimeout(cctx.Context, timeout)
 		defer cancel()
 		h, err := util.InitHost(nil)

--- a/cmd/run/contentprovider.go
+++ b/cmd/run/contentprovider.go
@@ -44,9 +44,11 @@ var ContentProviderCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
-		err := model.AutoMigrate(db)
+		db, err := database.OpenFromCLI(c)
 		if err != nil {
+			return err
+		}
+		if err := model.AutoMigrate(db); err != nil {
 			return handler.NewHandlerError(err)
 		}
 

--- a/cmd/run/datasetworker.go
+++ b/cmd/run/datasetworker.go
@@ -50,9 +50,11 @@ var DatasetWorkerCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
-		err := model.AutoMigrate(db)
+		db, err := database.OpenFromCLI(c)
 		if err != nil {
+			return err
+		}
+		if err := model.AutoMigrate(db); err != nil {
 			return handler.NewHandlerError(err)
 		}
 		worker := datasetworker.NewDatasetWorker(

--- a/cmd/run/dealmaker.go
+++ b/cmd/run/dealmaker.go
@@ -26,9 +26,11 @@ var DealMakerCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
-		err := model.AutoMigrate(db)
+		db, err := database.OpenFromCLI(c)
 		if err != nil {
+			return err
+		}
+		if err := model.AutoMigrate(db); err != nil {
 			return handler.NewHandlerError(err)
 		}
 		dealMaker, err := service.NewDealMakerService(db, c.String("lotus-api"), c.String("lotus-token"))

--- a/cmd/run/dealtracker.go
+++ b/cmd/run/dealtracker.go
@@ -1,12 +1,13 @@
 package run
 
 import (
+	"time"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/service/dealtracker"
 	"github.com/urfave/cli/v2"
-	"time"
 )
 
 var DealTrackerCmd = &cli.Command{
@@ -27,9 +28,11 @@ var DealTrackerCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
-		err := model.AutoMigrate(db)
+		db, err := database.OpenFromCLI(c)
 		if err != nil {
+			return err
+		}
+		if err := model.AutoMigrate(db); err != nil {
 			return handler.NewHandlerError(err)
 		}
 

--- a/cmd/run/spadeapi.go
+++ b/cmd/run/spadeapi.go
@@ -1,6 +1,8 @@
 package run
 
 import (
+	"time"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
@@ -8,7 +10,6 @@ import (
 	"github.com/data-preservation-programs/singularity/service"
 	"github.com/data-preservation-programs/singularity/util"
 	"github.com/urfave/cli/v2"
-	"time"
 )
 
 var SpadeAPICmd = &cli.Command{
@@ -34,9 +35,11 @@ var SpadeAPICmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
-		err := model.AutoMigrate(db)
+		db, err := database.OpenFromCLI(c)
 		if err != nil {
+			return err
+		}
+		if err := model.AutoMigrate(db); err != nil {
 			return handler.NewHandlerError(err)
 		}
 

--- a/cmd/wallet/addremote.go
+++ b/cmd/wallet/addremote.go
@@ -14,7 +14,10 @@ var AddRemoteCmd = &cli.Command{
 	ArgsUsage: "<address> <remote_peer>",
 	Flags:     []cli.Flag{},
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 
 		lotusClient := util.NewLotusClient(c.String("lotus-api"), c.String("lotus-token"))
 		w, err2 := wallet.AddRemoteHandler(db,

--- a/cmd/wallet/import.go
+++ b/cmd/wallet/import.go
@@ -13,7 +13,10 @@ var ImportCmd = &cli.Command{
 	Usage:     "Import a wallet from exported private key",
 	ArgsUsage: "PRIVATE_KEY",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
 
 		lotusClient := util.NewLotusClient(c.String("lotus-api"), c.String("lotus-token"))
 		w, err := wallet.ImportHandler(db,

--- a/cmd/wallet/list.go
+++ b/cmd/wallet/list.go
@@ -11,10 +11,13 @@ var ListCmd = &cli.Command{
 	Name:  "list",
 	Usage: "List all imported wallets",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
-		wallets, err2 := wallet.ListHandler(db)
-		if err2 != nil {
-			return err2
+		db, err := database.OpenFromCLI(c)
+		if err != nil {
+			return err
+		}
+		wallets, err := wallet.ListHandler(db)
+		if err != nil {
+			return err
 		}
 
 		cliutil.PrintToConsole(wallets, c.Bool("json"), nil)

--- a/cmd/wallet/remove.go
+++ b/cmd/wallet/remove.go
@@ -11,13 +11,10 @@ var RemoveCmd = &cli.Command{
 	Usage:     "Remove a wallet",
 	ArgsUsage: "<address>",
 	Action: func(c *cli.Context) error {
-		db := database.MustOpenFromCLI(c)
-		err := wallet.RemoveHandler(db, c.Args().Get(0))
-
+		db, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
-
-		return nil
+		return wallet.RemoveHandler(db, c.Args().Get(0))
 	},
 }

--- a/database/util_test.go
+++ b/database/util_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestAutoMigrate(t *testing.T) {
-	db := OpenInMemory()
+	db, err := OpenInMemory()
+	require.NoError(t, err)
 	require.NotNil(t, db)
 }

--- a/handler/admin/init_test.go
+++ b/handler/admin/init_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestInitHandler(t *testing.T) {
-	db := database.OpenInMemory()
-	defer model.DropAll(db)
-	err := InitHandler(db)
+	db, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer model.DropAll(db)
+	require.NoError(t, InitHandler(db))
 }

--- a/handler/dataset/addpiece.go
+++ b/handler/dataset/addpiece.go
@@ -2,9 +2,10 @@ package dataset
 
 import (
 	"bufio"
-	util "github.com/ipfs/go-ipfs-util"
 	"os"
 	"strconv"
+
+	util "github.com/ipfs/go-ipfs-util"
 
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler"
@@ -84,17 +85,25 @@ func AddPieceHandler(
 		rootCID = request.RootCID
 	}
 
-	car := model.Car{
-		PieceCID:  model.CID(cid.MustParse(request.PieceCID)),
+	pCid, err := cid.Decode(request.PieceCID)
+	if err != nil {
+		return nil, err
+	}
+	rCid, err := cid.Decode(rootCID)
+	if err != nil {
+		return nil, err
+	}
+	mCar := model.Car{
+		PieceCID:  model.CID(pCid),
 		PieceSize: pieceSize,
-		RootCID:   model.CID(cid.MustParse(rootCID)),
+		RootCID:   model.CID(rCid),
 		FilePath:  request.FilePath,
 		DatasetID: dataset.ID,
 	}
 
-	err = database.DoRetry(func() error { return db.Create(&car).Error })
+	err = database.DoRetry(func() error { return db.Create(&mCar).Error })
 	if err != nil {
 		return nil, handler.NewHandlerError(err)
 	}
-	return &car, nil
+	return &mCar, nil
 }

--- a/handler/dataset/create_test.go
+++ b/handler/dataset/create_test.go
@@ -9,72 +9,82 @@ import (
 )
 
 func TestCreateHandler_NoDatasetName(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	defer model.DropAll(db)
-	_, err := CreateHandler(db, CreateRequest{})
+	_, err = CreateHandler(db, CreateRequest{})
 	require.ErrorContains(t, err, "name is required")
 }
 
 func TestCreateHandler_MaxSizeNotValid(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	defer model.DropAll(db)
-	_, err := CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "not valid"})
+	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "not valid"})
 	require.ErrorContains(t, err, "invalid value for max-size")
 }
 
 func TestCreateHandler_PieceSizeNotValid(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	defer model.DropAll(db)
-	_, err := CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", PieceSizeStr: "not valid"})
+	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", PieceSizeStr: "not valid"})
 	require.ErrorContains(t, err, "invalid value for piece-size")
 }
 
 func TestCreateHandler_PieceSizeNotPowerOfTwo(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	defer model.DropAll(db)
-	_, err := CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", PieceSizeStr: "3GB"})
+	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", PieceSizeStr: "3GB"})
 	require.ErrorContains(t, err, "piece size must be a power of two")
 }
 
 func TestCreateHandler_PieceSizeTooLarge(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	defer model.DropAll(db)
-	_, err := CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", PieceSizeStr: "128GiB"})
+	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", PieceSizeStr: "128GiB"})
 	require.ErrorContains(t, err, "piece size cannot be larger than 64 GiB")
 }
 
 func TestCreateHandler_MaxSizeTooLarge(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	defer model.DropAll(db)
-	_, err := CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "63.9GiB"})
+	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "63.9GiB"})
 	require.ErrorContains(t, err, "max size needs to be reduced to leave space for padding")
 }
 
 func TestCreateHandler_OutDirDoesNotExist(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	defer model.DropAll(db)
-	_, err := CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", OutputDirs: []string{"not exist"}})
+	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", OutputDirs: []string{"not exist"}})
 	require.ErrorContains(t, err, "output directory does not exist")
 }
 
 func TestCreateHandler_RecipientsScriptCannotBeUsedTogether(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	defer model.DropAll(db)
-	_, err := CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", EncryptionRecipients: []string{"test"}, EncryptionScript: "test"})
+	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", EncryptionRecipients: []string{"test"}, EncryptionScript: "test"})
 	require.ErrorContains(t, err, "encryption recipients and script cannot be used together")
 }
 
 func TestCreateHandler_EncryptionNeedsOutputDir(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	defer model.DropAll(db)
-	_, err := CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", EncryptionRecipients: []string{"test"}})
+	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", EncryptionRecipients: []string{"test"}})
 	require.ErrorContains(t, err, "encryption is not compatible with inline preparation")
 }
 
 func TestCreateHandler_Success(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	defer model.DropAll(db)
-	_, err := CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB"})
+	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB"})
 	require.NoError(t, err)
 	dataset := model.Dataset{}
 	db.Where("name = ?", "test").First(&dataset)

--- a/handler/deal/schedule/create_test.go
+++ b/handler/deal/schedule/create_test.go
@@ -73,15 +73,16 @@ var createRequest = CreateRequest{
 }
 
 func TestCreateHandler_DatasetNotFound(t *testing.T) {
-	db := database.OpenInMemory()
-	_, err := CreateHandler(db, context.Background(), getMockLotusClient(), createRequest)
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), createRequest)
 	require.ErrorContains(t, err, "dataset not found")
 }
 
 func TestCreateHandler_InvalidStartDelay(t *testing.T) {
-	db := database.OpenInMemory()
-	err := db.Create(&model.Dataset{Name: "test"}).Error
+	db, err := database.OpenInMemory()
 	require.NoError(t, err)
+	require.NoError(t, db.Create(&model.Dataset{Name: "test"}).Error)
 	badRequest := createRequest
 	badRequest.StartDelay = "1year"
 	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
@@ -89,9 +90,9 @@ func TestCreateHandler_InvalidStartDelay(t *testing.T) {
 }
 
 func TestCreateHandler_InvalidDuration(t *testing.T) {
-	db := database.OpenInMemory()
-	err := db.Create(&model.Dataset{Name: "test"}).Error
+	db, err := database.OpenInMemory()
 	require.NoError(t, err)
+	require.NoError(t, db.Create(&model.Dataset{Name: "test"}).Error)
 	badRequest := createRequest
 	badRequest.Duration = "1year"
 	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
@@ -99,9 +100,9 @@ func TestCreateHandler_InvalidDuration(t *testing.T) {
 }
 
 func TestCreateHandler_InvalidScheduleInterval(t *testing.T) {
-	db := database.OpenInMemory()
-	err := db.Create(&model.Dataset{Name: "test"}).Error
+	db, err := database.OpenInMemory()
 	require.NoError(t, err)
+	require.NoError(t, db.Create(&model.Dataset{Name: "test"}).Error)
 	badRequest := createRequest
 	badRequest.ScheduleInterval = "1year"
 	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
@@ -109,8 +110,9 @@ func TestCreateHandler_InvalidScheduleInterval(t *testing.T) {
 }
 
 func TestCreateHandler_InvalidScheduleDealSize(t *testing.T) {
-	db := database.OpenInMemory()
-	err := db.Create(&model.Dataset{Name: "test"}).Error
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	err = db.Create(&model.Dataset{Name: "test"}).Error
 	require.NoError(t, err)
 	badRequest := createRequest
 	badRequest.ScheduleDealSize = "One PB"
@@ -119,8 +121,9 @@ func TestCreateHandler_InvalidScheduleDealSize(t *testing.T) {
 }
 
 func TestCreateHandler_InvalidTotalDealSize(t *testing.T) {
-	db := database.OpenInMemory()
-	err := db.Create(&model.Dataset{Name: "test"}).Error
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	err = db.Create(&model.Dataset{Name: "test"}).Error
 	require.NoError(t, err)
 	badRequest := createRequest
 	badRequest.TotalDealSize = "One PB"
@@ -129,8 +132,9 @@ func TestCreateHandler_InvalidTotalDealSize(t *testing.T) {
 }
 
 func TestCreateHandler_InvalidPendingDealSize(t *testing.T) {
-	db := database.OpenInMemory()
-	err := db.Create(&model.Dataset{Name: "test"}).Error
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	err = db.Create(&model.Dataset{Name: "test"}).Error
 	require.NoError(t, err)
 	badRequest := createRequest
 	badRequest.MaxPendingDealSize = "One PB"
@@ -139,8 +143,9 @@ func TestCreateHandler_InvalidPendingDealSize(t *testing.T) {
 }
 
 func TestCreateHandler_InvalidAllowedPieceCID_NotCID(t *testing.T) {
-	db := database.OpenInMemory()
-	err := db.Create(&model.Dataset{Name: "test"}).Error
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	err = db.Create(&model.Dataset{Name: "test"}).Error
 	require.NoError(t, err)
 	badRequest := createRequest
 	badRequest.AllowedPieceCIDs = []string{"not a cid"}
@@ -149,8 +154,9 @@ func TestCreateHandler_InvalidAllowedPieceCID_NotCID(t *testing.T) {
 }
 
 func TestCreateHandler_InvalidAllowedPieceCID_NotCommp(t *testing.T) {
-	db := database.OpenInMemory()
-	err := db.Create(&model.Dataset{Name: "test"}).Error
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	err = db.Create(&model.Dataset{Name: "test"}).Error
 	require.NoError(t, err)
 	badRequest := createRequest
 	badRequest.AllowedPieceCIDs = []string{"bafybeiejlvvmfokp5c6q2eqgbfjeaokz3nqho5c7yy3ov527vsatgsqfma"}
@@ -159,16 +165,18 @@ func TestCreateHandler_InvalidAllowedPieceCID_NotCommp(t *testing.T) {
 }
 
 func TestCreateHandler_NoAssociatedWallet(t *testing.T) {
-	db := database.OpenInMemory()
-	err := db.Create(&model.Dataset{Name: "test"}).Error
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	err = db.Create(&model.Dataset{Name: "test"}).Error
 	require.NoError(t, err)
 	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), createRequest)
 	require.ErrorContains(t, err, "no wallet")
 }
 
 func TestCreateHandler_InvalidProvider(t *testing.T) {
-	db := database.OpenInMemory()
-	err := db.Create(&model.Dataset{Name: "test"}).Error
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	err = db.Create(&model.Dataset{Name: "test"}).Error
 	require.NoError(t, err)
 	err = db.Create(&model.Wallet{ID: "f01"}).Error
 	require.NoError(t, err)
@@ -182,8 +190,9 @@ func TestCreateHandler_InvalidProvider(t *testing.T) {
 }
 
 func TestCreateHandler_Success(t *testing.T) {
-	db := database.OpenInMemory()
-	err := db.Create(&model.Dataset{Name: "test"}).Error
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	err = db.Create(&model.Dataset{Name: "test"}).Error
 	require.NoError(t, err)
 	err = db.Create(&model.Wallet{ID: "f01"}).Error
 	require.NoError(t, err)

--- a/handler/deal/send-manual_test.go
+++ b/handler/deal/send-manual_test.go
@@ -42,8 +42,9 @@ func TestSendManualHandler_WalletNotFound(t *testing.T) {
 		Address: "f10000",
 	}
 
-	db := database.OpenInMemory()
-	err := db.Create(&wallet).Error
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	err = db.Create(&wallet).Error
 	require.NoError(t, err)
 	ctx := context.Background()
 
@@ -59,8 +60,9 @@ func TestSendManualHandler_InvalidPieceCID(t *testing.T) {
 		Address: "f10000",
 	}
 
-	db := database.OpenInMemory()
-	err := db.Create(&wallet).Error
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	err = db.Create(&wallet).Error
 	require.NoError(t, err)
 	ctx := context.Background()
 
@@ -78,8 +80,9 @@ func TestSendManualHandler_InvalidPieceCID_NOTCOMMP(t *testing.T) {
 		Address: "f10000",
 	}
 
-	db := database.OpenInMemory()
-	err := db.Create(&wallet).Error
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	err = db.Create(&wallet).Error
 	require.NoError(t, err)
 	ctx := context.Background()
 
@@ -97,8 +100,9 @@ func TestSendManualHandler_InvalidPieceSize(t *testing.T) {
 		Address: "f10000",
 	}
 
-	db := database.OpenInMemory()
-	err := db.Create(&wallet).Error
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	err = db.Create(&wallet).Error
 	require.NoError(t, err)
 	ctx := context.Background()
 
@@ -116,8 +120,9 @@ func TestSendManualHandler_InvalidPieceSize_NotPowerOfTwo(t *testing.T) {
 		Address: "f10000",
 	}
 
-	db := database.OpenInMemory()
-	err := db.Create(&wallet).Error
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	err = db.Create(&wallet).Error
 	require.NoError(t, err)
 	ctx := context.Background()
 
@@ -135,8 +140,9 @@ func TestSendManualHandler_InvalidRootCID(t *testing.T) {
 		Address: "f10000",
 	}
 
-	db := database.OpenInMemory()
-	err := db.Create(&wallet).Error
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	err = db.Create(&wallet).Error
 	require.NoError(t, err)
 	ctx := context.Background()
 
@@ -154,8 +160,9 @@ func TestSendManualHandler_InvalidDuration(t *testing.T) {
 		Address: "f10000",
 	}
 
-	db := database.OpenInMemory()
-	err := db.Create(&wallet).Error
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	err = db.Create(&wallet).Error
 	require.NoError(t, err)
 	ctx := context.Background()
 
@@ -173,8 +180,9 @@ func TestSendManualHandler_InvalidStartDelay(t *testing.T) {
 		Address: "f10000",
 	}
 
-	db := database.OpenInMemory()
-	err := db.Create(&wallet).Error
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	err = db.Create(&wallet).Error
 	require.NoError(t, err)
 	ctx := context.Background()
 
@@ -192,8 +200,9 @@ func TestSendManualHandler(t *testing.T) {
 		Address: "f10000",
 	}
 
-	db := database.OpenInMemory()
-	err := db.Create(&wallet).Error
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	err = db.Create(&wallet).Error
 	require.NoError(t, err)
 	ctx := context.Background()
 

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -23,7 +23,10 @@ import (
 
 func Migrate(cctx *cli.Context) error {
 	logger := log.Logger("cli")
-	db := database.MustOpenFromCLI(cctx)
+	db, err := database.OpenFromCLI(cctx)
+	if err != nil {
+		return err
+	}
 	ctx := context.TODO()
 	mg, err := mongo.Connect(ctx, options.Client().ApplyURI(cctx.String("mongo-connection-string")))
 	if err != nil {

--- a/replication/makedeal.go
+++ b/replication/makedeal.go
@@ -5,6 +5,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/replication/internal/proposal110"
 	"github.com/data-preservation-programs/singularity/replication/internal/proposal120"
@@ -25,8 +28,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/ybbus/jsonrpc/v3"
 	"golang.org/x/exp/slices"
-	"strings"
-	"time"
 )
 
 const (
@@ -336,7 +337,7 @@ func (d DealMakerImpl) MakeDeal(ctx context.Context, walletObj model.Wallet,
 		return "", errors.Wrap(err, "failed to parse provider address")
 	}
 
-	label, err := proposal110.NewLabelFromString(cid.MustParse(cid.Cid(car.RootCID)).String())
+	label, err := proposal110.NewLabelFromString(cid.Cid(car.RootCID).String())
 	if err != nil {
 		return "", errors.Wrap(err, "failed to parse label")
 	}
@@ -361,7 +362,7 @@ func (d DealMakerImpl) MakeDeal(ctx context.Context, walletObj model.Wallet,
 	endEpoch := TimeToEpoch(now.Add(dealConfig.StartDelay + dealConfig.Duration))
 	price := dealConfig.GetPrice(car.PieceSize, dealConfig.Duration)
 	verified := dealConfig.Verified
-	pieceCID := cid.MustParse(cid.Cid(car.PieceCID))
+	pieceCID := cid.Cid(car.PieceCID)
 	pieceSize := abi.PaddedPieceSize(car.PieceSize)
 	collateral, err := d.getMinCollateral(ctx, car.PieceSize, verified)
 	if err != nil {
@@ -396,7 +397,7 @@ func (d DealMakerImpl) MakeDeal(ctx context.Context, walletObj model.Wallet,
 
 	if slices.Contains(protocols, StorageProposalV120) {
 		dealID := uuid.New()
-		resp, err := d.makeDeal120(ctx, deal, dealID, dealConfig, car.FileSize, cid.MustParse(cid.Cid(car.RootCID)), addrInfo)
+		resp, err := d.makeDeal120(ctx, deal, dealID, dealConfig, car.FileSize, cid.Cid(car.RootCID), addrInfo)
 		if err != nil {
 			return "", errors.Wrap(err, "failed to make deal")
 		}
@@ -406,7 +407,7 @@ func (d DealMakerImpl) MakeDeal(ctx context.Context, walletObj model.Wallet,
 
 		return "", errors.Errorf("deal rejected: %s", resp.Message)
 	} else if slices.Contains(protocols, StorageProposalV111) {
-		resp, err := d.makeDeal111(ctx, deal, dealConfig, cid.MustParse(cid.Cid(car.RootCID)), addrInfo)
+		resp, err := d.makeDeal111(ctx, deal, dealConfig, cid.Cid(car.RootCID), addrInfo)
 		if err != nil {
 			return "", errors.Wrap(err, "failed to make deal")
 		}

--- a/replication/wallet_test.go
+++ b/replication/wallet_test.go
@@ -42,7 +42,8 @@ func (m *MockRPCClient) CallBatchRaw(ctx context.Context, requests jsonrpc.RPCRe
 }
 
 func TestDatacapWalletChooser_Choose(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	lotusClient := new(MockRPCClient)
 
 	// Set up the test data
@@ -78,7 +79,7 @@ func TestDatacapWalletChooser_Choose(t *testing.T) {
 	chooser := NewDatacapWalletChooser(db, time.Minute, "lotusAPI", "lotusToken", 900001)
 	chooser.lotusClient = lotusClient
 
-	err := db.Create(&wallets).Error
+	err = db.Create(&wallets).Error
 	require.NoError(t, err)
 	err = db.Create(&model.Deal{
 		ClientID:  "3",

--- a/service/datasetworker/datasetworker_test.go
+++ b/service/datasetworker/datasetworker_test.go
@@ -14,14 +14,15 @@ import (
 )
 
 func TestDatasetWorkerRun(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	worker := NewDatasetWorker(db, DatasetWorkerConfig{
 		Concurrency:    1,
 		ExitOnComplete: true,
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	err := worker.Run(ctx)
+	err = worker.Run(ctx)
 	require.NoError(t, err)
 }
 
@@ -38,7 +39,8 @@ func TestDatasetWorkerThread_pack(t *testing.T) {
 	require.NoError(t, err)
 	err = file.Close()
 	require.NoError(t, err)
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	thread := DatasetWorkerThread{
 		id:                        uuid.New(),
 		db:                        db,
@@ -163,7 +165,8 @@ func TestDatasetWorkerThread_pack(t *testing.T) {
 
 func TestDatasetWorkerThread_scan(t *testing.T) {
 	ctx := context.Background()
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	thread := DatasetWorkerThread{
 		id:                        uuid.New(),
 		db:                        db,
@@ -183,7 +186,7 @@ func TestDatasetWorkerThread_scan(t *testing.T) {
 		Name:    "test",
 		MaxSize: 1024,
 	}
-	err := db.Create(&dataset).Error
+	err = db.Create(&dataset).Error
 	require.NoError(t, err)
 	cmd, _ := os.Getwd()
 	source := model.Source{
@@ -217,7 +220,8 @@ func TestDatasetWorkerThread_scan(t *testing.T) {
 }
 
 func TestDatasetWorkerThread_findPackWork(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	thread := DatasetWorkerThread{
 		id:                        uuid.New(),
 		db:                        db,
@@ -235,7 +239,7 @@ func TestDatasetWorkerThread_findPackWork(t *testing.T) {
 	worker := model.Worker{
 		ID: thread.id.String(),
 	}
-	err := db.Create(&worker).Error
+	err = db.Create(&worker).Error
 	require.NoError(t, err)
 	dataset := model.Dataset{
 		Name: "test",
@@ -319,7 +323,8 @@ func TestDatasetWorkerThread_findPackWork(t *testing.T) {
 }
 
 func TestDatasetWorkerThread_findScanWork(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	thread := DatasetWorkerThread{
 		id:                        uuid.New(),
 		db:                        db,
@@ -337,7 +342,7 @@ func TestDatasetWorkerThread_findScanWork(t *testing.T) {
 	worker := model.Worker{
 		ID: thread.id.String(),
 	}
-	err := db.Create(&worker).Error
+	err = db.Create(&worker).Error
 	require.NoError(t, err)
 	dataset := model.Dataset{
 		Name: "test",

--- a/service/dealmaker.go
+++ b/service/dealmaker.go
@@ -2,6 +2,12 @@ package service
 
 import (
 	"context"
+	"math"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/replication"
 	"github.com/data-preservation-programs/singularity/service/healthcheck"
@@ -14,11 +20,6 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
 	"gorm.io/gorm"
-	"math"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
 )
 
 type DealMakerService struct {
@@ -207,8 +208,8 @@ func (w *DealMakerWorker) runOnce(ctx context.Context, schedule model.Schedule) 
 			ClientID:   walletObj.ID,
 			Provider:   schedule.Provider,
 			ProposalID: proposalID,
-			Label:      cid.MustParse(cid.Cid(car.RootCID)).String(),
-			PieceCID:   cid.MustParse(cid.Cid(car.PieceCID)).String(),
+			Label:      cid.Cid(car.RootCID).String(),
+			PieceCID:   cid.Cid(car.PieceCID).String(),
 			PieceSize:  car.PieceSize,
 			//Start:      now.Add(schedule.StartDelay),
 			//Duration:   schedule.Duration,

--- a/service/dealtracker/dealtracker_test.go
+++ b/service/dealtracker/dealtracker_test.go
@@ -97,7 +97,8 @@ func TestTrackDeal(t *testing.T) {
 }
 
 func TestShouldTrackDeal(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	tracker := NewDealTracker(db, time.Second, "", "", "")
 	should, err := tracker.shouldTrackDeal(context.Background())
 	require.NoError(t, err)
@@ -115,8 +116,9 @@ func TestShouldTrackDeal(t *testing.T) {
 }
 
 func TestRunOnce(t *testing.T) {
-	db := database.OpenInMemory()
-	err := db.Create(&model.Wallet{
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
+	err = db.Create(&model.Wallet{
 		ID:      "t0100",
 		Address: "t3xxx",
 	}).Error

--- a/service/healthcheck/healthcheck_test.go
+++ b/service/healthcheck/healthcheck_test.go
@@ -12,7 +12,8 @@ import (
 
 func TestHealthCheck(t *testing.T) {
 	req := require.New(t)
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	defer database.DropAll(db)
 
 	id := uuid.New()
@@ -23,7 +24,7 @@ func TestHealthCheck(t *testing.T) {
 		}
 	})
 	var worker model.Worker
-	err := db.Where("id = ?", id.String()).First(&worker).Error
+	err = db.Where("id = ?", id.String()).First(&worker).Error
 	req.Nil(err)
 	req.Equal(model.Packing, worker.WorkType)
 	req.Equal("something", worker.WorkingOn)

--- a/store/item_reference_test.go
+++ b/store/item_reference_test.go
@@ -30,7 +30,8 @@ func TestItemReferenceBlockStore(t *testing.T) {
 	require.NoError(t, err)
 
 	// Initialize a new in-memory SQLite database for testing
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	defer database.DropAll(db)
 
 	// Create a new instance of the CarReferenceBlockStore

--- a/store/piece_store_test.go
+++ b/store/piece_store_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 func TestReadAt2(t *testing.T) {
-	db := database.OpenInMemory()
+	db, err := database.OpenInMemory()
+	require.NoError(t, err)
 	defer database.DropAll(db)
 
 	car := model.Car{


### PR DESCRIPTION
Refactor `Must*` functions to never panic during normal execution, and instead return error.

Replace `cid.MustParse` with `cid.Decode` to avoid panicking.

Remove redundant wrappings of `cid.MustParse`.