### PR TITLE
Optimise imports by grouping SDK packages

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -4,6 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
 	"github.com/data-preservation-programs/singularity/cmd/admin"
 	"github.com/data-preservation-programs/singularity/cmd/dataset"
 	"github.com/data-preservation-programs/singularity/cmd/datasource"
@@ -17,10 +22,6 @@ import (
 	"github.com/data-preservation-programs/singularity/util/must"
 	"github.com/mattn/go-shellwords"
 	"github.com/urfave/cli/v2"
-	"io"
-	"os"
-	"os/exec"
-	"strings"
 )
 
 var App = &cli.App{

--- a/cmd/cliutil/util.go
+++ b/cmd/cliutil/util.go
@@ -3,12 +3,13 @@ package cliutil
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/rodaine/table"
-	"golang.org/x/exp/slices"
 	"os"
 	"reflect"
 	"time"
+
+	"github.com/fatih/color"
+	"github.com/rodaine/table"
+	"golang.org/x/exp/slices"
 )
 
 func PrintAsJSON(obj interface{}) {

--- a/cmd/ez/prep.go
+++ b/cmd/ez/prep.go
@@ -2,6 +2,12 @@ package ez
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/data-preservation-programs/singularity/cmd/cliutil"
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler/admin"
@@ -12,11 +18,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 	"gorm.io/gorm"
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
-	"time"
 )
 
 var PrepCmd = &cli.Command{

--- a/dashboard/src/App.test.tsx
+++ b/dashboard/src/App.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import App from './App';
 
 test('renders learn react link', () => {

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Container, Navbar, Row, Col } from 'react-bootstrap';
+import React, {useState} from 'react';
+import {Col, Container, Navbar, Row} from 'react-bootstrap';
 import DatasetList from './components/DatasetList';
 import OverallDealStats from './components/OverallDealStats';
 import DatasetDealStats from './components/DatasetDealStats';

--- a/dashboard/src/components/CarExplorer.tsx
+++ b/dashboard/src/components/CarExplorer.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, {useEffect, useState} from 'react';
 import axios from 'axios';
-import { Table, Offcanvas, Pagination } from 'react-bootstrap';
+import {Offcanvas, Pagination, Table} from 'react-bootstrap';
 import './DatasetExplorer.css';
 
 interface Car {

--- a/dashboard/src/components/DatasetDealStats.tsx
+++ b/dashboard/src/components/DatasetDealStats.tsx
@@ -1,17 +1,17 @@
-import React, { useEffect, useState } from 'react';
+import React, {useEffect, useState} from 'react';
 import axios from 'axios';
-import { Card, CardGroup } from 'react-bootstrap';
+import {Card, CardGroup} from 'react-bootstrap';
 import {
-  BarChart,
-  Bar,
-  LineChart,
-  Line,
-  CartesianGrid,
-  XAxis,
-  YAxis,
-  Tooltip,
-  Legend,
-  ResponsiveContainer,
+    Bar,
+    BarChart,
+    CartesianGrid,
+    Legend,
+    Line,
+    LineChart,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis,
 } from 'recharts';
 import xbytes from 'xbytes';
 

--- a/dashboard/src/components/DatasetExplorer.tsx
+++ b/dashboard/src/components/DatasetExplorer.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, {useEffect, useState} from 'react';
 import axios from 'axios';
-import {Breadcrumb, Table, Offcanvas, Button} from 'react-bootstrap';
+import {Breadcrumb, Button, Offcanvas, Table} from 'react-bootstrap';
 import './DatasetExplorer.css';
 
 

--- a/dashboard/src/components/DatasetList.tsx
+++ b/dashboard/src/components/DatasetList.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, {useEffect, useState} from 'react';
 import axios from 'axios';
-import { Accordion, Card, Button } from 'react-bootstrap';
+import {Accordion, Button, Card} from 'react-bootstrap';
 import SourceList from './SourceList';
 import './DatasetList.css';
 

--- a/dashboard/src/components/OverallDealStats.tsx
+++ b/dashboard/src/components/OverallDealStats.tsx
@@ -1,17 +1,17 @@
-import React, { useEffect, useState } from 'react';
+import React, {useEffect, useState} from 'react';
 import axios from 'axios';
-import { Card, CardGroup } from 'react-bootstrap';
+import {Card, CardGroup} from 'react-bootstrap';
 import {
-  BarChart,
-  Bar,
-  LineChart,
-  Line,
-  CartesianGrid,
-  XAxis,
-  YAxis,
-  Tooltip,
-  Legend,
-  ResponsiveContainer,
+    Bar,
+    BarChart,
+    CartesianGrid,
+    Legend,
+    Line,
+    LineChart,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis,
 } from 'recharts';
 import xbytes from 'xbytes';
 

--- a/dashboard/src/components/SourceList.tsx
+++ b/dashboard/src/components/SourceList.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, {useEffect, useState} from 'react';
 import axios from 'axios';
-import { Button } from 'react-bootstrap';
+import {Button} from 'react-bootstrap';
 import './SourceList.css';
 
 interface Source {

--- a/dashboard/src/components/SourceView.tsx
+++ b/dashboard/src/components/SourceView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Tab, Tabs } from 'react-bootstrap';
+import {Tab, Tabs} from 'react-bootstrap';
 import DatasetExplorer from "./DatasetExplorer";
 import CarExplorer from "./CarExplorer";
 

--- a/dashboard/src/reportWebVitals.ts
+++ b/dashboard/src/reportWebVitals.ts
@@ -1,4 +1,4 @@
-import { ReportHandler } from 'web-vitals';
+import {ReportHandler} from 'web-vitals';
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {

--- a/dashboard/src/setupTests.ts
+++ b/dashboard/src/setupTests.ts
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom'; 

--- a/database/connstring.go
+++ b/database/connstring.go
@@ -3,6 +3,8 @@
 package database
 
 import (
+	"strings"
+
 	"github.com/glebarez/sqlite"
 	"github.com/ipfs/go-log/v2"
 	"github.com/pkg/errors"
@@ -10,7 +12,6 @@ import (
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlserver"
 	"gorm.io/gorm"
-	"strings"
 )
 
 var ErrDatabaseNotSupported = errors.New("database not supported")

--- a/database/connstring_cgo.go
+++ b/database/connstring_cgo.go
@@ -3,13 +3,14 @@
 package database
 
 import (
+	"strings"
+
 	"github.com/ipfs/go-log/v2"
 	"github.com/pkg/errors"
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"strings"
 )
 
 var ErrDatabaseNotSupported = errors.New("database not supported")

--- a/datasource/rclone.go
+++ b/datasource/rclone.go
@@ -3,6 +3,11 @@ package datasource
 import (
 	"context"
 	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/pkg/errors"
 	_ "github.com/rclone/rclone/backend/amazonclouddrive"
@@ -51,10 +56,6 @@ import (
 	"github.com/rjNemo/underscore"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/exp/slices"
-	"io"
-	"sort"
-	"strconv"
-	"strings"
 )
 
 type RCloneHandler struct {

--- a/datasource/types.go
+++ b/datasource/types.go
@@ -2,9 +2,10 @@ package datasource
 
 import (
 	"context"
+	"io"
+
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/rclone/rclone/fs"
-	"io"
 )
 
 // Entry is a struct that represents a single item during a data source scan

--- a/handler/dataset/create.go
+++ b/handler/dataset/create.go
@@ -1,10 +1,11 @@
 package dataset
 
 import (
-	"github.com/data-preservation-programs/singularity/database"
-	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
+
+	"github.com/data-preservation-programs/singularity/database"
+	"github.com/pkg/errors"
 
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"

--- a/handler/dataset/update.go
+++ b/handler/dataset/update.go
@@ -1,6 +1,9 @@
 package dataset
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
@@ -8,8 +11,6 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/ipfs/go-log/v2"
 	"gorm.io/gorm"
-	"os"
-	"path/filepath"
 )
 
 type UpdateRequest struct {

--- a/handler/datasource/check.go
+++ b/handler/datasource/check.go
@@ -2,6 +2,9 @@ package datasource
 
 import (
 	"context"
+	"strconv"
+	"time"
+
 	"github.com/data-preservation-programs/singularity/datasource"
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
@@ -9,8 +12,6 @@ import (
 	"github.com/rclone/rclone/fs"
 	"github.com/rjNemo/underscore"
 	"gorm.io/gorm"
-	"strconv"
-	"time"
 )
 
 type CheckSourceRequest struct {

--- a/handler/datasource/daggen.go
+++ b/handler/datasource/daggen.go
@@ -1,11 +1,12 @@
 package datasource
 
 import (
+	"strconv"
+
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
-	"strconv"
 )
 
 // DagGenHandler godoc

--- a/handler/datasource/generate/add.go
+++ b/handler/datasource/generate/add.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/data-preservation-programs/singularity/cmd/datasource"
-	"github.com/urfave/cli/v2"
 	"os"
 	"strings"
 	"text/template"
 	"unicode"
+
+	"github.com/data-preservation-programs/singularity/cmd/datasource"
+	"github.com/urfave/cli/v2"
 )
 
 const header = `

--- a/handler/datasource/inspect/chunkdetail.go
+++ b/handler/datasource/inspect/chunkdetail.go
@@ -1,11 +1,12 @@
 package inspect
 
 import (
+	"strconv"
+
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
-	"strconv"
 )
 
 // GetSourceChunkDetailHandler godoc

--- a/handler/datasource/inspect/chunks.go
+++ b/handler/datasource/inspect/chunks.go
@@ -1,11 +1,12 @@
 package inspect
 
 import (
+	"strconv"
+
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
-	"strconv"
 )
 
 // GetSourceChunksHandler godoc

--- a/handler/datasource/inspect/dags.go
+++ b/handler/datasource/inspect/dags.go
@@ -1,11 +1,12 @@
 package inspect
 
 import (
+	"strconv"
+
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
-	"strconv"
 )
 
 // GetDagsHandler godoc

--- a/handler/datasource/inspect/itemdetail.go
+++ b/handler/datasource/inspect/itemdetail.go
@@ -1,11 +1,12 @@
 package inspect
 
 import (
+	"strconv"
+
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
-	"strconv"
 )
 
 // GetSourceItemDetailHandler godoc

--- a/handler/datasource/inspect/items.go
+++ b/handler/datasource/inspect/items.go
@@ -1,11 +1,12 @@
 package inspect
 
 import (
+	"strconv"
+
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
-	"strconv"
 )
 
 // GetSourceItemsHandler godoc

--- a/handler/datasource/inspect/path.go
+++ b/handler/datasource/inspect/path.go
@@ -1,13 +1,14 @@
 package inspect
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/pkg/errors"
 	"github.com/rjNemo/underscore"
 	"gorm.io/gorm"
-	"strconv"
-	"strings"
 )
 
 type DirDetail struct {

--- a/handler/datasource/remove.go
+++ b/handler/datasource/remove.go
@@ -1,12 +1,13 @@
 package datasource
 
 import (
+	"strconv"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
-	"strconv"
 )
 
 // RemoveSourceHandler godoc

--- a/handler/datasource/rescan.go
+++ b/handler/datasource/rescan.go
@@ -1,12 +1,13 @@
 package datasource
 
 import (
+	"strconv"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
-	"strconv"
 )
 
 // RescanSourceHandler godoc

--- a/handler/datasource/summary.go
+++ b/handler/datasource/summary.go
@@ -1,11 +1,12 @@
 package datasource
 
 import (
+	"strconv"
+
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
-	"strconv"
 )
 
 type ChunksByState struct {

--- a/handler/datasource/update.go
+++ b/handler/datasource/update.go
@@ -2,6 +2,11 @@ package datasource
 
 import (
 	"context"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/datasource"
 	"github.com/data-preservation-programs/singularity/handler"
@@ -10,10 +15,6 @@ import (
 	"github.com/rclone/rclone/fs"
 	"github.com/rjNemo/underscore"
 	"gorm.io/gorm"
-	"strconv"
-	"strings"
-	"time"
-	"unicode"
 )
 
 type Config map[string]interface{}

--- a/handler/deal/schedule/create.go
+++ b/handler/deal/schedule/create.go
@@ -2,6 +2,9 @@ package schedule
 
 import (
 	"context"
+	"strconv"
+	"time"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
@@ -10,8 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/ybbus/jsonrpc/v3"
 	"gorm.io/gorm"
-	"strconv"
-	"time"
 )
 
 //nolint:lll

--- a/handler/deal/send-manual.go
+++ b/handler/deal/send-manual.go
@@ -2,9 +2,10 @@ package deal
 
 import (
 	"context"
-	"github.com/dustin/go-humanize"
 	"strconv"
 	"time"
+
+	"github.com/dustin/go-humanize"
 
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"

--- a/handler/download.go
+++ b/handler/download.go
@@ -2,6 +2,13 @@ package handler
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
 	"github.com/data-preservation-programs/singularity/datasource"
 	"github.com/data-preservation-programs/singularity/service/contentprovider"
 	"github.com/data-preservation-programs/singularity/store"
@@ -9,12 +16,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rclone/rclone/fs"
 	"github.com/rjNemo/underscore"
-	"io"
-	"net/http"
-	"os"
-	"path/filepath"
-	"strings"
-	"sync"
 )
 
 func DownloadHandler(ctx context.Context,

--- a/handler/errors.go
+++ b/handler/errors.go
@@ -1,9 +1,10 @@
 package handler
 
 import (
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
-	"net/http"
 )
 
 type Error struct {

--- a/handler/wallet/addremote.go
+++ b/handler/wallet/addremote.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"context"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"

--- a/handler/wallet/import.go
+++ b/handler/wallet/import.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"context"
+
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/filecoin-project/go-address"

--- a/model/dataset.go
+++ b/model/dataset.go
@@ -3,9 +3,10 @@ package model
 import (
 	"database/sql/driver"
 	"encoding/json"
+	"time"
+
 	"github.com/ipfs/go-cid"
 	"gorm.io/gorm"
-	"time"
 
 	"github.com/pkg/errors"
 )

--- a/model/migrate.go
+++ b/model/migrate.go
@@ -3,6 +3,7 @@ package model
 import (
 	"crypto/rand"
 	"encoding/base64"
+
 	"github.com/google/uuid"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/pkg/errors"

--- a/pack/daggen/directory.go
+++ b/pack/daggen/directory.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"io"
+
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/pack"
 	blocks "github.com/ipfs/go-block-format"
@@ -18,7 +20,6 @@ import (
 	"github.com/ipld/go-car/util"
 	"github.com/klauspost/compress/zstd"
 	"github.com/pkg/errors"
-	"io"
 )
 
 var encoder, _ = zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))

--- a/pack/encryption/age.go
+++ b/pack/encryption/age.go
@@ -1,9 +1,10 @@
 package encryption
 
 import (
+	"io"
+
 	"filippo.io/age"
 	"github.com/pkg/errors"
-	"io"
 )
 
 // AgeEncryptor implements the Encryptor interface using age

--- a/pack/encryption/interface.go
+++ b/pack/encryption/interface.go
@@ -1,11 +1,12 @@
 package encryption
 
 import (
+	"io"
+	"os/exec"
+
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/google/shlex"
 	"github.com/pkg/errors"
-	"io"
-	"os/exec"
 )
 
 // Encryptor is an interface that defines the methods required to encrypt data in a resumable way.

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -2,12 +2,13 @@ package pack
 
 import (
 	"context"
-	"github.com/data-preservation-programs/singularity/pack/encryption"
-	util "github.com/ipfs/go-ipfs-util"
-	"github.com/rclone/rclone/fs"
 	"io"
 	"os"
 	"path"
+
+	"github.com/data-preservation-programs/singularity/pack/encryption"
+	util "github.com/ipfs/go-ipfs-util"
+	"github.com/rclone/rclone/fs"
 
 	"github.com/data-preservation-programs/singularity/datasource"
 	"github.com/data-preservation-programs/singularity/model"

--- a/pack/util.go
+++ b/pack/util.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"time"
+
 	"github.com/data-preservation-programs/singularity/datasource"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/pack/encryption"
@@ -21,8 +24,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/hash"
-	"io"
-	"time"
 )
 
 const ChunkSize int64 = 1 << 20

--- a/replication/internal/proposal110/cbor.go
+++ b/replication/internal/proposal110/cbor.go
@@ -2,11 +2,12 @@ package proposal110
 
 import (
 	"fmt"
+	"io"
+	"unicode/utf8"
+
 	"github.com/filecoin-project/go-state-types/abi"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
-	"io"
-	"unicode/utf8"
 )
 
 var lengthBufClientDealProposal = []byte{130}

--- a/replication/internal/proposal110/types.go
+++ b/replication/internal/proposal110/types.go
@@ -1,11 +1,12 @@
 package proposal110
 
 import (
+	"unicode/utf8"
+
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
-	"unicode/utf8"
 
 	addr "github.com/filecoin-project/go-address"
 )

--- a/service/contentprovider/contentprovider.go
+++ b/service/contentprovider/contentprovider.go
@@ -5,6 +5,11 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
 	"github.com/data-preservation-programs/singularity/util"
 	"github.com/fxamacker/cbor/v2"
 	nilrouting "github.com/ipfs/go-ipfs-routing/none"
@@ -15,10 +20,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
-	"io"
-	"net/http"
-	"os"
-	"time"
 
 	"github.com/data-preservation-programs/singularity/datasource"
 	"github.com/data-preservation-programs/singularity/model"

--- a/service/datasetworker/daggen.go
+++ b/service/datasetworker/daggen.go
@@ -1,6 +1,10 @@
 package datasetworker
 
 import (
+	"os"
+	"path"
+	"time"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/pack"
@@ -10,9 +14,6 @@ import (
 	"github.com/multiformats/go-varint"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
-	"os"
-	"path"
-	"time"
 )
 
 func (w *DatasetWorkerThread) dag(source model.Source) error {

--- a/service/datasetworker/datasetworker.go
+++ b/service/datasetworker/datasetworker.go
@@ -2,14 +2,15 @@ package datasetworker
 
 import (
 	"context"
-	"github.com/data-preservation-programs/singularity/database"
-	"github.com/data-preservation-programs/singularity/service/healthcheck"
-	"github.com/rjNemo/underscore"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/data-preservation-programs/singularity/database"
+	"github.com/data-preservation-programs/singularity/service/healthcheck"
+	"github.com/rjNemo/underscore"
 
 	"github.com/data-preservation-programs/singularity/datasource"
 	"github.com/data-preservation-programs/singularity/model"

--- a/service/datasetworker/find.go
+++ b/service/datasetworker/find.go
@@ -1,10 +1,11 @@
 package datasetworker
 
 import (
+	"time"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/model"
 	"gorm.io/gorm"
-	"time"
 )
 
 func (w *DatasetWorkerThread) findDagWork() (*model.Source, error) {

--- a/service/datasetworker/pack.go
+++ b/service/datasetworker/pack.go
@@ -2,6 +2,8 @@ package datasetworker
 
 import (
 	"context"
+	"strings"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/pack"
@@ -12,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rjNemo/underscore"
 	"gorm.io/gorm"
-	"strings"
 )
 
 func (w *DatasetWorkerThread) pack(

--- a/service/datasetworker/scan.go
+++ b/service/datasetworker/scan.go
@@ -2,6 +2,9 @@ package datasetworker
 
 import (
 	"context"
+	"strings"
+	"time"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/util"
@@ -10,8 +13,6 @@ import (
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rjNemo/underscore"
 	"gorm.io/gorm"
-	"strings"
-	"time"
 )
 
 func MaxSizeToSplitSize(m int64) int64 {

--- a/service/dealtracker/dealtracker.go
+++ b/service/dealtracker/dealtracker.go
@@ -3,6 +3,12 @@ package dealtracker
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/bcicen/jstream"
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/model"
@@ -11,11 +17,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
-	"io"
-	"net/http"
-	"strconv"
-	"strings"
-	"time"
 )
 
 type Deal struct {

--- a/service/healthcheck/healthcheck.go
+++ b/service/healthcheck/healthcheck.go
@@ -2,14 +2,15 @@ package healthcheck
 
 import (
 	"context"
+	"os"
+	"time"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/google/uuid"
 	"github.com/ipfs/go-log/v2"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
-	"os"
-	"time"
 )
 
 var staleThreshold = time.Minute * 5

--- a/service/spadeapi.go
+++ b/service/spadeapi.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"time"
+
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/replication"
 	"github.com/ipfs/go-log/v2"
@@ -9,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rjNemo/underscore"
 	"gorm.io/gorm"
-	"time"
 )
 
 type SpadeAPI struct {

--- a/singularity.go
+++ b/singularity.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"context"
-	"github.com/data-preservation-programs/singularity/cmd"
-	log2 "github.com/ipfs/go-log/v2"
 	"log"
 	"os"
+
+	"github.com/data-preservation-programs/singularity/cmd"
+	log2 "github.com/ipfs/go-log/v2"
 
 	_ "github.com/joho/godotenv/autoload"
 )

--- a/store/item_reference.go
+++ b/store/item_reference.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"context"
+	"io"
+
 	"github.com/data-preservation-programs/singularity/datasource"
 	"github.com/data-preservation-programs/singularity/model"
 	blocks "github.com/ipfs/go-block-format"
@@ -9,7 +11,6 @@ import (
 	format "github.com/ipfs/go-ipld-format"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
-	"io"
 )
 
 type ItemReferenceBlockStore struct {

--- a/store/piece_store.go
+++ b/store/piece_store.go
@@ -2,12 +2,13 @@ package store
 
 import (
 	"context"
+	"io"
+	"sort"
+
 	"github.com/data-preservation-programs/singularity/pack"
 	"github.com/ipfs/go-log/v2"
 	"github.com/multiformats/go-varint"
 	"github.com/rclone/rclone/fs"
-	"io"
-	"sort"
 
 	"github.com/data-preservation-programs/singularity/datasource"
 	"github.com/data-preservation-programs/singularity/model"


### PR DESCRIPTION
Consistently optimise imports across all files and consistently format files.

In go code, group SDK package imports together for better readability of non-sdk imports.