### PR TITLE
Move push item to handler

### DIFF
--- a/handler/item/pushitem.go
+++ b/handler/item/pushitem.go
@@ -1,0 +1,86 @@
+package item
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/data-preservation-programs/singularity/datasource"
+	"github.com/data-preservation-programs/singularity/handler"
+	"github.com/data-preservation-programs/singularity/model"
+	"github.com/data-preservation-programs/singularity/service/datasetworker"
+	fs2 "github.com/rclone/rclone/fs"
+	"gorm.io/gorm"
+)
+
+type ItemInfo struct {
+	Path string `json:"path"` // Path to the new item, relative to the source
+}
+
+func PushItemHandler(
+	db *gorm.DB,
+	ctx context.Context,
+	datasourceHandlerResolver datasource.HandlerResolver,
+	sourceID uint32,
+	itemInfo ItemInfo,
+) (*model.Item, error) {
+	return pushItemHandler(db, ctx, datasourceHandlerResolver, sourceID, itemInfo)
+}
+
+// @Summary Push an item to be queued
+// @Description Tells Singularity that something is ready to be grabbed for data preparation
+// @Tags Data Source
+// @Accept json
+// @Produce json
+// @Param item body ItemInfo true "Item"
+// @Success 201 {object} model.Item
+// @Failure 400 {string} string "Bad Request"
+// @Failure 409 {string} string "Item already exists"
+// @Failure 500 {string} string "Internal Server Error"
+// @Router /source/{id}/push [post]
+func pushItemHandler(
+	db *gorm.DB,
+	ctx context.Context,
+	datasourceHandlerResolver datasource.HandlerResolver,
+	sourceID uint32,
+	itemInfo ItemInfo,
+) (*model.Item, error) {
+	var source model.Source
+	err := db.Preload("Dataset").Where("id = ?", sourceID).First(&source).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, handler.NewBadRequestError(fmt.Errorf("source %d not found.", sourceID))
+	}
+	if err != nil {
+		return nil, handler.NewHandlerError(err)
+	}
+
+	dsHandler, err := datasourceHandlerResolver.Resolve(ctx, source)
+	if err != nil {
+		return nil, handler.NewHandlerError(err)
+	}
+
+	entry, err := dsHandler.Check(ctx, itemInfo.Path)
+	if err != nil {
+		return nil, handler.NewBadRequestError(err)
+	}
+
+	obj, ok := entry.(fs2.ObjectInfo)
+	if !ok {
+		return nil, handler.NewBadRequestError(fmt.Errorf("%s is not an object", itemInfo.Path))
+	}
+
+	item, itemParts, err := datasetworker.PushItem(ctx, db, obj, source, *source.Dataset, map[string]uint64{})
+
+	if err != nil {
+		return nil, handler.NewHandlerError(err)
+	}
+
+	if item == nil {
+		return nil, handler.NewHTTPError(http.StatusConflict, fmt.Sprintf("%s already exists", obj.Remote()))
+	}
+
+	item.ItemParts = itemParts
+
+	return item, nil
+}


### PR DESCRIPTION
# Goals

A step along the way towards #83 , get the push item code into a handler

# Implementation

- Extract the pushItem method from api into a handler function
- Add a few new features to toEchoHandler in order to make everything work
  - add the ability to pass the datasource.HandlerResolver as a param
  - add the ability to pass integer parameters from the request path by checking for UInt and Int types, calling appropriate parse functions, and passing the integers to to the handler

# For Discussion

This does make a few changes to the behavior of the pushItemHandler API:
- the 201 success response code is now a 200
- the content of the errors is slightly different now due to errors in toEchoHandler being different

Also:
- these changes simply reflect the complexity of using toEchoHandler
- I wonder if toEchoHandler is just too much magic. Would it not make more sense for handlers to return regular errors and then have the API convert them into HTTP responses? Traditionally I would expect a model layer that performed the logic, and a controller layer that translated the results of model responses into HTTP responses.