### PR TITLE
Add CreateSourceHandler

### DIFF
--- a/handler/datasource/add.go
+++ b/handler/datasource/add.go
@@ -1,0 +1,146 @@
+package datasource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/data-preservation-programs/singularity/database"
+	"github.com/data-preservation-programs/singularity/datasource"
+	"github.com/data-preservation-programs/singularity/handler"
+	"github.com/data-preservation-programs/singularity/model"
+	fs2 "github.com/rclone/rclone/fs"
+	"github.com/rjNemo/underscore"
+	"gorm.io/gorm"
+)
+
+func CreateDatasourceHandler(
+	db *gorm.DB,
+	ctx context.Context,
+	datasourceHandlerResolver datasource.HandlerResolver,
+	sourceType string,
+	datasetName string,
+	sourceParameters map[string]interface{},
+) (*model.Source, error) {
+	return createDatasourceHandler(db, ctx, sourceType, datasetName, sourceParameters)
+}
+
+// @Summary Add acd source for a dataset
+// @Tags Data Source
+// @Accept json
+// @Produce json
+// @Param datasetName path string true "Dataset name"
+// @Success 200 {object} model.Source
+// @Failure 400 {object} handler.HTTPError
+// @Failure 500 {object} handler.HTTPError
+// @Param request body AcdRequest true "Request body"
+// @Router /source/acd/dataset/{datasetName} [post]
+func createDatasourceHandler(
+	db *gorm.DB,
+	ctx context.Context,
+	sourceType string,
+	datasetName string,
+	sourceParameters map[string]interface{},
+) (*model.Source, error) {
+	dataset, err := database.FindDatasetByName(db, datasetName)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, handler.NewNotFoundString("Dataset not found.")
+	}
+	if err != nil {
+		return nil, handler.NewHandlerError(fmt.Errorf("failed to find dataset: %w", err))
+	}
+
+	r, err := fs2.Find(sourceType)
+	if err != nil {
+		return nil, handler.NewNotFoundError(err)
+	}
+	sourcePath := sourceParameters["sourcePath"]
+	path, ok := sourcePath.(string)
+	if !ok {
+		return nil, handler.NewBadRequestString("sourcePath needs to be a string")
+	}
+	if path == "" {
+		return nil, handler.NewBadRequestString("sourcePath is required")
+	}
+	if r.Prefix == "local" {
+		path, err = filepath.Abs(path)
+		if err != nil {
+			return nil, handler.NewBadRequestError(fmt.Errorf("failed to get absolute path: %w", err))
+		}
+	}
+	deleteAfterExportValue := sourceParameters["deleteAfterExport"]
+	deleteAfterExport, ok := deleteAfterExportValue.(bool)
+	if !ok {
+		return nil, handler.NewBadRequestString("deleteAfterExport needs to be a boolean")
+	}
+	rescanIntervalValue := sourceParameters["rescanInterval"]
+	rescanInterval, ok := rescanIntervalValue.(string)
+	if !ok {
+		return nil, handler.NewBadRequestString("rescanInterval needs to be a string")
+	}
+	rescan, err := time.ParseDuration(rescanInterval)
+	if err != nil {
+		return nil, handler.NewBadRequestError(fmt.Errorf("failed to parse rescanInterval: %w", err))
+	}
+	delete(sourceParameters, "sourcePath")
+	delete(sourceParameters, "deleteAfterExport")
+	delete(sourceParameters, "rescanInterval")
+	delete(sourceParameters, "type")
+	delete(sourceParameters, "datasetName")
+	config := map[string]string{}
+	for k, v := range sourceParameters {
+		str, ok := v.(string)
+		if !ok {
+			return nil, handler.NewBadRequestString(fmt.Sprintf("%s needs to be a string", k))
+		}
+		optionName := lowerCamelToSnake(k)
+		if !underscore.Any(r.Options, func(o fs2.Option) bool {
+			return o.Name == optionName
+		}) {
+			return nil, handler.NewBadRequestString(fmt.Sprintf("%s is not a valid parameter for storage source type %s", k, r.Prefix))
+		}
+		config[optionName] = str
+	}
+
+	source := model.Source{
+		DatasetID:           dataset.ID,
+		Type:                r.Prefix,
+		Path:                path,
+		Metadata:            model.Metadata(config),
+		ScanIntervalSeconds: uint64(rescan.Seconds()),
+		ScanningState:       model.Ready,
+		DeleteAfterExport:   deleteAfterExport,
+		DagGenState:         model.Created,
+	}
+
+	dsHandler, err := datasource.DefaultHandlerResolver{}.Resolve(ctx, source)
+	if err != nil {
+		return nil, handler.NewHandlerError(fmt.Errorf("failed to resolve handler: %w", err))
+	}
+
+	_, err = dsHandler.List(ctx, "")
+	if err != nil {
+		return nil, handler.NewHandlerError(fmt.Errorf("failed to check source: %w", err))
+	}
+
+	err = db.Create(&source).Error
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return nil, handler.NewConflictString(fmt.Sprintf("source at %s of type %s for dataset %s already exists", sourcePath, sourceType, datasetName))
+	}
+	if err != nil {
+		return nil, handler.NewHandlerError(fmt.Errorf("failed to create source: %w", err))
+	}
+
+	dir := model.Directory{
+		Name:     path,
+		SourceID: source.ID,
+	}
+	err = db.Create(&dir).Error
+	if err != nil {
+		return nil, handler.NewHandlerError(fmt.Errorf("failed to create directory: %w", err))
+	}
+
+	return &source, nil
+}

--- a/handler/datasource/pushitem.go
+++ b/handler/datasource/pushitem.go
@@ -1,10 +1,9 @@
-package item
+package datasource
 
 import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 
 	"github.com/data-preservation-programs/singularity/datasource"
 	"github.com/data-preservation-programs/singularity/handler"
@@ -49,7 +48,7 @@ func pushItemHandler(
 	var source model.Source
 	err := db.Preload("Dataset").Where("id = ?", sourceID).First(&source).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, handler.NewBadRequestError(fmt.Errorf("source %d not found.", sourceID))
+		return nil, handler.NewBadRequestString(fmt.Sprintf("source %d not found", sourceID))
 	}
 	if err != nil {
 		return nil, handler.NewHandlerError(err)
@@ -67,7 +66,7 @@ func pushItemHandler(
 
 	obj, ok := entry.(fs2.ObjectInfo)
 	if !ok {
-		return nil, handler.NewBadRequestError(fmt.Errorf("%s is not an object", itemInfo.Path))
+		return nil, handler.NewBadRequestString(fmt.Sprintf("%s is not an object", itemInfo.Path))
 	}
 
 	item, itemParts, err := datasetworker.PushItem(ctx, db, obj, source, *source.Dataset, map[string]uint64{})
@@ -77,7 +76,7 @@ func pushItemHandler(
 	}
 
 	if item == nil {
-		return nil, handler.NewHTTPError(http.StatusConflict, fmt.Sprintf("%s already exists", obj.Remote()))
+		return nil, handler.NewConflictString(fmt.Sprintf("%s already exists", obj.Remote()))
 	}
 
 	item.ItemParts = itemParts

--- a/handler/errors.go
+++ b/handler/errors.go
@@ -46,6 +46,34 @@ func NewBadRequestString(err string) *Error {
 	}
 }
 
+func NewNotFoundError(err error) *Error {
+	return &Error{
+		Err:            err,
+		HTTPStatusCode: http.StatusNotFound,
+	}
+}
+
+func NewNotFoundString(err string) *Error {
+	return &Error{
+		Err:            errors.New(err),
+		HTTPStatusCode: http.StatusNotFound,
+	}
+}
+
+func NewConflictError(err error) *Error {
+	return &Error{
+		Err:            err,
+		HTTPStatusCode: http.StatusConflict,
+	}
+}
+
+func NewConflictString(err string) *Error {
+	return &Error{
+		Err:            errors.New(err),
+		HTTPStatusCode: http.StatusConflict,
+	}
+}
+
 func NewHTTPError(code int, err string) *Error {
 	return &Error{
 		Err:            errors.New(err),


### PR DESCRIPTION
# Goals

Move more code into handlers, so we can setup a library interface -- this removes the last major piece of logic code in the API

# Implementation

- HandlePostSource to CreateSourceHandler
- A few cleanups around handler errors
- Move PushItem under datasource directory (this is where one would expect it to be given the API syntax)
- Fix tests to work with the handler
- Adds a check on the parameter names to make sure they match the datasource type (reject inappropriately named params)
- 

# For discussion

This also fixes the build errors I introduced when I merged #85 