### PR TITLE
Refactor health check report to only allow once instance

### DIFF
--- a/service/datasetworker/datasetworker.go
+++ b/service/datasetworker/datasetworker.go
@@ -88,6 +88,11 @@ func (w DatasetWorker) Run(parent context.Context) error {
 			config:                    w.config,
 		}
 		w.threads[i] = thread
+		_, err := healthcheck.Register(ctx, w.db, thread.id, thread.getState, true)
+		if err != nil {
+			logger.Errorw("failed to register worker", "error", err)
+			continue
+		}
 		go thread.run(ctx, errChan, &wg)
 	}
 
@@ -131,8 +136,7 @@ func (w *DatasetWorkerThread) run(ctx context.Context, errChan chan<- error, wg 
 			errChan <- errors.Errorf("panic: %v", err)
 		}
 	}()
-	healthcheck.HealthCheck(w.db, w.id, w.getState)
-	go healthcheck.StartHealthCheck(ctx, w.db, w.id, w.getState)
+	go healthcheck.StartReportHealth(ctx, w.db, w.id, w.getState)
 	for {
 		w.directoryCache = map[string]uint64{}
 		// 0, find dag work

--- a/service/dealmaker/dealmaker.go
+++ b/service/dealmaker/dealmaker.go
@@ -302,8 +302,6 @@ func NewDealMakerService(db *gorm.DB, lotusURL string,
 	}, nil
 }
 
-var staleThreshold = time.Minute * 5
-
 func (d *DealMakerService) runOnce(ctx context.Context) {
 	var schedules []model.Schedule
 	scheduleMap := map[uint32]model.Schedule{}
@@ -339,29 +337,37 @@ func (d *DealMakerService) runOnce(ctx context.Context) {
 }
 
 func (d *DealMakerService) Run(ctx context.Context) error {
-	var activeWorkerCount int64
-	err := d.db.Model(&model.Worker{}).Where("work_type = ? AND last_heartbeat > ?", model.DealMaking, time.Now().UTC().Add(-staleThreshold)).
-		Count(&activeWorkerCount).Error
-	if err != nil {
-		return errors.Wrap(err, "failed to count active workers")
-	}
-	if activeWorkerCount > 0 {
-		return errors.New("deal maker already running")
-	}
-
-	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM, syscall.SIGTRAP)
-
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-
 	getState := func() healthcheck.State {
 		return healthcheck.State{
 			WorkType: model.DealMaking,
 		}
 	}
-	healthcheck.HealthCheck(d.db, d.workerID, getState)
-	go healthcheck.StartHealthCheck(ctx, d.db, d.workerID, getState)
+
+	for {
+		alreadyRunning, err := healthcheck.Register(ctx, d.db, d.workerID, getState, false)
+		if err == nil && !alreadyRunning {
+			break
+		}
+		if err != nil {
+			logger.Errorw("failed to register worker", "error", err)
+		}
+		if alreadyRunning {
+			logger.Warnw("another worker already running")
+		}
+		logger.Warn("retrying in 1 minute")
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Minute):
+		}
+	}
+
+	go healthcheck.StartReportHealth(ctx, d.db, d.workerID, getState)
+
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM, syscall.SIGTRAP)
 
 	d.cron.Start()
 	for {

--- a/service/dealtracker/dealtracker.go
+++ b/service/dealtracker/dealtracker.go
@@ -160,33 +160,38 @@ func (d *DealTracker) dealStateStream(ctx context.Context) (chan *jstream.MetaVa
 	return DealStateStreamFromHTTPRequest(req, 2, false)
 }
 
-var staleThreshold = time.Minute * 5
-
 func (d *DealTracker) Run(ctx context.Context) error {
-	var activeWorkerCount int64
-	err := d.db.WithContext(ctx).Model(&model.Worker{}).Where("work_type = ? AND last_heartbeat > ?", model.DealTracking, time.Now().UTC().Add(-staleThreshold)).
-		Count(&activeWorkerCount).Error
-	if err != nil {
-		return errors.Wrap(err, "failed to count active workers")
-	}
-	if activeWorkerCount > 0 {
-		return errors.New("deal tracker already running")
-	}
-
-	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM, syscall.SIGTRAP)
-
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-
 	getState := func() healthcheck.State {
 		return healthcheck.State{
 			WorkType: model.DealTracking,
 		}
 	}
 
-	healthcheck.StartHealthCheck(ctx, d.db, d.workerID, getState)
-	go healthcheck.StartHealthCheck(ctx, d.db, d.workerID, getState)
+	for {
+		alreadyRunning, err := healthcheck.Register(ctx, d.db, d.workerID, getState, false)
+		if err == nil && !alreadyRunning {
+			break
+		}
+		if err != nil {
+			logger.Errorw("failed to register worker", "error", err)
+		}
+		if alreadyRunning {
+			logger.Warnw("another worker already running")
+		}
+		logger.Warn("retrying in 1 minute")
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Minute):
+		}
+	}
+
+	go healthcheck.StartReportHealth(ctx, d.db, d.workerID, getState)
+
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM, syscall.SIGTRAP)
 
 	go func() {
 		for {


### PR DESCRIPTION
Allow only once instance of deal maker and deal tracker. Later we will also only allow one instance of metrics reporter.