### PR TITLE
Add a client API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/handler/admin"
 	"github.com/data-preservation-programs/singularity/handler/dataset"
 	"github.com/data-preservation-programs/singularity/handler/datasource/inspect"
@@ -25,7 +26,6 @@ import (
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/datasource"
 	_ "github.com/data-preservation-programs/singularity/docs/swagger"
-	"github.com/data-preservation-programs/singularity/handler"
 	datasource2 "github.com/data-preservation-programs/singularity/handler/datasource"
 	"github.com/data-preservation-programs/singularity/model"
 	logging "github.com/ipfs/go-log/v2"
@@ -59,32 +59,13 @@ func (s Server) getMetadataHandler(c echo.Context) error {
 	return contentprovider.GetMetadataHandler(c, s.db)
 }
 
-func (s Server) SendManualHandler(c echo.Context) error {
-	db := s.db.WithContext(c.Request().Context())
-	ctx := c.Request().Context()
-	var request deal.Proposal
-	err := c.Bind(&request)
-	if err != nil {
-		return c.String(http.StatusBadRequest, fmt.Sprintf("Error: %s", err.Error()))
-	}
-	dealModel, err := deal.SendManualHandler(db, ctx, request, s.dealMaker)
-	if err != nil {
-		var err2 *handler.Error
-		if errors.As(err, &err2) {
-			return err2.HTTPResponse(c)
-		}
-		return c.String(http.StatusInternalServerError, fmt.Sprintf("Error: %s", err.Error()))
-	}
-	return c.JSON(http.StatusOK, dealModel)
-}
-
 func Run(c *cli.Context) error {
 	db, err := database.OpenFromCLI(c)
 	if err != nil {
 		return err
 	}
 	if err := model.AutoMigrate(db); err != nil {
-		return handler.NewHandlerError(err)
+		return err
 	}
 	bind := c.String("bind")
 
@@ -137,23 +118,27 @@ func (s Server) toEchoHandler(handlerFunc any) echo.HandlerFunc {
 				inputParams = append(inputParams, reflect.ValueOf(s.lotusClient))
 				continue
 			}
+			if paramType.String() == "replication.DealMaker" {
+				inputParams = append(inputParams, reflect.ValueOf(s.dealMaker))
+				continue
+			}
 			if paramType.Kind() == reflect.String || isIntKind(paramType.Kind()) || isUIntKind(paramType.Kind()) {
 				if j >= len(c.ParamValues()) {
 					logger.Error("Invalid handler function signature.")
-					return echo.NewHTTPError(http.StatusInternalServerError, "Invalid handler function signature.")
+					return c.JSON(http.StatusInternalServerError, HTTPError{Err: "invalid handler function signature"})
 				}
 				paramValue := c.ParamValues()[j]
 				switch {
 				case paramType.Kind() == reflect.String:
 					decoded, err := url.QueryUnescape(paramValue)
 					if err != nil {
-						return echo.NewHTTPError(http.StatusInternalServerError, "Failed to decode path parameter.")
+						return c.JSON(http.StatusInternalServerError, HTTPError{Err: "failed to decode path parameter"})
 					}
 					inputParams = append(inputParams, reflect.ValueOf(decoded))
 				case isIntKind(paramType.Kind()):
 					decoded, err := strconv.ParseInt(paramValue, 10, paramType.Bits())
 					if err != nil {
-						return echo.NewHTTPError(http.StatusBadRequest, "Failed to parse path parameter as number.")
+						return c.JSON(http.StatusBadRequest, HTTPError{Err: "failed to parse path parameter as number"})
 					}
 					val := reflect.New(paramType).Elem()
 					val.SetInt(decoded)
@@ -161,7 +146,7 @@ func (s Server) toEchoHandler(handlerFunc any) echo.HandlerFunc {
 				case isUIntKind(paramType.Kind()):
 					decoded, err := strconv.ParseUint(paramValue, 10, paramType.Bits())
 					if err != nil {
-						return echo.NewHTTPError(http.StatusBadRequest, "Failed to parse path parameter as number.")
+						return c.JSON(http.StatusBadRequest, HTTPError{Err: "failed to parse path parameter as number"})
 					}
 					val := reflect.New(paramType).Elem()
 					val.SetUint(decoded)
@@ -176,7 +161,7 @@ func (s Server) toEchoHandler(handlerFunc any) echo.HandlerFunc {
 				bodyParam.Set(reflect.MakeMap(bodyParam.Type()))
 			}
 			if err := c.Bind(bodyParam.Addr().Interface()); err != nil {
-				return echo.NewHTTPError(http.StatusBadRequest, "Failed to bind request body.")
+				return c.JSON(http.StatusBadRequest, HTTPError{Err: "failed to bind request body"})
 			}
 			inputParams = append(inputParams, bodyParam)
 			break
@@ -187,31 +172,23 @@ func (s Server) toEchoHandler(handlerFunc any) echo.HandlerFunc {
 
 		if len(results) == 1 {
 			// Handle the returned error
-			err, ok := results[0].Interface().(*handler.Error)
-			if results[0].Interface() != nil && !ok {
+			if results[0].Interface() != nil {
 				err, ok := results[1].Interface().(error)
 				if !ok {
-					return echo.NewHTTPError(http.StatusInternalServerError, "Invalid handler function signature.")
+					return c.JSON(http.StatusInternalServerError, HTTPError{Err: "invalid handler function signature"})
 				}
-				return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-			}
-			if err != nil {
-				return err.HTTPResponse(c)
+				return httpResponseFromError(c, err)
 			}
 			return c.NoContent(http.StatusNoContent)
 		}
 
 		// Handle the returned error
-		err, ok := results[1].Interface().(*handler.Error)
-		if results[1].Interface() != nil && !ok {
+		if results[1].Interface() != nil {
 			err, ok := results[1].Interface().(error)
 			if !ok {
-				return echo.NewHTTPError(http.StatusInternalServerError, "Invalid handler function signature.")
+				return c.JSON(http.StatusInternalServerError, HTTPError{Err: "invalid handler function signature"})
 			}
-			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-		}
-		if err != nil {
-			return err.HTTPResponse(c)
+			return httpResponseFromError(c, err)
 		}
 
 		// Handle the returned data
@@ -267,7 +244,7 @@ func (s Server) setupRoutes(e *echo.Echo) {
 	e.GET("/api/item/:id", s.toEchoHandler(inspect.GetSourceItemDetailHandler))
 
 	// Deal Schedule
-	e.POST("/api/send_deal", s.SendManualHandler)
+	e.POST("/api/send_deal", s.toEchoHandler(deal.SendManualHandler))
 	e.POST("/api/schedule", s.toEchoHandler(schedule.CreateHandler))
 	e.GET("/api/schedule", s.toEchoHandler(schedule.ListHandler))
 	e.POST("/api/schedule/:id/pause", s.toEchoHandler(schedule.PauseHandler))
@@ -343,6 +320,38 @@ func isIntKind(kind reflect.Kind) bool {
 
 func isUIntKind(kind reflect.Kind) bool {
 	return kind == reflect.Uint || kind == reflect.Uint8 || kind == reflect.Uint16 || kind == reflect.Uint32 || kind == reflect.Uint64
+}
+
+type HTTPError struct {
+	Err string `json:"err"`
+}
+
+func httpResponseFromError(c echo.Context, e error) error {
+	if e == nil {
+		return c.String(http.StatusOK, "OK")
+	}
+
+	httpStatusCode := http.StatusInternalServerError
+
+	var invalidParameterErr handler.ErrInvalidParameter
+	if errors.As(e, &invalidParameterErr) {
+		httpStatusCode = http.StatusBadRequest
+		e = invalidParameterErr.Unwrap()
+	}
+
+	var notFoundErr handler.ErrNotFound
+	if errors.As(e, &notFoundErr) {
+		httpStatusCode = http.StatusBadRequest
+		e = notFoundErr.Unwrap()
+	}
+
+	var duplicateRecordErr handler.ErrDuplicateRecord
+	if errors.As(e, &duplicateRecordErr) {
+		httpStatusCode = http.StatusConflict
+		e = duplicateRecordErr.Unwrap()
+	}
+
+	return c.JSON(httpStatusCode, HTTPError{Err: e.Error()})
 }
 
 /* deprecated API

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -71,11 +71,9 @@ func TestPushItem_InvalidID(t *testing.T) {
 		datasourceHandlerResolver: &datasource.DefaultHandlerResolver{},
 	}
 	err = server.toEchoHandler(dshandler.PushItemHandler)(c)
-	require.Error(t, err)
-	var httpError *echo.HTTPError
-	require.ErrorAs(t, err, &httpError)
-	require.Equal(t, http.StatusBadRequest, httpError.Code)
-	require.Contains(t, "Failed to parse path parameter as number.", httpError.Message)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "failed to parse path parameter as number")
 }
 
 func TestPushItem_InvalidPayload(t *testing.T) {
@@ -94,11 +92,9 @@ func TestPushItem_InvalidPayload(t *testing.T) {
 		datasourceHandlerResolver: &datasource.DefaultHandlerResolver{},
 	}
 	err = server.toEchoHandler(dshandler.PushItemHandler)(c)
-	require.Error(t, err)
-	var httpError *echo.HTTPError
-	require.ErrorAs(t, err, &httpError)
-	require.Equal(t, http.StatusBadRequest, httpError.Code)
-	require.Contains(t, "Failed to bind request body.", httpError.Message)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "failed to bind request body")
 }
 
 func TestPushItem_SourceNotFound(t *testing.T) {

--- a/client/client.go
+++ b/client/client.go
@@ -9,9 +9,9 @@ import (
 	"github.com/data-preservation-programs/singularity/model"
 )
 
-type ErrDuplicateRecord = handler.ErrDuplicateRecord
-type ErrInvalidParameter = handler.ErrInvalidParameter
-type ErrNotFound = handler.ErrNotFound
+type DuplicateRecordError = handler.DuplicateRecordError
+type InvalidParameterError = handler.InvalidParameterError
+type NotFoundError = handler.NotFoundError
 
 type Client interface {
 	CreateDataset(ctx context.Context, request dataset.CreateRequest) (*model.Dataset, error)

--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"context"
+
+	"github.com/data-preservation-programs/singularity/handler"
+	"github.com/data-preservation-programs/singularity/handler/dataset"
+	"github.com/data-preservation-programs/singularity/handler/datasource"
+	"github.com/data-preservation-programs/singularity/model"
+)
+
+type ErrDuplicateRecord = handler.ErrDuplicateRecord
+type ErrInvalidParameter = handler.ErrInvalidParameter
+type ErrNotFound = handler.ErrNotFound
+
+type Client interface {
+	CreateDataset(ctx context.Context, request dataset.CreateRequest) (*model.Dataset, error)
+	CreateLocalSource(ctx context.Context, datasetName string, params datasource.LocalRequest) (*model.Source, error)
+	GetItem(ctx context.Context, id uint64) (*model.Item, error)
+	PushItem(ctx context.Context, sourceID uint32, itemInfo datasource.ItemInfo) (*model.Item, error)
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,121 @@
+package client_test
+
+import (
+	"context"
+	"crypto/rand"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/data-preservation-programs/singularity/api"
+	"github.com/data-preservation-programs/singularity/client"
+	httpclient "github.com/data-preservation-programs/singularity/client/http"
+	libclient "github.com/data-preservation-programs/singularity/client/lib"
+	"github.com/data-preservation-programs/singularity/database"
+
+	"github.com/data-preservation-programs/singularity/handler"
+	"github.com/data-preservation-programs/singularity/handler/dataset"
+	"github.com/data-preservation-programs/singularity/handler/datasource"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPClient(t *testing.T) {
+	ctx := context.Background()
+	testWithAllClients(ctx, t, func(t *testing.T, client client.Client) {
+		// createDataset
+		ds, err := client.CreateDataset(ctx, dataset.CreateRequest{
+			Name:       "test",
+			MaxSizeStr: "31.5GiB",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "test", ds.Name)
+
+		// cannot create dataset with same name
+
+		dupDataset, err := client.CreateDataset(ctx, dataset.CreateRequest{
+			Name:       "test",
+			MaxSizeStr: "31.5GiB",
+		})
+		var asConflict handler.DuplicateRecordError
+		require.ErrorAs(t, err, &asConflict)
+		require.Nil(t, dupDataset)
+
+		// cannot create dataset with invalid parameter
+		invalidDataset, err := client.CreateDataset(ctx, dataset.CreateRequest{})
+		var asInvalidParameter handler.InvalidParameterError
+		require.ErrorAs(t, err, &asInvalidParameter)
+		require.Nil(t, invalidDataset)
+
+		path := t.TempDir()
+		// create datasource
+		source, err := client.CreateLocalSource(ctx, "test", datasource.LocalRequest{
+			SourcePath:     path,
+			RescanInterval: "0h",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "local", source.Type)
+		require.Equal(t, ds.ID, source.DatasetID)
+		require.Equal(t, path, source.Path)
+
+		// create datasource when dataset not found
+		notFoundSource, err := client.CreateLocalSource(ctx, "apples", datasource.LocalRequest{
+			SourcePath:     path,
+			RescanInterval: "0h",
+		})
+		var asNotFoundError handler.NotFoundError
+		require.ErrorAs(t, err, &asNotFoundError)
+		require.Nil(t, notFoundSource)
+
+		// push item
+		file, err := os.CreateTemp(path, "push-*")
+		require.NoError(t, err)
+		buf := make([]byte, 1000)
+		_, _ = rand.Read(buf)
+		file.Write(buf)
+		name := file.Name()
+		err = file.Close()
+		require.NoError(t, err)
+		item, err := client.PushItem(ctx, source.ID, datasource.ItemInfo{Path: filepath.Base(name)})
+		require.NoError(t, err)
+		require.Equal(t, filepath.Base(name), item.Path)
+
+		// get item
+		returnedItem, err := client.GetItem(ctx, item.ID)
+		require.NoError(t, err)
+		require.Equal(t, item.Path, returnedItem.Path)
+	})
+}
+
+func testWithAllClients(ctx context.Context, t *testing.T, test func(*testing.T, client.Client)) {
+	t.Run("http", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+		httpErr := make(chan error, 1)
+		defer func() {
+			cancel()
+			err := <-httpErr
+			require.ErrorIs(t, err, http.ErrServerClosed)
+		}()
+		server, err := api.InitServer(api.APIParams{
+			ConnString: "sqlite:" + t.TempDir() + "/singularity.db",
+			Bind:       "127.0.0.1:9090",
+			LotusAPI:   "https://api.node.glif.io/rpc/v1",
+		})
+		require.NoError(t, err)
+		go func() {
+			err := server.Run(ctx)
+			httpErr <- err
+		}()
+		time.Sleep(time.Second)
+		client := httpclient.NewHTTPClient(http.DefaultClient, "http://127.0.0.1:9090")
+		test(t, client)
+	})
+	t.Run("lib", func(t *testing.T) {
+		db, err := database.OpenWithDefaults("sqlite:" + t.TempDir() + "/singularity.db")
+		require.NoError(t, err)
+		client, err := libclient.NewClient(db)
+		require.NoError(t, err)
+		test(t, client)
+	})
+}

--- a/client/http/client.go
+++ b/client/http/client.go
@@ -1,0 +1,159 @@
+package httpclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/data-preservation-programs/singularity/handler"
+	"github.com/data-preservation-programs/singularity/handler/dataset"
+	"github.com/data-preservation-programs/singularity/handler/datasource"
+	"github.com/data-preservation-programs/singularity/model"
+)
+
+type Client struct {
+	client    *http.Client
+	serverURL string
+}
+
+func NewHTTPClient(client *http.Client, serverURL string) *Client {
+	return &Client{
+		client:    client,
+		serverURL: serverURL,
+	}
+}
+
+func (c *Client) CreateDataset(ctx context.Context, request dataset.CreateRequest) (*model.Dataset, error) {
+	jsonParams, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+	httpRequest, err := http.NewRequestWithContext(ctx, "POST", c.serverURL+"/api/dataset", bytes.NewReader(jsonParams))
+	if err != nil {
+		return nil, err
+	}
+	response, err := c.client.Do(httpRequest)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode < 200 && response.StatusCode >= 300 {
+		return nil, parseHTTPError(response)
+	}
+	var dataset model.Dataset
+	err = json.NewDecoder(response.Body).Decode(&dataset)
+	if err != nil {
+		return nil, err
+	}
+	return &dataset, nil
+}
+
+func (c *Client) CreateLocalSource(ctx context.Context, datasetName string, params datasource.LocalRequest) (*model.Source, error) {
+	jsonParams, err := json.Marshal(params)
+	if err != nil {
+		return nil, err
+	}
+	httpRequest, err := http.NewRequestWithContext(ctx, "POST", c.serverURL+"/api/source/local/dataset/"+datasetName, bytes.NewReader(jsonParams))
+	if err != nil {
+		return nil, err
+	}
+	response, err := c.client.Do(httpRequest)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode < 200 && response.StatusCode >= 300 {
+		return nil, parseHTTPError(response)
+	}
+	var source model.Source
+	err = json.NewDecoder(response.Body).Decode(&source)
+	if err != nil {
+		return nil, err
+	}
+	return &source, nil
+}
+
+func (c *Client) GetItem(ctx context.Context, id uint64) (*model.Item, error) {
+
+	httpRequest, err := http.NewRequestWithContext(ctx, "GET", c.serverURL+"/api/item/"+strconv.FormatUint(id, 10), nil)
+	if err != nil {
+		return nil, err
+	}
+	response, err := c.client.Do(httpRequest)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode < 200 && response.StatusCode >= 300 {
+		return nil, parseHTTPError(response)
+	}
+	var item model.Item
+	err = json.NewDecoder(response.Body).Decode(&item)
+	if err != nil {
+		return nil, err
+	}
+	return &item, nil
+}
+
+func (c *Client) PushItem(ctx context.Context, sourceID uint32, itemInfo datasource.ItemInfo) (*model.Item, error) {
+	jsonParams, err := json.Marshal(itemInfo)
+	if err != nil {
+		return nil, err
+	}
+	httpRequest, err := http.NewRequestWithContext(ctx, "POST", c.serverURL+"/api/source/"+strconv.FormatUint(uint64(sourceID), 10)+"/push", bytes.NewReader(jsonParams))
+	if err != nil {
+		return nil, err
+	}
+	response, err := c.client.Do(httpRequest)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode < 200 && response.StatusCode >= 300 {
+		return nil, parseHTTPError(response)
+	}
+	var item model.Item
+	err = json.NewDecoder(response.Body).Decode(&item)
+	if err != nil {
+		return nil, err
+	}
+	return &item, nil
+}
+
+type HTTPError struct {
+	Err string `json:"err"`
+}
+
+func parseHTTPError(response *http.Response) error {
+	bodyData, err := io.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+	var httpError HTTPError
+	jsonErr := json.Unmarshal(bodyData, &httpError)
+	if jsonErr == nil {
+		err = errors.New(httpError.Err)
+	} else {
+		err = errors.New(string(bodyData))
+	}
+
+	if response.StatusCode == http.StatusBadRequest {
+		return handler.ErrInvalidParameter{
+			Err: err,
+		}
+	}
+
+	if response.StatusCode == http.StatusBadRequest {
+		return handler.ErrNotFound{
+			Err: err,
+		}
+	}
+
+	if response.StatusCode == http.StatusConflict {
+		return handler.ErrDuplicateRecord{
+			Err: err,
+		}
+	}
+
+	return err
+}

--- a/client/lib/client.go
+++ b/client/lib/client.go
@@ -1,0 +1,58 @@
+package libclient
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+
+	"github.com/data-preservation-programs/singularity/client"
+	"github.com/data-preservation-programs/singularity/datasource"
+	"github.com/data-preservation-programs/singularity/handler/dataset"
+	dshandler "github.com/data-preservation-programs/singularity/handler/datasource"
+	"github.com/data-preservation-programs/singularity/handler/datasource/inspect"
+	"github.com/data-preservation-programs/singularity/model"
+	"gorm.io/gorm"
+)
+
+type Client struct {
+	db                        *gorm.DB
+	datasourceHandlerResolver datasource.HandlerResolver
+}
+
+func NewClient(db *gorm.DB) (*Client, error) {
+
+	if err := model.AutoMigrate(db); err != nil {
+		return nil, err
+	}
+	return &Client{
+		db:                        db,
+		datasourceHandlerResolver: &datasource.DefaultHandlerResolver{},
+	}, nil
+}
+
+func (c *Client) CreateDataset(ctx context.Context, request dataset.CreateRequest) (*model.Dataset, error) {
+	return dataset.CreateHandler(c.db.WithContext(ctx), request)
+}
+
+func (c *Client) CreateLocalSource(ctx context.Context, datasetName string, params dshandler.LocalRequest) (*model.Source, error) {
+	paramJson, err := json.Marshal(params)
+	if err != nil {
+		return nil, err
+	}
+	paramsMap := map[string]interface{}{}
+	err = json.Unmarshal(paramJson, &paramsMap)
+	if err != nil {
+		return nil, err
+	}
+	return dshandler.CreateDatasourceHandler(c.db.WithContext(ctx), ctx, c.datasourceHandlerResolver, "local", datasetName, paramsMap)
+}
+
+func (c *Client) GetItem(ctx context.Context, id uint64) (*model.Item, error) {
+	return inspect.GetSourceItemDetailHandler(c.db.WithContext(ctx), strconv.FormatUint(id, 10))
+}
+
+func (c *Client) PushItem(ctx context.Context, sourceID uint32, itemInfo dshandler.ItemInfo) (*model.Item, error) {
+	return dshandler.PushItemHandler(c.db.WithContext(ctx), ctx, c.datasourceHandlerResolver, sourceID, itemInfo)
+}
+
+var _ client.Client = (*Client)(nil)

--- a/client/lib/client.go
+++ b/client/lib/client.go
@@ -20,7 +20,6 @@ type Client struct {
 }
 
 func NewClient(db *gorm.DB) (*Client, error) {
-
 	if err := model.AutoMigrate(db); err != nil {
 		return nil, err
 	}
@@ -35,12 +34,12 @@ func (c *Client) CreateDataset(ctx context.Context, request dataset.CreateReques
 }
 
 func (c *Client) CreateLocalSource(ctx context.Context, datasetName string, params dshandler.LocalRequest) (*model.Source, error) {
-	paramJson, err := json.Marshal(params)
+	paramJSON, err := json.Marshal(params)
 	if err != nil {
 		return nil, err
 	}
 	paramsMap := map[string]interface{}{}
-	err = json.Unmarshal(paramJson, &paramsMap)
+	err = json.Unmarshal(paramJSON, &paramsMap)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/datasource/add.go
+++ b/cmd/datasource/add.go
@@ -47,7 +47,7 @@ var AddCmd = &cli.Command{
 			}
 			dataset, err := database.FindDatasetByName(db, datasetName)
 			if err != nil {
-				return handler.ErrInvalidParameter{Err: err}
+				return handler.InvalidParameterError{Err: err}
 			}
 			if path == "" {
 				return handler.NewInvalidParameterErr("path is required")

--- a/cmd/datasource/add.go
+++ b/cmd/datasource/add.go
@@ -47,10 +47,10 @@ var AddCmd = &cli.Command{
 			}
 			dataset, err := database.FindDatasetByName(db, datasetName)
 			if err != nil {
-				return handler.NewBadRequestError(err)
+				return handler.ErrInvalidParameter{Err: err}
 			}
 			if path == "" {
-				return handler.NewBadRequestString("path is required")
+				return handler.NewInvalidParameterErr("path is required")
 			}
 			if r.Prefix == "local" {
 				path, err = filepath.Abs(path)

--- a/cmd/deal/send-manual.go
+++ b/cmd/deal/send-manual.go
@@ -145,7 +145,7 @@ var SendManualCmd = &cli.Command{
 			10*timeout,
 			timeout,
 		)
-		dealModel, err2 := deal.SendManualHandler(db.WithContext(ctx), ctx, proposal, dealMaker)
+		dealModel, err2 := deal.SendManualHandler(db.WithContext(ctx), ctx, dealMaker, proposal)
 		if err2 != nil {
 			return err2
 		}

--- a/cmd/run/contentprovider.go
+++ b/cmd/run/contentprovider.go
@@ -2,7 +2,6 @@ package run
 
 import (
 	"github.com/data-preservation-programs/singularity/database"
-	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/service/contentprovider"
 	"github.com/urfave/cli/v2"
@@ -49,7 +48,7 @@ var ContentProviderCmd = &cli.Command{
 			return err
 		}
 		if err := model.AutoMigrate(db); err != nil {
-			return handler.NewHandlerError(err)
+			return err
 		}
 
 		config := contentprovider.ContentProviderConfig{

--- a/cmd/run/datasetworker.go
+++ b/cmd/run/datasetworker.go
@@ -2,7 +2,6 @@ package run
 
 import (
 	"github.com/data-preservation-programs/singularity/database"
-	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/service/datasetworker"
 	"github.com/urfave/cli/v2"
@@ -55,7 +54,7 @@ var DatasetWorkerCmd = &cli.Command{
 			return err
 		}
 		if err := model.AutoMigrate(db); err != nil {
-			return handler.NewHandlerError(err)
+			return err
 		}
 		worker := datasetworker.NewDatasetWorker(
 			db,

--- a/cmd/run/dealmaker.go
+++ b/cmd/run/dealmaker.go
@@ -2,7 +2,6 @@ package run
 
 import (
 	"github.com/data-preservation-programs/singularity/database"
-	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/service/dealmaker"
 	"github.com/data-preservation-programs/singularity/service/epochutil"
@@ -18,7 +17,7 @@ var DealMakerCmd = &cli.Command{
 			return err
 		}
 		if err := model.AutoMigrate(db); err != nil {
-			return handler.NewHandlerError(err)
+			return err
 		}
 
 		lotusAPI := c.String("lotus-api")

--- a/cmd/run/dealtracker.go
+++ b/cmd/run/dealtracker.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/data-preservation-programs/singularity/database"
-	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/service/dealtracker"
 	"github.com/data-preservation-programs/singularity/service/epochutil"
@@ -35,7 +34,7 @@ var DealTrackerCmd = &cli.Command{
 			return err
 		}
 		if err := model.AutoMigrate(db); err != nil {
-			return handler.NewHandlerError(err)
+			return err
 		}
 
 		lotusAPI := c.String("lotus-api")

--- a/cmd/run/spadeapi.go
+++ b/cmd/run/spadeapi.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/data-preservation-programs/singularity/database"
-	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/replication"
 	"github.com/data-preservation-programs/singularity/service"
@@ -28,7 +27,7 @@ var SpadeAPICmd = &cli.Command{
 			return err
 		}
 		if err := model.AutoMigrate(db); err != nil {
-			return handler.NewHandlerError(err)
+			return err
 		}
 
 		h, err := util.InitHost(nil)

--- a/datasource/rclone.go
+++ b/datasource/rclone.go
@@ -196,13 +196,17 @@ func OptionsToCLIFlags(regInfo *fs.RegInfo) *cli.Command {
 		}
 		envvar := strings.ToUpper(regInfo.Prefix + "_" + name)
 		flagName := strings.ToLower(strings.ReplaceAll(envvar, "_", "-"))
+		defaultValue := fmt.Sprint(options[0].Default)
+		if cmd.Name == "local" && name == "encoding" {
+			defaultValue = "Slash,Dot"
+		}
 		flag := &cli.StringFlag{
 			Name:     flagName,
 			Category: category,
 			Usage:    strings.Split(options[0].Help, "\n")[0],
 			Required: options[0].Required,
 			Hidden:   options[0].Hide&fs.OptionHideCommandLine != 0,
-			Value:    fmt.Sprint(options[0].Default),
+			Value:    defaultValue,
 			Aliases:  aliases,
 			EnvVars:  []string{envvar},
 		}

--- a/docs/en/cli-reference/datasource/add/local.md
+++ b/docs/en/cli-reference/datasource/add/local.md
@@ -145,7 +145,7 @@ OPTIONS:
    --local-case-insensitive value       Force the filesystem to report itself as case insensitive. (default: "false") [$LOCAL_CASE_INSENSITIVE]
    --local-case-sensitive value         Force the filesystem to report itself as case sensitive. (default: "false") [$LOCAL_CASE_SENSITIVE]
    --local-copy-links value             Follow symlinks and copy the pointed to item. (default: "false") [$LOCAL_COPY_LINKS]
-   --local-encoding value               The encoding for the backend. (default: "Slash,InvalidUtf8,Dot") [$LOCAL_ENCODING]
+   --local-encoding value               The encoding for the backend. (default: "Slash,Dot") [$LOCAL_ENCODING]
    --local-links value                  Translate symlinks to/from regular files with a '.rclonelink' extension. (default: "false") [$LOCAL_LINKS]
    --local-no-check-updated value       Don't check to see if the files change during upload. (default: "false") [$LOCAL_NO_CHECK_UPDATED]
    --local-no-preallocate value         Disable preallocation of disk space for transferred files. (default: "false") [$LOCAL_NO_PREALLOCATE]

--- a/docs/en/cli-reference/datasource/add/local.md
+++ b/docs/en/cli-reference/datasource/add/local.md
@@ -145,7 +145,7 @@ OPTIONS:
    --local-case-insensitive value       Force the filesystem to report itself as case insensitive. (default: "false") [$LOCAL_CASE_INSENSITIVE]
    --local-case-sensitive value         Force the filesystem to report itself as case sensitive. (default: "false") [$LOCAL_CASE_SENSITIVE]
    --local-copy-links value             Follow symlinks and copy the pointed to item. (default: "false") [$LOCAL_COPY_LINKS]
-   --local-encoding value               The encoding for the backend. (default: "Slash,Dot") [$LOCAL_ENCODING]
+   --local-encoding value               The encoding for the backend. (default: "Slash,InvalidUtf8,Dot") [$LOCAL_ENCODING]
    --local-links value                  Translate symlinks to/from regular files with a '.rclonelink' extension. (default: "false") [$LOCAL_LINKS]
    --local-no-check-updated value       Don't check to see if the files change during upload. (default: "false") [$LOCAL_NO_CHECK_UPDATED]
    --local-no-preallocate value         Disable preallocation of disk space for transferred files. (default: "false") [$LOCAL_NO_PREALLOCATE]

--- a/docs/en/cli-reference/datasource/update.md
+++ b/docs/en/cli-reference/datasource/update.md
@@ -301,7 +301,7 @@ OPTIONS:
    --local-case-insensitive value       Force the filesystem to report itself as case insensitive. (default: "false") [$LOCAL_CASE_INSENSITIVE]
    --local-case-sensitive value         Force the filesystem to report itself as case sensitive. (default: "false") [$LOCAL_CASE_SENSITIVE]
    --local-copy-links value             Follow symlinks and copy the pointed to item. (default: "false") [$LOCAL_COPY_LINKS]
-   --local-encoding value               The encoding for the backend. (default: "Slash,Dot") [$LOCAL_ENCODING]
+   --local-encoding value               The encoding for the backend. (default: "Slash,InvalidUtf8,Dot") [$LOCAL_ENCODING]
    --local-links value                  Translate symlinks to/from regular files with a '.rclonelink' extension. (default: "false") [$LOCAL_LINKS]
    --local-no-check-updated value       Don't check to see if the files change during upload. (default: "false") [$LOCAL_NO_CHECK_UPDATED]
    --local-no-preallocate value         Disable preallocation of disk space for transferred files. (default: "false") [$LOCAL_NO_PREALLOCATE]

--- a/docs/en/cli-reference/datasource/update.md
+++ b/docs/en/cli-reference/datasource/update.md
@@ -301,7 +301,7 @@ OPTIONS:
    --local-case-insensitive value       Force the filesystem to report itself as case insensitive. (default: "false") [$LOCAL_CASE_INSENSITIVE]
    --local-case-sensitive value         Force the filesystem to report itself as case sensitive. (default: "false") [$LOCAL_CASE_SENSITIVE]
    --local-copy-links value             Follow symlinks and copy the pointed to item. (default: "false") [$LOCAL_COPY_LINKS]
-   --local-encoding value               The encoding for the backend. (default: "Slash,InvalidUtf8,Dot") [$LOCAL_ENCODING]
+   --local-encoding value               The encoding for the backend. (default: "Slash,Dot") [$LOCAL_ENCODING]
    --local-links value                  Translate symlinks to/from regular files with a '.rclonelink' extension. (default: "false") [$LOCAL_LINKS]
    --local-no-check-updated value       Don't check to see if the files change during upload. (default: "false") [$LOCAL_NO_CHECK_UPDATED]
    --local-no-preallocate value         Disable preallocation of disk space for transferred files. (default: "false") [$LOCAL_NO_PREALLOCATE]

--- a/docs/en/cli-reference/download.md
+++ b/docs/en/cli-reference/download.md
@@ -303,7 +303,7 @@ OPTIONS:
    --local-case-insensitive value       Force the filesystem to report itself as case insensitive. (default: "false") [$LOCAL_CASE_INSENSITIVE]
    --local-case-sensitive value         Force the filesystem to report itself as case sensitive. (default: "false") [$LOCAL_CASE_SENSITIVE]
    --local-copy-links value             Follow symlinks and copy the pointed to item. (default: "false") [$LOCAL_COPY_LINKS]
-   --local-encoding value               The encoding for the backend. (default: "Slash,InvalidUtf8,Dot") [$LOCAL_ENCODING]
+   --local-encoding value               The encoding for the backend. (default: "Slash,Dot") [$LOCAL_ENCODING]
    --local-links value                  Translate symlinks to/from regular files with a '.rclonelink' extension. (default: "false") [$LOCAL_LINKS]
    --local-no-check-updated value       Don't check to see if the files change during upload. (default: "false") [$LOCAL_NO_CHECK_UPDATED]
    --local-no-preallocate value         Disable preallocation of disk space for transferred files. (default: "false") [$LOCAL_NO_PREALLOCATE]

--- a/docs/en/cli-reference/download.md
+++ b/docs/en/cli-reference/download.md
@@ -303,7 +303,7 @@ OPTIONS:
    --local-case-insensitive value       Force the filesystem to report itself as case insensitive. (default: "false") [$LOCAL_CASE_INSENSITIVE]
    --local-case-sensitive value         Force the filesystem to report itself as case sensitive. (default: "false") [$LOCAL_CASE_SENSITIVE]
    --local-copy-links value             Follow symlinks and copy the pointed to item. (default: "false") [$LOCAL_COPY_LINKS]
-   --local-encoding value               The encoding for the backend. (default: "Slash,Dot") [$LOCAL_ENCODING]
+   --local-encoding value               The encoding for the backend. (default: "Slash,InvalidUtf8,Dot") [$LOCAL_ENCODING]
    --local-links value                  Translate symlinks to/from regular files with a '.rclonelink' extension. (default: "false") [$LOCAL_LINKS]
    --local-no-check-updated value       Don't check to see if the files change during upload. (default: "false") [$LOCAL_NO_CHECK_UPDATED]
    --local-no-preallocate value         Disable preallocation of disk space for transferred files. (default: "false") [$LOCAL_NO_PREALLOCATE]

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -4851,7 +4851,7 @@ const docTemplate = `{
                 "localEncoding": {
                     "description": "The encoding for the backend.",
                     "type": "string",
-                    "default": "Slash,InvalidUtf8,Dot"
+                    "default": "Slash,Dot"
                 },
                 "localLinks": {
                     "description": "Translate symlinks to/from regular files with a '.rclonelink' extension.",
@@ -7514,7 +7514,7 @@ const docTemplate = `{
                 "encoding": {
                     "description": "The encoding for the backend.",
                     "type": "string",
-                    "default": "Slash,InvalidUtf8,Dot"
+                    "default": "Slash,Dot"
                 },
                 "links": {
                     "description": "Translate symlinks to/from regular files with a '.rclonelink' extension.",

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -36,7 +36,7 @@ const docTemplate = `{
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -56,7 +56,7 @@ const docTemplate = `{
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -93,7 +93,7 @@ const docTemplate = `{
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -121,13 +121,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -165,13 +165,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -200,13 +200,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -250,13 +250,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -296,13 +296,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -346,13 +346,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -389,13 +389,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -439,13 +439,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -478,13 +478,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -527,13 +527,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -570,7 +570,7 @@ const docTemplate = `{
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -657,13 +657,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -697,13 +697,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -737,13 +737,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -771,13 +771,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -817,13 +817,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -859,13 +859,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -911,13 +911,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -963,13 +963,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1015,13 +1015,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1067,13 +1067,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1119,13 +1119,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1171,13 +1171,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1223,13 +1223,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1275,13 +1275,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1327,13 +1327,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1379,13 +1379,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1431,13 +1431,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1483,13 +1483,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1535,13 +1535,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1587,13 +1587,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1639,13 +1639,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1691,13 +1691,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1743,13 +1743,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1795,13 +1795,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1847,13 +1847,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1899,13 +1899,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1951,13 +1951,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2003,13 +2003,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2055,13 +2055,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2107,13 +2107,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2159,13 +2159,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2211,13 +2211,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2263,13 +2263,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2315,13 +2315,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2367,13 +2367,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2419,13 +2419,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2471,13 +2471,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2523,13 +2523,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2575,13 +2575,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2627,13 +2627,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2679,13 +2679,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2731,13 +2731,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2783,13 +2783,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2835,13 +2835,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2887,13 +2887,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2939,13 +2939,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2991,13 +2991,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3025,13 +3025,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3075,13 +3075,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3130,13 +3130,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3176,7 +3176,7 @@ const docTemplate = `{
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3210,13 +3210,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3256,13 +3256,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3308,13 +3308,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3400,7 +3400,7 @@ const docTemplate = `{
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3437,13 +3437,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3471,13 +3471,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3514,13 +3514,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3559,13 +3559,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3593,13 +3593,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3607,6 +3607,14 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "api.HTTPError": {
+            "type": "object",
+            "properties": {
+                "err": {
+                    "type": "string"
+                }
+            }
+        },
         "dataset.AddPieceRequest": {
             "type": "object",
             "properties": {
@@ -3763,6 +3771,9 @@ const docTemplate = `{
         },
         "datasource.AllConfig": {
             "type": "object",
+            "required": [
+                "sourcePath"
+            ],
             "properties": {
                 "acdAuthUrl": {
                     "description": "Auth server URL.",
@@ -4840,7 +4851,7 @@ const docTemplate = `{
                 "localEncoding": {
                     "description": "The encoding for the backend.",
                     "type": "string",
-                    "default": "Slash,Dot"
+                    "default": "Slash,InvalidUtf8,Dot"
                 },
                 "localLinks": {
                     "description": "Translate symlinks to/from regular files with a '.rclonelink' extension.",
@@ -5796,6 +5807,10 @@ const docTemplate = `{
                     "description": "SMB username.",
                     "type": "string",
                     "default": "$USER"
+                },
+                "sourcePath": {
+                    "description": "The path of the source to scan items",
+                    "type": "string"
                 },
                 "storjAccessGrant": {
                     "description": "Access grant.",
@@ -7499,7 +7514,7 @@ const docTemplate = `{
                 "encoding": {
                     "description": "The encoding for the backend.",
                     "type": "string",
-                    "default": "Slash,Dot"
+                    "default": "Slash,InvalidUtf8,Dot"
                 },
                 "links": {
                     "description": "Translate symlinks to/from regular files with a '.rclonelink' extension.",
@@ -9364,14 +9379,6 @@ const docTemplate = `{
                 },
                 "size": {
                     "type": "integer"
-                }
-            }
-        },
-        "handler.HTTPError": {
-            "type": "object",
-            "properties": {
-                "err": {
-                    "type": "string"
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -4844,7 +4844,7 @@
                 "localEncoding": {
                     "description": "The encoding for the backend.",
                     "type": "string",
-                    "default": "Slash,InvalidUtf8,Dot"
+                    "default": "Slash,Dot"
                 },
                 "localLinks": {
                     "description": "Translate symlinks to/from regular files with a '.rclonelink' extension.",
@@ -7507,7 +7507,7 @@
                 "encoding": {
                     "description": "The encoding for the backend.",
                     "type": "string",
-                    "default": "Slash,InvalidUtf8,Dot"
+                    "default": "Slash,Dot"
                 },
                 "links": {
                     "description": "Translate symlinks to/from regular files with a '.rclonelink' extension.",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -29,7 +29,7 @@
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -49,7 +49,7 @@
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -86,7 +86,7 @@
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -114,13 +114,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -158,13 +158,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -193,13 +193,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -243,13 +243,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -289,13 +289,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -339,13 +339,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -382,13 +382,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -432,13 +432,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -471,13 +471,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -520,13 +520,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -563,7 +563,7 @@
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -650,13 +650,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -690,13 +690,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -730,13 +730,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -764,13 +764,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -810,13 +810,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -852,13 +852,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -904,13 +904,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -956,13 +956,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1008,13 +1008,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1060,13 +1060,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1112,13 +1112,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1164,13 +1164,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1216,13 +1216,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1268,13 +1268,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1320,13 +1320,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1372,13 +1372,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1424,13 +1424,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1476,13 +1476,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1528,13 +1528,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1580,13 +1580,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1632,13 +1632,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1684,13 +1684,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1736,13 +1736,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1788,13 +1788,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1840,13 +1840,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1892,13 +1892,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1944,13 +1944,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -1996,13 +1996,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2048,13 +2048,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2100,13 +2100,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2152,13 +2152,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2204,13 +2204,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2256,13 +2256,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2308,13 +2308,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2360,13 +2360,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2412,13 +2412,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2464,13 +2464,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2516,13 +2516,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2568,13 +2568,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2620,13 +2620,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2672,13 +2672,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2724,13 +2724,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2776,13 +2776,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2828,13 +2828,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2880,13 +2880,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2932,13 +2932,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -2984,13 +2984,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3018,13 +3018,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3068,13 +3068,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3123,13 +3123,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3169,7 +3169,7 @@
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3203,13 +3203,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3249,13 +3249,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3301,13 +3301,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3393,7 +3393,7 @@
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3430,13 +3430,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3464,13 +3464,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3507,13 +3507,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3552,13 +3552,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3586,13 +3586,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.HTTPError"
+                            "$ref": "#/definitions/api.HTTPError"
                         }
                     }
                 }
@@ -3600,6 +3600,14 @@
         }
     },
     "definitions": {
+        "api.HTTPError": {
+            "type": "object",
+            "properties": {
+                "err": {
+                    "type": "string"
+                }
+            }
+        },
         "dataset.AddPieceRequest": {
             "type": "object",
             "properties": {
@@ -3756,6 +3764,9 @@
         },
         "datasource.AllConfig": {
             "type": "object",
+            "required": [
+                "sourcePath"
+            ],
             "properties": {
                 "acdAuthUrl": {
                     "description": "Auth server URL.",
@@ -4833,7 +4844,7 @@
                 "localEncoding": {
                     "description": "The encoding for the backend.",
                     "type": "string",
-                    "default": "Slash,Dot"
+                    "default": "Slash,InvalidUtf8,Dot"
                 },
                 "localLinks": {
                     "description": "Translate symlinks to/from regular files with a '.rclonelink' extension.",
@@ -5789,6 +5800,10 @@
                     "description": "SMB username.",
                     "type": "string",
                     "default": "$USER"
+                },
+                "sourcePath": {
+                    "description": "The path of the source to scan items",
+                    "type": "string"
                 },
                 "storjAccessGrant": {
                     "description": "Access grant.",
@@ -7492,7 +7507,7 @@
                 "encoding": {
                     "description": "The encoding for the backend.",
                     "type": "string",
-                    "default": "Slash,Dot"
+                    "default": "Slash,InvalidUtf8,Dot"
                 },
                 "links": {
                     "description": "Translate symlinks to/from regular files with a '.rclonelink' extension.",
@@ -9357,14 +9372,6 @@
                 },
                 "size": {
                     "type": "integer"
-                }
-            }
-        },
-        "handler.HTTPError": {
-            "type": "object",
-            "properties": {
-                "err": {
-                    "type": "string"
                 }
             }
         },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -988,7 +988,7 @@ definitions:
         description: Follow symlinks and copy the pointed to item.
         type: string
       localEncoding:
-        default: Slash,InvalidUtf8,Dot
+        default: Slash,Dot
         description: The encoding for the backend.
         type: string
       localLinks:
@@ -3110,7 +3110,7 @@ definitions:
         description: Delete the source after exporting to CAR files
         type: boolean
       encoding:
-        default: Slash,InvalidUtf8,Dot
+        default: Slash,Dot
         description: The encoding for the backend.
         type: string
       links:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1,5 +1,10 @@
 basePath: /api
 definitions:
+  api.HTTPError:
+    properties:
+      err:
+        type: string
+    type: object
   dataset.AddPieceRequest:
     properties:
       filePath:
@@ -983,7 +988,7 @@ definitions:
         description: Follow symlinks and copy the pointed to item.
         type: string
       localEncoding:
-        default: Slash,Dot
+        default: Slash,InvalidUtf8,Dot
         description: The encoding for the backend.
         type: string
       localLinks:
@@ -1762,6 +1767,9 @@ definitions:
         default: $USER
         description: SMB username.
         type: string
+      sourcePath:
+        description: The path of the source to scan items
+        type: string
       storjAccessGrant:
         description: Access grant.
         type: string
@@ -1972,6 +1980,8 @@ definitions:
       zohoTokenUrl:
         description: Token server url.
         type: string
+    required:
+    - sourcePath
     type: object
   datasource.AzureblobRequest:
     properties:
@@ -3100,7 +3110,7 @@ definitions:
         description: Delete the source after exporting to CAR files
         type: boolean
       encoding:
-        default: Slash,Dot
+        default: Slash,InvalidUtf8,Dot
         description: The encoding for the backend.
         type: string
       links:
@@ -4586,11 +4596,6 @@ definitions:
       size:
         type: integer
     type: object
-  handler.HTTPError:
-    properties:
-      err:
-        type: string
-    type: object
   inspect.DirDetail:
     properties:
       current:
@@ -5107,7 +5112,7 @@ paths:
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Initialize the database
       tags:
       - Admin
@@ -5120,7 +5125,7 @@ paths:
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Reset the database
       tags:
       - Admin
@@ -5144,7 +5149,7 @@ paths:
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Get detail of a specific chunk
       tags:
       - Data Source
@@ -5162,11 +5167,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: List all datasets
       tags:
       - Dataset
@@ -5191,11 +5196,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Create a new dataset
       tags:
       - Dataset
@@ -5215,11 +5220,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Remove a specific dataset. This will not remove the CAR files.
       tags:
       - Dataset
@@ -5248,11 +5253,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Update a dataset
       tags:
       - Dataset
@@ -5278,11 +5283,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: List all pieces for the dataset that are available for deal making
       tags:
       - Dataset
@@ -5311,11 +5316,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Manually register a piece (CAR file) with the dataset for deal making
         purpose
       tags:
@@ -5340,11 +5345,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: List all wallets of a dataset.
       tags:
       - Wallet
@@ -5367,11 +5372,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Remove an associated wallet from a dataset
       tags:
       - Wallet
@@ -5399,11 +5404,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Associate a new wallet with a dataset
       tags:
       - Wallet Association
@@ -5431,11 +5436,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: List all deals
       tags:
       - Deal
@@ -5459,7 +5464,7 @@ paths:
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Get details about an item
       tags:
       - Data Source
@@ -5517,11 +5522,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Create a new schedule
       tags:
       - Deal Schedule
@@ -5543,11 +5548,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Pause a specific schedule
       tags:
       - Deal Schedule
@@ -5569,11 +5574,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Resume a specific schedule
       tags:
       - Deal Schedule
@@ -5591,11 +5596,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: List all deal making schedules
       tags:
       - Deal Schedule
@@ -5621,11 +5626,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Send a manual deal proposal
       tags:
       - Deal
@@ -5648,11 +5653,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: List all sources for a dataset
       tags:
       - Data Source
@@ -5670,11 +5675,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Remove a source
       tags:
       - Data Source
@@ -5703,11 +5708,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Update the config options of a source
       tags:
       - Data Source
@@ -5739,11 +5744,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Check the connection of the data source by listing a path
       tags:
       - Data Source
@@ -5769,7 +5774,7 @@ paths:
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Get all dag details of a data source
       tags:
       - Data Source
@@ -5791,11 +5796,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Mark a source as ready for DAG generation
       tags:
       - Data Source
@@ -5821,11 +5826,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Get all item details of a data source
       tags:
       - Data Source
@@ -5855,11 +5860,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Get all item details inside a data source path
       tags:
       - Data Source
@@ -5916,7 +5921,7 @@ paths:
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Trigger a rescan of a data source
       tags:
       - Data Source
@@ -5940,11 +5945,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Get the data preparation summary of a data source
       tags:
       - Data Source
@@ -5974,11 +5979,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add acd source for a dataset
       tags:
       - Data Source
@@ -6008,11 +6013,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add azureblob source for a dataset
       tags:
       - Data Source
@@ -6042,11 +6047,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add b2 source for a dataset
       tags:
       - Data Source
@@ -6076,11 +6081,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add box source for a dataset
       tags:
       - Data Source
@@ -6110,11 +6115,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add drive source for a dataset
       tags:
       - Data Source
@@ -6144,11 +6149,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add dropbox source for a dataset
       tags:
       - Data Source
@@ -6178,11 +6183,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add fichier source for a dataset
       tags:
       - Data Source
@@ -6212,11 +6217,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add filefabric source for a dataset
       tags:
       - Data Source
@@ -6246,11 +6251,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add ftp source for a dataset
       tags:
       - Data Source
@@ -6280,11 +6285,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add gcs source for a dataset
       tags:
       - Data Source
@@ -6314,11 +6319,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add gphotos source for a dataset
       tags:
       - Data Source
@@ -6348,11 +6353,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add hdfs source for a dataset
       tags:
       - Data Source
@@ -6382,11 +6387,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add hidrive source for a dataset
       tags:
       - Data Source
@@ -6416,11 +6421,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add http source for a dataset
       tags:
       - Data Source
@@ -6450,11 +6455,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add internetarchive source for a dataset
       tags:
       - Data Source
@@ -6484,11 +6489,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add jottacloud source for a dataset
       tags:
       - Data Source
@@ -6518,11 +6523,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add koofr source for a dataset
       tags:
       - Data Source
@@ -6552,11 +6557,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add local source for a dataset
       tags:
       - Data Source
@@ -6586,11 +6591,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add mailru source for a dataset
       tags:
       - Data Source
@@ -6620,11 +6625,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add mega source for a dataset
       tags:
       - Data Source
@@ -6654,11 +6659,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add netstorage source for a dataset
       tags:
       - Data Source
@@ -6688,11 +6693,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add onedrive source for a dataset
       tags:
       - Data Source
@@ -6722,11 +6727,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add oos source for a dataset
       tags:
       - Data Source
@@ -6756,11 +6761,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add opendrive source for a dataset
       tags:
       - Data Source
@@ -6790,11 +6795,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add pcloud source for a dataset
       tags:
       - Data Source
@@ -6824,11 +6829,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add premiumizeme source for a dataset
       tags:
       - Data Source
@@ -6858,11 +6863,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add putio source for a dataset
       tags:
       - Data Source
@@ -6892,11 +6897,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add qingstor source for a dataset
       tags:
       - Data Source
@@ -6926,11 +6931,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add s3 source for a dataset
       tags:
       - Data Source
@@ -6960,11 +6965,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add seafile source for a dataset
       tags:
       - Data Source
@@ -6994,11 +6999,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add sftp source for a dataset
       tags:
       - Data Source
@@ -7028,11 +7033,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add sharefile source for a dataset
       tags:
       - Data Source
@@ -7062,11 +7067,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add sia source for a dataset
       tags:
       - Data Source
@@ -7096,11 +7101,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add smb source for a dataset
       tags:
       - Data Source
@@ -7130,11 +7135,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add storj source for a dataset
       tags:
       - Data Source
@@ -7164,11 +7169,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add sugarsync source for a dataset
       tags:
       - Data Source
@@ -7198,11 +7203,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add swift source for a dataset
       tags:
       - Data Source
@@ -7232,11 +7237,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add uptobox source for a dataset
       tags:
       - Data Source
@@ -7266,11 +7271,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add webdav source for a dataset
       tags:
       - Data Source
@@ -7300,11 +7305,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add yandex source for a dataset
       tags:
       - Data Source
@@ -7334,11 +7339,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add zoho source for a dataset
       tags:
       - Data Source
@@ -7356,11 +7361,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: List all imported wallets
       tags:
       - Wallet
@@ -7384,11 +7389,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Import a private key
       tags:
       - Wallet
@@ -7406,11 +7411,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Remove a wallet
       tags:
       - Wallet
@@ -7435,11 +7440,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.HTTPError'
+            $ref: '#/definitions/api.HTTPError'
       summary: Add a remote wallet
       tags:
       - Wallet

--- a/handler/admin/init.go
+++ b/handler/admin/init.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"gorm.io/gorm"
 )
@@ -13,12 +12,12 @@ func InitHandler(db *gorm.DB) error {
 // @Summary Initialize the database
 // @Tags Admin
 // @Success 204
-// @Failure 500 {object} handler.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /admin/init [post]
 func initHandler(db *gorm.DB) error {
 	err := model.AutoMigrate(db)
 	if err != nil {
-		return handler.NewHandlerError(err)
+		return err
 	}
 
 	return nil

--- a/handler/admin/reset.go
+++ b/handler/admin/reset.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"gorm.io/gorm"
 )
@@ -10,17 +9,17 @@ import (
 // @Description This will drop all tables and recreate them.
 // @Tags Admin
 // @Success 204
-// @Failure 500 {object} handler.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /admin/reset [post]
 func resetHandler(db *gorm.DB) error {
 	err := model.DropAll(db)
 	if err != nil {
-		return handler.NewHandlerError(err)
+		return err
 	}
 
 	err = model.AutoMigrate(db)
 	if err != nil {
-		return handler.NewHandlerError(err)
+		return err
 	}
 
 	return nil

--- a/handler/dataset/addpiece.go
+++ b/handler/dataset/addpiece.go
@@ -38,8 +38,8 @@ func AddPieceHandler(
 // @Param datasetName path string true "Dataset name"
 // @Param request body AddPieceRequest true "Request body"
 // @Success 200 {object} model.Car
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /dataset/{datasetName}/piece [post]
 func addPieceHandler(
 	db *gorm.DB,
@@ -48,38 +48,38 @@ func addPieceHandler(
 ) (*model.Car, error) {
 	logger := log.Logger("cli")
 	if datasetName == "" {
-		return nil, handler.NewBadRequestString("dataset name is required")
+		return nil, handler.NewInvalidParameterErr("dataset name is required")
 	}
 
 	dataset, err := database.FindDatasetByName(db, datasetName)
 	if err != nil {
-		return nil, handler.NewBadRequestString("failed to find dataset: " + err.Error())
+		return nil, handler.NewInvalidParameterErr("failed to find dataset: " + err.Error())
 	}
 
 	pieceCID, err := cid.Parse(request.PieceCID)
 	if err != nil {
-		return nil, handler.NewBadRequestString("invalid piece CID")
+		return nil, handler.NewInvalidParameterErr("invalid piece CID")
 	}
 	if pieceCID.Type() != cid.FilCommitmentUnsealed {
-		return nil, handler.NewBadRequestString("piece CID must be commp")
+		return nil, handler.NewInvalidParameterErr("piece CID must be commp")
 	}
 	pieceSize, err := strconv.ParseInt(request.PieceSize, 10, 64)
 	if err != nil {
-		return nil, handler.NewBadRequestString("invalid piece size")
+		return nil, handler.NewInvalidParameterErr("invalid piece size")
 	}
 	if (pieceSize & (pieceSize - 1)) != 0 {
-		return nil, handler.NewBadRequestString("piece size must be a power of 2")
+		return nil, handler.NewInvalidParameterErr("piece size must be a power of 2")
 	}
 	rootCID := cid.NewCidV1(cid.Raw, util.Hash([]byte(""))).String()
 	if request.FilePath != "" {
 		file, err := os.Open(request.FilePath)
 		if err != nil {
-			return nil, handler.NewBadRequestString("failed to open file: " + err.Error())
+			return nil, handler.NewInvalidParameterErr("failed to open file: " + err.Error())
 		}
 		defer file.Close()
 		header, err := car.ReadHeader(bufio.NewReader(file))
 		if err != nil {
-			return nil, handler.NewBadRequestString("failed to read CAR header: " + err.Error())
+			return nil, handler.NewInvalidParameterErr("failed to read CAR header: " + err.Error())
 		}
 		if len(header.Roots) != 1 {
 			logger.Warnf("CAR file has %d roots, expected 1", len(header.Roots))
@@ -110,7 +110,7 @@ func addPieceHandler(
 
 	err = database.DoRetry(func() error { return db.Create(&mCar).Error })
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 	return &mCar, nil
 }

--- a/handler/dataset/create.go
+++ b/handler/dataset/create.go
@@ -117,7 +117,7 @@ func createHandler(
 
 	err2 := database.DoRetry(func() error { return db.Create(dataset).Error })
 	if errors.Is(err2, gorm.ErrDuplicatedKey) {
-		return nil, handler.NewInvalidParameterErr("dataset with this name already exists")
+		return nil, handler.NewDuplicateRecordError("dataset with this name already exists")
 	}
 
 	if err2 != nil {

--- a/handler/dataset/create.go
+++ b/handler/dataset/create.go
@@ -27,48 +27,48 @@ type CreateRequest struct {
 func parseCreateRequest(request CreateRequest) (*model.Dataset, error) {
 	maxSize, err := humanize.ParseBytes(request.MaxSizeStr)
 	if err != nil {
-		return nil, handler.NewBadRequestString("invalid value for max-size: " + err.Error())
+		return nil, handler.NewInvalidParameterErr("invalid value for max-size: " + err.Error())
 	}
 
 	pieceSize := util.NextPowerOfTwo(maxSize)
 	if request.PieceSizeStr != "" {
 		pieceSize, err = humanize.ParseBytes(request.PieceSizeStr)
 		if err != nil {
-			return nil, handler.NewBadRequestString("invalid value for piece-size: " + err.Error())
+			return nil, handler.NewInvalidParameterErr("invalid value for piece-size: " + err.Error())
 		}
 
 		if pieceSize != util.NextPowerOfTwo(pieceSize) {
-			return nil, handler.NewBadRequestString("piece size must be a power of two")
+			return nil, handler.NewInvalidParameterErr("piece size must be a power of two")
 		}
 	}
 
 	if pieceSize > 1<<36 {
-		return nil, handler.NewBadRequestString("piece size cannot be larger than 64 GiB")
+		return nil, handler.NewInvalidParameterErr("piece size cannot be larger than 64 GiB")
 	}
 
 	if maxSize*128/127 >= pieceSize {
-		return nil, handler.NewBadRequestString("max size needs to be reduced to leave space for padding")
+		return nil, handler.NewInvalidParameterErr("max size needs to be reduced to leave space for padding")
 	}
 
 	outDirs := make([]string, len(request.OutputDirs))
 	for i, outputDir := range request.OutputDirs {
 		info, err := os.Stat(outputDir)
 		if err != nil || !info.IsDir() {
-			return nil, handler.NewBadRequestString("output directory does not exist: " + outputDir)
+			return nil, handler.NewInvalidParameterErr("output directory does not exist: " + outputDir)
 		}
 		abs, err := filepath.Abs(outputDir)
 		if err != nil {
-			return nil, handler.NewBadRequestString("could not get absolute path for output directory: " + err.Error())
+			return nil, handler.NewInvalidParameterErr("could not get absolute path for output directory: " + err.Error())
 		}
 		outDirs[i] = abs
 	}
 
 	if len(request.EncryptionRecipients) > 0 && request.EncryptionScript != "" {
-		return nil, handler.NewBadRequestString("encryption recipients and script cannot be used together")
+		return nil, handler.NewInvalidParameterErr("encryption recipients and script cannot be used together")
 	}
 
 	if (len(request.EncryptionRecipients) > 0 || request.EncryptionScript != "") && len(request.OutputDirs) == 0 {
-		return nil, handler.NewBadRequestString(
+		return nil, handler.NewInvalidParameterErr(
 			"encryption is not compatible with inline preparation and " +
 				"requires at least one output directory",
 		)
@@ -98,8 +98,8 @@ func CreateHandler(
 // @Description The dataset is a top level object to distinguish different dataset.
 // @Param request body CreateRequest true "Request body"
 // @Success 200 {object} model.Dataset
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /dataset [post]
 func createHandler(
 	db *gorm.DB,
@@ -107,7 +107,7 @@ func createHandler(
 ) (*model.Dataset, error) {
 	logger := log.Logger("cli")
 	if request.Name == "" {
-		return nil, handler.NewBadRequestString("name is required")
+		return nil, handler.NewInvalidParameterErr("name is required")
 	}
 
 	dataset, err := parseCreateRequest(request)
@@ -117,11 +117,11 @@ func createHandler(
 
 	err2 := database.DoRetry(func() error { return db.Create(dataset).Error })
 	if errors.Is(err2, gorm.ErrDuplicatedKey) {
-		return nil, handler.NewBadRequestString("dataset with this name already exists")
+		return nil, handler.NewInvalidParameterErr("dataset with this name already exists")
 	}
 
 	if err2 != nil {
-		return nil, handler.NewHandlerError(err2)
+		return nil, err2
 	}
 
 	logger.Infof("Dataset created with ID: %d", dataset.ID)

--- a/handler/dataset/list.go
+++ b/handler/dataset/list.go
@@ -1,7 +1,6 @@
 package dataset
 
 import (
-	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"gorm.io/gorm"
 )
@@ -10,8 +9,8 @@ import (
 // @Tags Dataset
 // @Produce json
 // @Success 200 {array} model.Dataset
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /dataset [get]
 func listHandler(
 	db *gorm.DB,
@@ -19,7 +18,7 @@ func listHandler(
 	var datasets []model.Dataset
 	err := db.Find(&datasets).Error
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 	return datasets, nil
 }

--- a/handler/dataset/listpieces.go
+++ b/handler/dataset/listpieces.go
@@ -13,26 +13,26 @@ import (
 // @Accept json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {array} model.Car
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /dataset/{datasetName}/piece [get]
 func listPiecesHandler(
 	db *gorm.DB,
 	datasetName string,
 ) ([]model.Car, error) {
 	if datasetName == "" {
-		return nil, handler.NewBadRequestString("dataset name is required")
+		return nil, handler.NewInvalidParameterErr("dataset name is required")
 	}
 
 	dataset, err := database.FindDatasetByName(db, datasetName)
 	if err != nil {
-		return nil, handler.NewBadRequestString("failed to find dataset: " + err.Error())
+		return nil, handler.NewInvalidParameterErr("failed to find dataset: " + err.Error())
 	}
 
 	var cars []model.Car
 	err = db.Where("dataset_id = ?", dataset.ID).Find(&cars).Error
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	return cars, nil

--- a/handler/dataset/remove.go
+++ b/handler/dataset/remove.go
@@ -11,8 +11,8 @@ import (
 // @Tags Dataset
 // @Param datasetName path string true "Dataset name"
 // @Success 204
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /dataset/{datasetName} [delete]
 func removeHandler(
 	db *gorm.DB,
@@ -20,11 +20,11 @@ func removeHandler(
 ) error {
 	dataset, err := database.FindDatasetByName(db, datasetName)
 	if err != nil {
-		return handler.NewBadRequestString("failed to find dataset: " + err.Error())
+		return handler.NewInvalidParameterErr("failed to find dataset: " + err.Error())
 	}
 	err = database.DoRetry(func() error { return db.Delete(&dataset).Error })
 	if err != nil {
-		return handler.NewHandlerError(err)
+		return err
 	}
 	return nil
 }

--- a/handler/datasource/add.go
+++ b/handler/datasource/add.go
@@ -46,7 +46,7 @@ func createDatasourceHandler(
 ) (*model.Source, error) {
 	dataset, err := database.FindDatasetByName(db, datasetName)
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, handler.ErrNotFound{Err: err}
+		return nil, handler.NotFoundError{Err: err}
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to find dataset: %w", err)
@@ -54,7 +54,7 @@ func createDatasourceHandler(
 
 	r, err := fs2.Find(sourceType)
 	if err != nil {
-		return nil, handler.ErrInvalidParameter{Err: err}
+		return nil, handler.InvalidParameterError{Err: err}
 	}
 	sourcePath := sourceParameters["sourcePath"]
 	path, ok := sourcePath.(string)
@@ -67,7 +67,7 @@ func createDatasourceHandler(
 	if r.Prefix == "local" {
 		path, err = filepath.Abs(path)
 		if err != nil {
-			return nil, handler.ErrInvalidParameter{Err: fmt.Errorf("failed to get absolute path: %w", err)}
+			return nil, handler.InvalidParameterError{Err: fmt.Errorf("failed to get absolute path: %w", err)}
 		}
 	}
 	deleteAfterExportValue := sourceParameters["deleteAfterExport"]
@@ -82,7 +82,7 @@ func createDatasourceHandler(
 	}
 	rescan, err := time.ParseDuration(rescanInterval)
 	if err != nil {
-		return nil, handler.ErrInvalidParameter{Err: fmt.Errorf("failed to parse rescanInterval: %w", err)}
+		return nil, handler.InvalidParameterError{Err: fmt.Errorf("failed to parse rescanInterval: %w", err)}
 	}
 	delete(sourceParameters, "sourcePath")
 	delete(sourceParameters, "deleteAfterExport")

--- a/handler/datasource/add_gen.go
+++ b/handler/datasource/add_gen.go
@@ -542,23 +542,23 @@ type KoofrRequest struct {
 func handleKoofr() {}
 
 type LocalRequest struct {
-	SourcePath           string `validate:"required" json:"sourcePath"`           // The path of the source to scan items
-	DeleteAfterExport    bool   `validate:"required" json:"deleteAfterExport"`    // Delete the source after exporting to CAR files
-	RescanInterval       string `validate:"required" json:"rescanInterval"`       // Automatically rescan the source directory when this interval has passed from last successful scan
-	CaseInsensitive      string `json:"caseInsensitive" default:"false"`          // Force the filesystem to report itself as case insensitive.
-	CaseSensitive        string `json:"caseSensitive" default:"false"`            // Force the filesystem to report itself as case sensitive.
-	CopyLinks            string `json:"copyLinks" default:"false"`                // Follow symlinks and copy the pointed to item.
-	Encoding             string `json:"encoding" default:"Slash,InvalidUtf8,Dot"` // The encoding for the backend.
-	Links                string `json:"links" default:"false"`                    // Translate symlinks to/from regular files with a '.rclonelink' extension.
-	NoCheckUpdated       string `json:"noCheckUpdated" default:"false"`           // Don't check to see if the files change during upload.
-	NoPreallocate        string `json:"noPreallocate" default:"false"`            // Disable preallocation of disk space for transferred files.
-	NoSetModtime         string `json:"noSetModtime" default:"false"`             // Disable setting modtime.
-	NoSparse             string `json:"noSparse" default:"false"`                 // Disable sparse files for multi-thread downloads.
-	Nounc                string `json:"nounc" default:"false"`                    // Disable UNC (long path names) conversion on Windows.
-	OneFileSystem        string `json:"oneFileSystem" default:"false"`            // Don't cross filesystem boundaries (unix/macOS only).
-	SkipLinks            string `json:"skipLinks" default:"false"`                // Don't warn about skipped symlinks.
-	UnicodeNormalization string `json:"unicodeNormalization" default:"false"`     // Apply unicode NFC normalization to paths and filenames.
-	ZeroSizeLinks        string `json:"zeroSizeLinks" default:"false"`            // Assume the Stat size of links is zero (and read them instead) (deprecated).
+	SourcePath           string `validate:"required" json:"sourcePath"`        // The path of the source to scan items
+	DeleteAfterExport    bool   `validate:"required" json:"deleteAfterExport"` // Delete the source after exporting to CAR files
+	RescanInterval       string `validate:"required" json:"rescanInterval"`    // Automatically rescan the source directory when this interval has passed from last successful scan
+	CaseInsensitive      string `json:"caseInsensitive" default:"false"`       // Force the filesystem to report itself as case insensitive.
+	CaseSensitive        string `json:"caseSensitive" default:"false"`         // Force the filesystem to report itself as case sensitive.
+	CopyLinks            string `json:"copyLinks" default:"false"`             // Follow symlinks and copy the pointed to item.
+	Encoding             string `json:"encoding" default:"Slash,Dot"`          // The encoding for the backend.
+	Links                string `json:"links" default:"false"`                 // Translate symlinks to/from regular files with a '.rclonelink' extension.
+	NoCheckUpdated       string `json:"noCheckUpdated" default:"false"`        // Don't check to see if the files change during upload.
+	NoPreallocate        string `json:"noPreallocate" default:"false"`         // Disable preallocation of disk space for transferred files.
+	NoSetModtime         string `json:"noSetModtime" default:"false"`          // Disable setting modtime.
+	NoSparse             string `json:"noSparse" default:"false"`              // Disable sparse files for multi-thread downloads.
+	Nounc                string `json:"nounc" default:"false"`                 // Disable UNC (long path names) conversion on Windows.
+	OneFileSystem        string `json:"oneFileSystem" default:"false"`         // Don't cross filesystem boundaries (unix/macOS only).
+	SkipLinks            string `json:"skipLinks" default:"false"`             // Don't warn about skipped symlinks.
+	UnicodeNormalization string `json:"unicodeNormalization" default:"false"`  // Apply unicode NFC normalization to paths and filenames.
+	ZeroSizeLinks        string `json:"zeroSizeLinks" default:"false"`         // Assume the Stat size of links is zero (and read them instead) (deprecated).
 }
 
 // @Summary Add local source for a dataset
@@ -1487,7 +1487,7 @@ type AllConfig struct {
 	LocalCaseInsensitive                string `json:"localCaseInsensitive" default:"false"`                                                                                                                        // Force the filesystem to report itself as case insensitive.
 	LocalCaseSensitive                  string `json:"localCaseSensitive" default:"false"`                                                                                                                          // Force the filesystem to report itself as case sensitive.
 	LocalCopyLinks                      string `json:"localCopyLinks" default:"false"`                                                                                                                              // Follow symlinks and copy the pointed to item.
-	LocalEncoding                       string `json:"localEncoding" default:"Slash,InvalidUtf8,Dot"`                                                                                                               // The encoding for the backend.
+	LocalEncoding                       string `json:"localEncoding" default:"Slash,Dot"`                                                                                                                           // The encoding for the backend.
 	LocalLinks                          string `json:"localLinks" default:"false"`                                                                                                                                  // Translate symlinks to/from regular files with a '.rclonelink' extension.
 	LocalNoCheckUpdated                 string `json:"localNoCheckUpdated" default:"false"`                                                                                                                         // Don't check to see if the files change during upload.
 	LocalNoPreallocate                  string `json:"localNoPreallocate" default:"false"`                                                                                                                          // Disable preallocation of disk space for transferred files.

--- a/handler/datasource/add_gen.go
+++ b/handler/datasource/add_gen.go
@@ -24,8 +24,8 @@ type AcdRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body AcdRequest true "Request body"
 // @Router /source/acd/dataset/{datasetName} [post]
 func handleAcd() {}
@@ -74,8 +74,8 @@ type AzureblobRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body AzureblobRequest true "Request body"
 // @Router /source/azureblob/dataset/{datasetName} [post]
 func handleAzureblob() {}
@@ -108,8 +108,8 @@ type B2Request struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body B2Request true "Request body"
 // @Router /source/b2/dataset/{datasetName} [post]
 func handleB2() {}
@@ -140,8 +140,8 @@ type BoxRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body BoxRequest true "Request body"
 // @Router /source/box/dataset/{datasetName} [post]
 func handleBox() {}
@@ -201,8 +201,8 @@ type DriveRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body DriveRequest true "Request body"
 // @Router /source/drive/dataset/{datasetName} [post]
 func handleDrive() {}
@@ -233,8 +233,8 @@ type DropboxRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body DropboxRequest true "Request body"
 // @Router /source/dropbox/dataset/{datasetName} [post]
 func handleDropbox() {}
@@ -256,8 +256,8 @@ type FichierRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body FichierRequest true "Request body"
 // @Router /source/fichier/dataset/{datasetName} [post]
 func handleFichier() {}
@@ -281,8 +281,8 @@ type FilefabricRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body FilefabricRequest true "Request body"
 // @Router /source/filefabric/dataset/{datasetName} [post]
 func handleFilefabric() {}
@@ -319,8 +319,8 @@ type FtpRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body FtpRequest true "Request body"
 // @Router /source/ftp/dataset/{datasetName} [post]
 func handleFtp() {}
@@ -356,8 +356,8 @@ type GcsRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body GcsRequest true "Request body"
 // @Router /source/gcs/dataset/{datasetName} [post]
 func handleGcs() {}
@@ -384,8 +384,8 @@ type GphotosRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body GphotosRequest true "Request body"
 // @Router /source/gphotos/dataset/{datasetName} [post]
 func handleGphotos() {}
@@ -407,8 +407,8 @@ type HdfsRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body HdfsRequest true "Request body"
 // @Router /source/hdfs/dataset/{datasetName} [post]
 func handleHdfs() {}
@@ -439,8 +439,8 @@ type HidriveRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body HidriveRequest true "Request body"
 // @Router /source/hidrive/dataset/{datasetName} [post]
 func handleHidrive() {}
@@ -461,8 +461,8 @@ type HttpRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body HttpRequest true "Request body"
 // @Router /source/http/dataset/{datasetName} [post]
 func handleHttp() {}
@@ -486,8 +486,8 @@ type InternetarchiveRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body InternetarchiveRequest true "Request body"
 // @Router /source/internetarchive/dataset/{datasetName} [post]
 func handleInternetarchive() {}
@@ -510,8 +510,8 @@ type JottacloudRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body JottacloudRequest true "Request body"
 // @Router /source/jottacloud/dataset/{datasetName} [post]
 func handleJottacloud() {}
@@ -535,30 +535,30 @@ type KoofrRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body KoofrRequest true "Request body"
 // @Router /source/koofr/dataset/{datasetName} [post]
 func handleKoofr() {}
 
 type LocalRequest struct {
-	SourcePath           string `validate:"required" json:"sourcePath"`        // The path of the source to scan items
-	DeleteAfterExport    bool   `validate:"required" json:"deleteAfterExport"` // Delete the source after exporting to CAR files
-	RescanInterval       string `validate:"required" json:"rescanInterval"`    // Automatically rescan the source directory when this interval has passed from last successful scan
-	CaseInsensitive      string `json:"caseInsensitive" default:"false"`       // Force the filesystem to report itself as case insensitive.
-	CaseSensitive        string `json:"caseSensitive" default:"false"`         // Force the filesystem to report itself as case sensitive.
-	CopyLinks            string `json:"copyLinks" default:"false"`             // Follow symlinks and copy the pointed to item.
-	Encoding             string `json:"encoding" default:"Slash,Dot"`          // The encoding for the backend.
-	Links                string `json:"links" default:"false"`                 // Translate symlinks to/from regular files with a '.rclonelink' extension.
-	NoCheckUpdated       string `json:"noCheckUpdated" default:"false"`        // Don't check to see if the files change during upload.
-	NoPreallocate        string `json:"noPreallocate" default:"false"`         // Disable preallocation of disk space for transferred files.
-	NoSetModtime         string `json:"noSetModtime" default:"false"`          // Disable setting modtime.
-	NoSparse             string `json:"noSparse" default:"false"`              // Disable sparse files for multi-thread downloads.
-	Nounc                string `json:"nounc" default:"false"`                 // Disable UNC (long path names) conversion on Windows.
-	OneFileSystem        string `json:"oneFileSystem" default:"false"`         // Don't cross filesystem boundaries (unix/macOS only).
-	SkipLinks            string `json:"skipLinks" default:"false"`             // Don't warn about skipped symlinks.
-	UnicodeNormalization string `json:"unicodeNormalization" default:"false"`  // Apply unicode NFC normalization to paths and filenames.
-	ZeroSizeLinks        string `json:"zeroSizeLinks" default:"false"`         // Assume the Stat size of links is zero (and read them instead) (deprecated).
+	SourcePath           string `validate:"required" json:"sourcePath"`           // The path of the source to scan items
+	DeleteAfterExport    bool   `validate:"required" json:"deleteAfterExport"`    // Delete the source after exporting to CAR files
+	RescanInterval       string `validate:"required" json:"rescanInterval"`       // Automatically rescan the source directory when this interval has passed from last successful scan
+	CaseInsensitive      string `json:"caseInsensitive" default:"false"`          // Force the filesystem to report itself as case insensitive.
+	CaseSensitive        string `json:"caseSensitive" default:"false"`            // Force the filesystem to report itself as case sensitive.
+	CopyLinks            string `json:"copyLinks" default:"false"`                // Follow symlinks and copy the pointed to item.
+	Encoding             string `json:"encoding" default:"Slash,InvalidUtf8,Dot"` // The encoding for the backend.
+	Links                string `json:"links" default:"false"`                    // Translate symlinks to/from regular files with a '.rclonelink' extension.
+	NoCheckUpdated       string `json:"noCheckUpdated" default:"false"`           // Don't check to see if the files change during upload.
+	NoPreallocate        string `json:"noPreallocate" default:"false"`            // Disable preallocation of disk space for transferred files.
+	NoSetModtime         string `json:"noSetModtime" default:"false"`             // Disable setting modtime.
+	NoSparse             string `json:"noSparse" default:"false"`                 // Disable sparse files for multi-thread downloads.
+	Nounc                string `json:"nounc" default:"false"`                    // Disable UNC (long path names) conversion on Windows.
+	OneFileSystem        string `json:"oneFileSystem" default:"false"`            // Don't cross filesystem boundaries (unix/macOS only).
+	SkipLinks            string `json:"skipLinks" default:"false"`                // Don't warn about skipped symlinks.
+	UnicodeNormalization string `json:"unicodeNormalization" default:"false"`     // Apply unicode NFC normalization to paths and filenames.
+	ZeroSizeLinks        string `json:"zeroSizeLinks" default:"false"`            // Assume the Stat size of links is zero (and read them instead) (deprecated).
 }
 
 // @Summary Add local source for a dataset
@@ -567,8 +567,8 @@ type LocalRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body LocalRequest true "Request body"
 // @Router /source/local/dataset/{datasetName} [post]
 func handleLocal() {}
@@ -595,8 +595,8 @@ type MailruRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body MailruRequest true "Request body"
 // @Router /source/mailru/dataset/{datasetName} [post]
 func handleMailru() {}
@@ -619,8 +619,8 @@ type MegaRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body MegaRequest true "Request body"
 // @Router /source/mega/dataset/{datasetName} [post]
 func handleMega() {}
@@ -641,8 +641,8 @@ type NetstorageRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body NetstorageRequest true "Request body"
 // @Router /source/netstorage/dataset/{datasetName} [post]
 func handleNetstorage() {}
@@ -680,8 +680,8 @@ type OnedriveRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body OnedriveRequest true "Request body"
 // @Router /source/onedrive/dataset/{datasetName} [post]
 func handleOnedrive() {}
@@ -702,8 +702,8 @@ type OpendriveRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body OpendriveRequest true "Request body"
 // @Router /source/opendrive/dataset/{datasetName} [post]
 func handleOpendrive() {}
@@ -742,8 +742,8 @@ type OosRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body OosRequest true "Request body"
 // @Router /source/oos/dataset/{datasetName} [post]
 func handleOos() {}
@@ -770,8 +770,8 @@ type PcloudRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body PcloudRequest true "Request body"
 // @Router /source/pcloud/dataset/{datasetName} [post]
 func handlePcloud() {}
@@ -790,8 +790,8 @@ type PremiumizemeRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body PremiumizemeRequest true "Request body"
 // @Router /source/premiumizeme/dataset/{datasetName} [post]
 func handlePremiumizeme() {}
@@ -809,8 +809,8 @@ type PutioRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body PutioRequest true "Request body"
 // @Router /source/putio/dataset/{datasetName} [post]
 func handlePutio() {}
@@ -837,8 +837,8 @@ type QingstorRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body QingstorRequest true "Request body"
 // @Router /source/qingstor/dataset/{datasetName} [post]
 func handleQingstor() {}
@@ -904,8 +904,8 @@ type S3Request struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body S3Request true "Request body"
 // @Router /source/s3/dataset/{datasetName} [post]
 func handleS3() {}
@@ -931,8 +931,8 @@ type SeafileRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body SeafileRequest true "Request body"
 // @Router /source/seafile/dataset/{datasetName} [post]
 func handleSeafile() {}
@@ -980,8 +980,8 @@ type SftpRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body SftpRequest true "Request body"
 // @Router /source/sftp/dataset/{datasetName} [post]
 func handleSftp() {}
@@ -1003,8 +1003,8 @@ type SharefileRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body SharefileRequest true "Request body"
 // @Router /source/sharefile/dataset/{datasetName} [post]
 func handleSharefile() {}
@@ -1025,8 +1025,8 @@ type SiaRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body SiaRequest true "Request body"
 // @Router /source/sia/dataset/{datasetName} [post]
 func handleSia() {}
@@ -1053,8 +1053,8 @@ type SmbRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body SmbRequest true "Request body"
 // @Router /source/smb/dataset/{datasetName} [post]
 func handleSmb() {}
@@ -1076,8 +1076,8 @@ type StorjRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body StorjRequest true "Request body"
 // @Router /source/storj/dataset/{datasetName} [post]
 func handleStorj() {}
@@ -1105,8 +1105,8 @@ type SugarsyncRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body SugarsyncRequest true "Request body"
 // @Router /source/sugarsync/dataset/{datasetName} [post]
 func handleSugarsync() {}
@@ -1146,8 +1146,8 @@ type SwiftRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body SwiftRequest true "Request body"
 // @Router /source/swift/dataset/{datasetName} [post]
 func handleSwift() {}
@@ -1166,8 +1166,8 @@ type UptoboxRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body UptoboxRequest true "Request body"
 // @Router /source/uptobox/dataset/{datasetName} [post]
 func handleUptobox() {}
@@ -1192,8 +1192,8 @@ type WebdavRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body WebdavRequest true "Request body"
 // @Router /source/webdav/dataset/{datasetName} [post]
 func handleWebdav() {}
@@ -1217,8 +1217,8 @@ type YandexRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body YandexRequest true "Request body"
 // @Router /source/yandex/dataset/{datasetName} [post]
 func handleYandex() {}
@@ -1242,13 +1242,14 @@ type ZohoRequest struct {
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body ZohoRequest true "Request body"
 // @Router /source/zoho/dataset/{datasetName} [post]
 func handleZoho() {}
 
 type AllConfig struct {
+	SourcePath                          string `validate:"required" json:"sourcePath"`                                                                                                                              // The path of the source to scan items
 	DeleteAfterExport                   bool   `validate:"optional" json:"deleteAfterExport"`                                                                                                                       // Delete the source after exporting to CAR files
 	RescanInterval                      string `validate:"optional" json:"rescanInterval"`                                                                                                                          // Automatically rescan the source directory when this interval has passed from last successful scan
 	AcdAuthUrl                          string `json:"acdAuthUrl"`                                                                                                                                                  // Auth server URL.
@@ -1486,7 +1487,7 @@ type AllConfig struct {
 	LocalCaseInsensitive                string `json:"localCaseInsensitive" default:"false"`                                                                                                                        // Force the filesystem to report itself as case insensitive.
 	LocalCaseSensitive                  string `json:"localCaseSensitive" default:"false"`                                                                                                                          // Force the filesystem to report itself as case sensitive.
 	LocalCopyLinks                      string `json:"localCopyLinks" default:"false"`                                                                                                                              // Follow symlinks and copy the pointed to item.
-	LocalEncoding                       string `json:"localEncoding" default:"Slash,Dot"`                                                                                                                           // The encoding for the backend.
+	LocalEncoding                       string `json:"localEncoding" default:"Slash,InvalidUtf8,Dot"`                                                                                                               // The encoding for the backend.
 	LocalLinks                          string `json:"localLinks" default:"false"`                                                                                                                                  // Translate symlinks to/from regular files with a '.rclonelink' extension.
 	LocalNoCheckUpdated                 string `json:"localNoCheckUpdated" default:"false"`                                                                                                                         // Don't check to see if the files change during upload.
 	LocalNoPreallocate                  string `json:"localNoPreallocate" default:"false"`                                                                                                                          // Disable preallocation of disk space for transferred files.

--- a/handler/datasource/daggen.go
+++ b/handler/datasource/daggen.go
@@ -21,8 +21,8 @@ func DagGenHandler(
 // @Produce json
 // @Param id path string true "Source ID"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /source/{id}/daggen [post]
 func dagGenHandler(
 	db *gorm.DB,
@@ -30,20 +30,20 @@ func dagGenHandler(
 ) (*model.Source, error) {
 	sourceID, err := strconv.Atoi(id)
 	if err != nil {
-		return nil, handler.NewBadRequestString("invalid source id")
+		return nil, handler.NewInvalidParameterErr("invalid source id")
 	}
 	var source model.Source
 	err = db.Where("id = ?", sourceID).First(&source).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, handler.NewBadRequestString("source not found")
+		return nil, handler.NewInvalidParameterErr("source not found")
 	}
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	err = db.Model(&source).Update("dag_gen_state", model.Ready).Error
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 	source.DagGenState = model.Ready
 	return &source, nil

--- a/handler/datasource/generate/add.go
+++ b/handler/datasource/generate/add.go
@@ -32,6 +32,7 @@ type {{.Name}} struct {
 
 const allStructTemplate = `
 type {{.Name}} struct {
+		SourcePath string ` + "`validate:\"required\" json:\"sourcePath\"`" + `// The path of the source to scan items
     DeleteAfterExport bool ` + "`validate:\"optional\" json:\"deleteAfterExport\"`" + `// Delete the source after exporting to CAR files
     RescanInterval string ` + "`validate:\"optional\" json:\"rescanInterval\"`" + `// Automatically rescan the source directory when this interval has passed from last successful scan
     {{- range .Fields }}
@@ -47,8 +48,8 @@ const handlerTemplate = `
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {object} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Param request body {{.StructName}} true "Request body"
 // @Router /source/{{.Name}}/dataset/{datasetName} [post]
 func {{.FuncName}}() {}

--- a/handler/datasource/inspect/chunkdetail.go
+++ b/handler/datasource/inspect/chunkdetail.go
@@ -22,7 +22,7 @@ func GetSourceChunkDetailHandler(
 // @Produce json
 // @Param id path string true "Chunk ID"
 // @Success 200 {object} model.Chunk
-// @Failure 500 {object} handler.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /chunk/{id} [get]
 func getSourceChunkDetailHandler(
 	db *gorm.DB,
@@ -30,15 +30,15 @@ func getSourceChunkDetailHandler(
 ) (*model.Chunk, error) {
 	chunkID, err := strconv.Atoi(id)
 	if err != nil {
-		return nil, handler.NewBadRequestString("invalid chunk id")
+		return nil, handler.NewInvalidParameterErr("invalid chunk id")
 	}
 	var chunk model.Chunk
 	err = db.Preload("Cars").Preload("ItemParts.Item").Where("id = ?", chunkID).First(&chunk).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, handler.NewBadRequestString("chunk not found")
+		return nil, handler.NewInvalidParameterErr("chunk not found")
 	}
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	return &chunk, nil

--- a/handler/datasource/inspect/chunks.go
+++ b/handler/datasource/inspect/chunks.go
@@ -22,8 +22,8 @@ func GetSourceChunksHandler(
 // @Produce json
 // @Param id path string true "Source ID"
 // @Success 200 {array} model.Chunk
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /source/{id}/chunks [get]
 func getSourceChunksHandler(
 	db *gorm.DB,
@@ -31,21 +31,21 @@ func getSourceChunksHandler(
 ) ([]model.Chunk, error) {
 	sourceID, err := strconv.Atoi(id)
 	if err != nil {
-		return nil, handler.NewBadRequestString("invalid source id")
+		return nil, handler.NewInvalidParameterErr("invalid source id")
 	}
 	var source model.Source
 	err = db.Where("id = ?", sourceID).First(&source).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, handler.NewBadRequestString("source not found")
+		return nil, handler.NewInvalidParameterErr("source not found")
 	}
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	var chunks []model.Chunk
 	err = db.Preload("Cars").Where("source_id = ?", sourceID).Find(&chunks).Error
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	return chunks, nil

--- a/handler/datasource/inspect/dags.go
+++ b/handler/datasource/inspect/dags.go
@@ -22,7 +22,7 @@ func GetDagsHandler(
 // @Produce json
 // @Param id path string true "Source ID"
 // @Success 200 {array} model.Car
-// @Failure 500 {object} handler.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /source/{id}/chunks [get]
 func getDagsHandler(
 	db *gorm.DB,
@@ -30,21 +30,21 @@ func getDagsHandler(
 ) ([]model.Car, error) {
 	sourceID, err := strconv.Atoi(id)
 	if err != nil {
-		return nil, handler.NewBadRequestString("invalid source id")
+		return nil, handler.NewInvalidParameterErr("invalid source id")
 	}
 	var source model.Source
 	err = db.Where("id = ?", sourceID).First(&source).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, handler.NewBadRequestString("source not found")
+		return nil, handler.NewInvalidParameterErr("source not found")
 	}
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	var cars []model.Car
 	err = db.Where("source_id = ? AND chunk_id IS NULL", sourceID).Find(&cars).Error
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	return cars, nil

--- a/handler/datasource/inspect/itemdetail.go
+++ b/handler/datasource/inspect/itemdetail.go
@@ -22,7 +22,7 @@ func GetSourceItemDetailHandler(
 // @Produce json
 // @Param id path string true "Item ID"
 // @Success 200 {object} model.Item
-// @Failure 500 {object} handler.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /item/{id} [get]
 func getSourceItemDetailHandler(
 	db *gorm.DB,
@@ -30,15 +30,15 @@ func getSourceItemDetailHandler(
 ) (*model.Item, error) {
 	itemID, err := strconv.Atoi(id)
 	if err != nil {
-		return nil, handler.NewBadRequestString("invalid item id")
+		return nil, handler.NewInvalidParameterErr("invalid item id")
 	}
 	var item model.Item
 	err = db.Preload("ItemParts").Where("id = ?", itemID).First(&item).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, handler.NewBadRequestString("item not found")
+		return nil, handler.NewInvalidParameterErr("item not found")
 	}
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	return &item, nil

--- a/handler/datasource/inspect/items.go
+++ b/handler/datasource/inspect/items.go
@@ -22,8 +22,8 @@ func GetSourceItemsHandler(
 // @Produce json
 // @Param id path string true "Source ID"
 // @Success 200 {array} model.Item
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /source/{id}/items [get]
 func getSourceItemsHandler(
 	db *gorm.DB,
@@ -31,21 +31,21 @@ func getSourceItemsHandler(
 ) ([]model.Item, error) {
 	sourceID, err := strconv.Atoi(id)
 	if err != nil {
-		return nil, handler.NewBadRequestString("invalid source id")
+		return nil, handler.NewInvalidParameterErr("invalid source id")
 	}
 	var source model.Source
 	err = db.Where("id = ?", sourceID).First(&source).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, handler.NewBadRequestString("source not found")
+		return nil, handler.NewInvalidParameterErr("source not found")
 	}
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	var items []model.Item
 	err = db.Where("source_id = ?", sourceID).Find(&items).Error
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	return items, nil

--- a/handler/datasource/list.go
+++ b/handler/datasource/list.go
@@ -15,17 +15,17 @@ func ListSourceByDatasetHandler(
 	if datasetName == "" {
 		err := db.Find(&sources).Error
 		if err != nil {
-			return nil, handler.NewHandlerError(err)
+			return nil, err
 		}
 		return sources, nil
 	}
 	dataset, err := database.FindDatasetByName(db, datasetName)
 	if err != nil {
-		return nil, handler.NewBadRequestString("failed to find dataset: " + err.Error())
+		return nil, handler.NewInvalidParameterErr("failed to find dataset: " + err.Error())
 	}
 	err = db.Where("dataset_id = ?", dataset.ID).Find(&sources).Error
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 	return sources, nil
 }
@@ -35,8 +35,8 @@ func ListSourceByDatasetHandler(
 // @Produce json
 // @Param dataset query string false "Dataset name"
 // @Success 200 {array} model.Source
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /source [get]
 func listSourceHandler(
 	db *gorm.DB,

--- a/handler/datasource/pushitem.go
+++ b/handler/datasource/pushitem.go
@@ -61,7 +61,7 @@ func pushItemHandler(
 
 	entry, err := dsHandler.Check(ctx, itemInfo.Path)
 	if err != nil {
-		return nil, handler.ErrInvalidParameter{Err: err}
+		return nil, handler.InvalidParameterError{Err: err}
 	}
 
 	obj, ok := entry.(fs2.ObjectInfo)

--- a/handler/datasource/pushitem.go
+++ b/handler/datasource/pushitem.go
@@ -48,35 +48,35 @@ func pushItemHandler(
 	var source model.Source
 	err := db.Preload("Dataset").Where("id = ?", sourceID).First(&source).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, handler.NewBadRequestString(fmt.Sprintf("source %d not found", sourceID))
+		return nil, handler.NewInvalidParameterErr(fmt.Sprintf("source %d not found.", sourceID))
 	}
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	dsHandler, err := datasourceHandlerResolver.Resolve(ctx, source)
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	entry, err := dsHandler.Check(ctx, itemInfo.Path)
 	if err != nil {
-		return nil, handler.NewBadRequestError(err)
+		return nil, handler.ErrInvalidParameter{Err: err}
 	}
 
 	obj, ok := entry.(fs2.ObjectInfo)
 	if !ok {
-		return nil, handler.NewBadRequestString(fmt.Sprintf("%s is not an object", itemInfo.Path))
+		return nil, handler.NewInvalidParameterErr(fmt.Sprintf("%s is not an object", itemInfo.Path))
 	}
 
 	item, itemParts, err := datasetworker.PushItem(ctx, db, obj, source, *source.Dataset, map[string]uint64{})
 
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	if item == nil {
-		return nil, handler.NewConflictString(fmt.Sprintf("%s already exists", obj.Remote()))
+		return nil, handler.NewDuplicateRecordError(fmt.Sprintf("%s already exists", obj.Remote()))
 	}
 
 	item.ItemParts = itemParts

--- a/handler/datasource/remove.go
+++ b/handler/datasource/remove.go
@@ -14,8 +14,8 @@ import (
 // @Tags Data Source
 // @Param id path string true "Source ID"
 // @Success 204
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /source/{id} [delete]
 func removeSourceHandler(
 	db *gorm.DB,
@@ -24,18 +24,18 @@ func removeSourceHandler(
 	var source model.Source
 	sourceID, err := strconv.Atoi(id)
 	if err != nil {
-		return handler.NewBadRequestString("invalid source id")
+		return handler.NewInvalidParameterErr("invalid source id")
 	}
 	err = db.Where("id = ?", sourceID).First(&source).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return handler.NewBadRequestString("source not found")
+		return handler.NewInvalidParameterErr("source not found")
 	}
 	if err != nil {
-		return handler.NewHandlerError(err)
+		return err
 	}
 	err = database.DoRetry(func() error { return db.Delete(&source).Error })
 	if err != nil {
-		return handler.NewHandlerError(err)
+		return err
 	}
 	return nil
 }

--- a/handler/datasource/rescan.go
+++ b/handler/datasource/rescan.go
@@ -15,7 +15,7 @@ import (
 // @Produce json
 // @Param id path string true "Source ID"
 // @Success 200 {object} model.Source
-// @Failure 500 {object} handler.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /source/{id}/rescan [post]
 func rescanSourceHandler(
 	db *gorm.DB,
@@ -23,7 +23,7 @@ func rescanSourceHandler(
 ) (*model.Source, error) {
 	sourceID, err := strconv.Atoi(id)
 	if err != nil {
-		return nil, handler.NewBadRequestString("invalid source id")
+		return nil, handler.NewInvalidParameterErr("invalid source id")
 	}
 	var source model.Source
 	err = db.Transaction(func(db *gorm.DB) error {
@@ -44,10 +44,10 @@ func rescanSourceHandler(
 	})
 
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, handler.NewBadRequestString("source not found")
+		return nil, handler.NewInvalidParameterErr("source not found")
 	}
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	return &source, nil

--- a/handler/datasource/update.go
+++ b/handler/datasource/update.go
@@ -115,7 +115,7 @@ func updateSourceHandler(
 
 	_, err = h.List(ctx, "")
 	if err != nil {
-		return nil, handler.ErrInvalidParameter{Err: err}
+		return nil, handler.InvalidParameterError{Err: err}
 	}
 
 	err = database.DoRetry(func() error {

--- a/handler/deal/list.go
+++ b/handler/deal/list.go
@@ -1,7 +1,6 @@
 package deal
 
 import (
-	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/rjNemo/underscore"
 	"gorm.io/gorm"
@@ -25,8 +24,8 @@ func ListHandler(db *gorm.DB, request ListDealRequest) ([]model.Deal, error) {
 // @Produce json
 // @Param request body ListDealRequest true "ListDealRequest"
 // @Success 200 {array} model.Deal
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /deal [post]
 func listHandler(db *gorm.DB, request ListDealRequest) ([]model.Deal, error) {
 	var deals []model.Deal
@@ -35,7 +34,7 @@ func listHandler(db *gorm.DB, request ListDealRequest) ([]model.Deal, error) {
 		var datasets []model.Dataset
 		err := db.Where("name in ?", request.Datasets).Find(&datasets).Error
 		if err != nil {
-			return nil, handler.NewHandlerError(err)
+			return nil, err
 		}
 		statement = statement.Where("dataset_id IN ?", underscore.Map(datasets, func(dataset model.Dataset) uint32 { return dataset.ID }))
 	}
@@ -54,7 +53,7 @@ func listHandler(db *gorm.DB, request ListDealRequest) ([]model.Deal, error) {
 
 	err := db.Where(statement).Find(&deals).Error
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 	return deals, nil
 }

--- a/handler/deal/schedule/list.go
+++ b/handler/deal/schedule/list.go
@@ -1,7 +1,6 @@
 package schedule
 
 import (
-	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"gorm.io/gorm"
 )
@@ -10,8 +9,8 @@ import (
 // @Tags Deal Schedule
 // @Produce json
 // @Success 200 {array} model.Schedule
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /schedules [get]
 func listHandler(
 	db *gorm.DB,
@@ -19,7 +18,7 @@ func listHandler(
 	var schedules []model.Schedule
 	err := db.Find(&schedules).Error
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	return schedules, nil

--- a/handler/deal/schedule/pause.go
+++ b/handler/deal/schedule/pause.go
@@ -19,8 +19,8 @@ func PauseHandler(
 // @Produce json
 // @Param id path string true "Schedule ID"
 // @Success 200 {object} model.Schedule
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /schedule/{id}/pause [post]
 func pauseHandler(
 	db *gorm.DB,
@@ -29,20 +29,20 @@ func pauseHandler(
 	var schedule model.Schedule
 	err := db.First(&schedule, "id = ?", scheduleID).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, handler.NewBadRequestString("schedule not found")
+		return nil, handler.NewInvalidParameterErr("schedule not found")
 	}
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	if schedule.State == model.ScheduleCompleted {
-		return nil, handler.NewBadRequestString("schedule is already completed")
+		return nil, handler.NewInvalidParameterErr("schedule is already completed")
 	}
 
 	schedule.State = model.SchedulePaused
 	err = db.Model(&model.Schedule{}).Where("id = ?", scheduleID).Update("state", model.SchedulePaused).Error
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	return &schedule, nil

--- a/handler/deal/schedule/resume.go
+++ b/handler/deal/schedule/resume.go
@@ -19,8 +19,8 @@ func ResumeHandler(
 // @Produce json
 // @Param id path string true "Schedule ID"
 // @Success 200 {object} model.Schedule
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /schedule/{id}/resume [post]
 func resumeHandler(
 	db *gorm.DB,
@@ -29,18 +29,18 @@ func resumeHandler(
 	var schedule model.Schedule
 	err := db.First(&schedule, "id = ?", scheduleID).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, handler.NewBadRequestString("schedule not found")
+		return nil, handler.NewInvalidParameterErr("schedule not found")
 	}
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 	if schedule.State != model.SchedulePaused {
-		return nil, handler.NewBadRequestString("schedule is not paused")
+		return nil, handler.NewInvalidParameterErr("schedule is not paused")
 	}
 	schedule.State = model.ScheduleActive
 	err = db.Model(&model.Schedule{}).Where("id = ?", scheduleID).Update("state", model.ScheduleActive).Error
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	return &schedule, nil

--- a/handler/deal/send-manual_test.go
+++ b/handler/deal/send-manual_test.go
@@ -50,7 +50,7 @@ func TestSendManualHandler_WalletNotFound(t *testing.T) {
 
 	mockDealMaker := new(MockDealMaker)
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return(&model.Deal{}, nil)
-	_, err = SendManualHandler(db, ctx, proposal, mockDealMaker)
+	_, err = SendManualHandler(db, ctx, mockDealMaker, proposal)
 	require.ErrorContains(t, err, "client address not found")
 }
 
@@ -70,7 +70,7 @@ func TestSendManualHandler_InvalidPieceCID(t *testing.T) {
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return(&model.Deal{}, nil)
 	badProposal := proposal
 	badProposal.PieceCID = "bad"
-	_, err = SendManualHandler(db, ctx, badProposal, mockDealMaker)
+	_, err = SendManualHandler(db, ctx, mockDealMaker, badProposal)
 	require.ErrorContains(t, err, "invalid piece CID")
 }
 
@@ -90,7 +90,7 @@ func TestSendManualHandler_InvalidPieceCID_NOTCOMMP(t *testing.T) {
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return(&model.Deal{}, nil)
 	badProposal := proposal
 	badProposal.PieceCID = proposal.RootCID
-	_, err = SendManualHandler(db, ctx, badProposal, mockDealMaker)
+	_, err = SendManualHandler(db, ctx, mockDealMaker, badProposal)
 	require.ErrorContains(t, err, "piece CID must be commp")
 }
 
@@ -110,7 +110,7 @@ func TestSendManualHandler_InvalidPieceSize(t *testing.T) {
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return(&model.Deal{}, nil)
 	badProposal := proposal
 	badProposal.PieceSize = "aaa"
-	_, err = SendManualHandler(db, ctx, badProposal, mockDealMaker)
+	_, err = SendManualHandler(db, ctx, mockDealMaker, badProposal)
 	require.ErrorContains(t, err, "invalid piece size")
 }
 
@@ -130,7 +130,7 @@ func TestSendManualHandler_InvalidPieceSize_NotPowerOfTwo(t *testing.T) {
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return(&model.Deal{}, nil)
 	badProposal := proposal
 	badProposal.PieceSize = "31GiB"
-	_, err = SendManualHandler(db, ctx, badProposal, mockDealMaker)
+	_, err = SendManualHandler(db, ctx, mockDealMaker, badProposal)
 	require.ErrorContains(t, err, "piece size must be a power of 2")
 }
 
@@ -150,7 +150,7 @@ func TestSendManualHandler_InvalidRootCID(t *testing.T) {
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return(&model.Deal{}, nil)
 	badProposal := proposal
 	badProposal.RootCID = "xxxx"
-	_, err = SendManualHandler(db, ctx, badProposal, mockDealMaker)
+	_, err = SendManualHandler(db, ctx, mockDealMaker, badProposal)
 	require.ErrorContains(t, err, "invalid root CID")
 }
 
@@ -170,7 +170,7 @@ func TestSendManualHandler_InvalidDuration(t *testing.T) {
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return(&model.Deal{}, nil)
 	badProposal := proposal
 	badProposal.Duration = "xxxx"
-	_, err = SendManualHandler(db, ctx, badProposal, mockDealMaker)
+	_, err = SendManualHandler(db, ctx, mockDealMaker, badProposal)
 	require.ErrorContains(t, err, "invalid duration")
 }
 
@@ -190,7 +190,7 @@ func TestSendManualHandler_InvalidStartDelay(t *testing.T) {
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return(&model.Deal{}, nil)
 	badProposal := proposal
 	badProposal.StartDelay = "xxxx"
-	_, err = SendManualHandler(db, ctx, badProposal, mockDealMaker)
+	_, err = SendManualHandler(db, ctx, mockDealMaker, badProposal)
 	require.ErrorContains(t, err, "invalid start delay")
 }
 
@@ -208,7 +208,7 @@ func TestSendManualHandler(t *testing.T) {
 
 	mockDealMaker := new(MockDealMaker)
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return(&model.Deal{}, nil)
-	resp, err := SendManualHandler(db, ctx, proposal, mockDealMaker)
+	resp, err := SendManualHandler(db, ctx, mockDealMaker, proposal)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 }

--- a/handler/errors.go
+++ b/handler/errors.go
@@ -6,48 +6,48 @@ import (
 	"github.com/pkg/errors"
 )
 
-type ErrInvalidParameter struct {
+type InvalidParameterError struct {
 	Err error
 }
 
-func (e ErrInvalidParameter) Unwrap() error {
+func (e InvalidParameterError) Unwrap() error {
 	return e.Err
 }
-func (e ErrInvalidParameter) Error() string {
+func (e InvalidParameterError) Error() string {
 	return fmt.Sprintf("invalid parameter: %s", e.Err.Error())
 }
 
-func NewInvalidParameterErr(err string) ErrInvalidParameter {
-	return ErrInvalidParameter{
+func NewInvalidParameterErr(err string) InvalidParameterError {
+	return InvalidParameterError{
 		Err: errors.New(err),
 	}
 }
 
-type ErrNotFound struct {
+type NotFoundError struct {
 	Err error
 }
 
-func (e ErrNotFound) Unwrap() error {
+func (e NotFoundError) Unwrap() error {
 	return e.Err
 }
-func (e ErrNotFound) Error() string {
+func (e NotFoundError) Error() string {
 	return fmt.Sprintf("not found: %s", e.Err.Error())
 }
 
-type ErrDuplicateRecord struct {
+type DuplicateRecordError struct {
 	Err error
 }
 
-func (e ErrDuplicateRecord) Unwrap() error {
+func (e DuplicateRecordError) Unwrap() error {
 	return e.Err
 }
 
-func (e ErrDuplicateRecord) Error() string {
+func (e DuplicateRecordError) Error() string {
 	return fmt.Sprintf("duplicate record: %s", e.Err.Error())
 }
 
-func NewDuplicateRecordError(err string) ErrDuplicateRecord {
-	return ErrDuplicateRecord{
+func NewDuplicateRecordError(err string) DuplicateRecordError {
+	return DuplicateRecordError{
 		Err: errors.New(err),
 	}
 }

--- a/handler/errors.go
+++ b/handler/errors.go
@@ -1,89 +1,53 @@
 package handler
 
 import (
-	"net/http"
+	"fmt"
 
-	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 )
 
-type Error struct {
-	Err            error
-	HTTPStatusCode int
+type ErrInvalidParameter struct {
+	Err error
 }
 
-type HTTPError struct {
-	Err string `json:"err"`
+func (e ErrInvalidParameter) Unwrap() error {
+	return e.Err
+}
+func (e ErrInvalidParameter) Error() string {
+	return fmt.Sprintf("invalid parameter: %s", e.Err.Error())
 }
 
-func (e *Error) HTTPResponse(c echo.Context) error {
-	if e == nil {
-		return c.String(http.StatusOK, "OK")
-	}
-
-	if e.HTTPStatusCode == 0 {
-		e.HTTPStatusCode = http.StatusInternalServerError
-	}
-
-	return c.JSON(e.HTTPStatusCode, HTTPError{Err: e.Error()})
-}
-
-func (e *Error) Error() string {
-	return e.Err.Error()
-}
-
-func NewBadRequestError(err error) *Error {
-	return &Error{
-		Err:            err,
-		HTTPStatusCode: http.StatusBadRequest,
+func NewInvalidParameterErr(err string) ErrInvalidParameter {
+	return ErrInvalidParameter{
+		Err: errors.New(err),
 	}
 }
 
-func NewBadRequestString(err string) *Error {
-	return &Error{
-		Err:            errors.New(err),
-		HTTPStatusCode: http.StatusBadRequest,
-	}
+type ErrNotFound struct {
+	Err error
 }
 
-func NewNotFoundError(err error) *Error {
-	return &Error{
-		Err:            err,
-		HTTPStatusCode: http.StatusNotFound,
-	}
+func (e ErrNotFound) Unwrap() error {
+	return e.Err
+}
+func (e ErrNotFound) Error() string {
+	return fmt.Sprintf("not found: %s", e.Err.Error())
 }
 
-func NewNotFoundString(err string) *Error {
-	return &Error{
-		Err:            errors.New(err),
-		HTTPStatusCode: http.StatusNotFound,
-	}
+type ErrDuplicateRecord struct {
+	Err error
 }
 
-func NewConflictError(err error) *Error {
-	return &Error{
-		Err:            err,
-		HTTPStatusCode: http.StatusConflict,
-	}
+func (e ErrDuplicateRecord) Unwrap() error {
+	return e.Err
 }
 
-func NewConflictString(err string) *Error {
-	return &Error{
-		Err:            errors.New(err),
-		HTTPStatusCode: http.StatusConflict,
-	}
+func (e ErrDuplicateRecord) Error() string {
+	return fmt.Sprintf("duplicate record: %s", e.Err.Error())
 }
 
-func NewHTTPError(code int, err string) *Error {
-	return &Error{
-		Err:            errors.New(err),
-		HTTPStatusCode: code,
-	}
-}
-
-func NewHandlerError(err error) *Error {
-	return &Error{
-		Err:            err,
-		HTTPStatusCode: http.StatusInternalServerError,
+func NewDuplicateRecordError(err string) ErrDuplicateRecord {
+	return ErrDuplicateRecord{
+		Err: errors.New(err),
 	}
 }

--- a/handler/tool/extractcar.go
+++ b/handler/tool/extractcar.go
@@ -9,7 +9,7 @@ import (
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-ipfs-blockstore"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	ipld "github.com/ipfs/go-ipld-format"
 	"github.com/ipfs/go-merkledag"
 	"github.com/ipfs/go-unixfs"
@@ -205,7 +205,7 @@ func writeToOutput(ctx context.Context, dagServ ipld.DAGService, outPath string,
 			if err != nil {
 				return errors.Wrapf(err, "failed to iterate links for CID %s", c)
 			}
-		default:
+		case unixfs.TRaw, unixfs.TMetadata, unixfs.TSymlink:
 			return errors.Errorf("unsupported node type %d", fsnode.Type())
 		}
 	default:

--- a/handler/wallet/addwallet.go
+++ b/handler/wallet/addwallet.go
@@ -22,8 +22,8 @@ func AddWalletHandler(
 // @Param datasetName path string true "Dataset name"
 // @Param wallet path string true "Wallet Address"
 // @Success 200 {object} model.WalletAssignment
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /dataset/{datasetName}/wallet/{wallet} [post]
 func addWalletHandler(
 	db *gorm.DB,
@@ -31,22 +31,22 @@ func addWalletHandler(
 	wallet string,
 ) (*model.WalletAssignment, error) {
 	if datasetName == "" {
-		return nil, handler.NewBadRequestString("dataset name is required")
+		return nil, handler.NewInvalidParameterErr("dataset name is required")
 	}
 
 	if wallet == "" {
-		return nil, handler.NewBadRequestString("wallet address is required")
+		return nil, handler.NewInvalidParameterErr("wallet address is required")
 	}
 
 	dataset, err := database.FindDatasetByName(db, datasetName)
 	if err != nil {
-		return nil, handler.NewBadRequestString("failed to find dataset: " + err.Error())
+		return nil, handler.NewInvalidParameterErr("failed to find dataset: " + err.Error())
 	}
 
 	var w model.Wallet
 	err = db.Where("address = ? OR id = ?", wallet, wallet).First(&w).Error
 	if err != nil {
-		return nil, handler.NewBadRequestString("failed to find wallet: " + err.Error())
+		return nil, handler.NewInvalidParameterErr("failed to find wallet: " + err.Error())
 	}
 
 	a := model.WalletAssignment{
@@ -59,7 +59,7 @@ func addWalletHandler(
 	})
 
 	if err != nil {
-		return nil, handler.NewBadRequestString("failed to create wallet assignment: " + err.Error())
+		return nil, handler.NewInvalidParameterErr("failed to create wallet assignment: " + err.Error())
 	}
 
 	return &a, nil

--- a/handler/wallet/import.go
+++ b/handler/wallet/import.go
@@ -30,8 +30,8 @@ func ImportHandler(
 // @Produce json
 // @Param request body ImportRequest true "Request body"
 // @Success 200 {object} model.Wallet
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /wallet [post]
 func importHandler(
 	db *gorm.DB,
@@ -41,18 +41,18 @@ func importHandler(
 ) (*model.Wallet, error) {
 	addr, err := wallet.PublicKey(request.PrivateKey)
 	if err != nil {
-		return nil, handler.NewBadRequestString("invalid private key")
+		return nil, handler.NewInvalidParameterErr("invalid private key")
 	}
 
 	var result string
 	err = lotusClient.CallFor(ctx, &result, "Filecoin.StateLookupID", addr.String(), nil)
 	if err != nil {
-		return nil, handler.NewBadRequestString("invalid private key")
+		return nil, handler.NewInvalidParameterErr("invalid private key")
 	}
 
 	_, err = address.NewFromString(result)
 	if err != nil {
-		return nil, handler.NewBadRequestString("invalid actor ID from GLIF result: " + result)
+		return nil, handler.NewInvalidParameterErr("invalid actor ID from GLIF result: " + result)
 	}
 
 	wallet := model.Wallet{
@@ -65,7 +65,7 @@ func importHandler(
 		return db.Create(&wallet).Error
 	})
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	return &wallet, nil

--- a/handler/wallet/list.go
+++ b/handler/wallet/list.go
@@ -1,7 +1,6 @@
 package wallet
 
 import (
-	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"gorm.io/gorm"
 )
@@ -16,8 +15,8 @@ func ListHandler(
 // @Tags Wallet
 // @Produce json
 // @Success 200 {array} model.Wallet
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /wallet [get]
 func listHandler(
 	db *gorm.DB,
@@ -26,7 +25,7 @@ func listHandler(
 
 	err := db.Find(&wallets).Error
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	return wallets, nil

--- a/handler/wallet/listwallet.go
+++ b/handler/wallet/listwallet.go
@@ -19,24 +19,24 @@ func ListWalletHandler(
 // @Produce json
 // @Param datasetName path string true "Dataset name"
 // @Success 200 {array} model.Wallet
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /dataset/{datasetName}/wallet [get]
 func listWalletHandler(
 	db *gorm.DB,
 	datasetName string,
 ) ([]model.Wallet, error) {
 	if datasetName == "" {
-		return nil, handler.NewBadRequestString("dataset name is required")
+		return nil, handler.NewInvalidParameterErr("dataset name is required")
 	}
 
 	var dataset model.Dataset
 	err := db.Preload("Wallets").Where("name = ?", datasetName).First(&dataset).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, handler.NewBadRequestString("dataset not found")
+		return nil, handler.NewInvalidParameterErr("dataset not found")
 	}
 	if err != nil {
-		return nil, handler.NewHandlerError(err)
+		return nil, err
 	}
 
 	return dataset.Wallets, nil

--- a/handler/wallet/remove.go
+++ b/handler/wallet/remove.go
@@ -2,7 +2,6 @@ package wallet
 
 import (
 	"github.com/data-preservation-programs/singularity/database"
-	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"gorm.io/gorm"
 )
@@ -18,8 +17,8 @@ func RemoveHandler(
 // @Tags Wallet
 // @Param address path string true "Address"
 // @Success 204
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /wallet/{address} [delete]
 func removeHandler(
 	db *gorm.DB,
@@ -27,7 +26,7 @@ func removeHandler(
 ) error {
 	err := database.DoRetry(func() error { return db.Where("address = ? OR id = ?", address, address).Delete(&model.Wallet{}).Error })
 	if err != nil {
-		return handler.NewHandlerError(err)
+		return err
 	}
 	return nil
 }

--- a/handler/wallet/removewallet.go
+++ b/handler/wallet/removewallet.go
@@ -20,8 +20,8 @@ func RemoveWalletHandler(
 // @Param datasetName path string true "Dataset name"
 // @Param wallet path string true "Wallet Address"
 // @Success 204
-// @Failure 400 {object} handler.HTTPError
-// @Failure 500 {object} handler.HTTPError
+// @Failure 400 {object} api.HTTPError
+// @Failure 500 {object} api.HTTPError
 // @Router /dataset/{datasetName}/wallet/{wallet} [delete]
 func removeWalletHandler(
 	db *gorm.DB,
@@ -29,22 +29,22 @@ func removeWalletHandler(
 	wallet string,
 ) error {
 	if datasetName == "" {
-		return handler.NewBadRequestString("dataset name is required")
+		return handler.NewInvalidParameterErr("dataset name is required")
 	}
 
 	if wallet == "" {
-		return handler.NewBadRequestString("wallet address is required")
+		return handler.NewInvalidParameterErr("wallet address is required")
 	}
 
 	dataset, err := database.FindDatasetByName(db, datasetName)
 	if err != nil {
-		return handler.NewBadRequestString("failed to find dataset: " + err.Error())
+		return handler.NewInvalidParameterErr("failed to find dataset: " + err.Error())
 	}
 
 	var w model.Wallet
 	err = db.Where("address = ? OR id = ?", wallet, wallet).First(&w).Error
 	if err != nil {
-		return handler.NewBadRequestString("failed to find wallet: " + err.Error())
+		return handler.NewInvalidParameterErr("failed to find wallet: " + err.Error())
 	}
 
 	err = database.DoRetry(func() error {
@@ -52,7 +52,7 @@ func removeWalletHandler(
 	})
 
 	if err != nil {
-		return handler.NewHandlerError(err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
# Goals

Adds an API for interacting with singularity over HTTP or through code

# Implementation

- refactor errors so handlers no longer require HTTP codes, but are also identifiable by type
- move conversion of errors to response codes to the api handler
- clean up some of the error generation
- add a client interface (so far, just what Motion needs, but to be expanded upon)
- add a direct code implementation and a implementation based on the HTTP API