### PR TITLE
Add support for testnet/calibnet

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -26,20 +26,31 @@ import (
 )
 
 var App = &cli.App{
-	Name:                 "singularity",
-	Usage:                "A tool for large-scale clients with PB-scale data onboarding to Filecoin network",
+	Name:  "singularity",
+	Usage: "A tool for large-scale clients with PB-scale data onboarding to Filecoin network",
+	Description: `Database Backend Support:
+  Singularity supports multiple database backend: sqlite3, postgres, mysql
+  Use '--database-connection-string' or $DATABASE_CONNECTION_STRING to specify the database connection string.
+    Example for postgres  - postgres://user:pass@example.com:5432/dbname
+    Example for mysql     - mysql://user:pass@tcp(localhost:3306)/dbname?charset=ascii&parseTime=true
+                            Note: the database needs to be created using ascii Character Set:
+                              CREATE DATABASE <dbname> DEFAULT CHARACTER SET ascii
+    Example for sqlite3   - sqlite:/absolute/path/to/database.db
+                or        - sqlite:relative/path/to/database.db
+
+Network Support:
+  Default settings in Singularity are for Mainnet. You may set below environment values for other network:
+    For Calibration network:
+      * Set LOTUS_API to https://api.calibration.node.glif.io/rpc/v1
+      * Set MARKET_DEAL_URL to https://marketdeals-calibration.s3.amazonaws.com/StateMarketDeals.json.zst
+    For all other networks:
+      * Set LOTUS_API to your network's Lotus API endpoint
+      * Set MARKET_DEAL_URL to empty string`,
 	EnableBashCompletion: true,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name: "database-connection-string",
-			Usage: "Connection string to the database.\n" +
-				"Supported database: sqlite3, postgres, mysql\n" +
-				"Example for postgres  - postgres://user:pass@example.com:5432/dbname\n" +
-				"Example for mysql     - mysql://user:pass@tcp(localhost:3306)/dbname?charset=ascii&parseTime=true\n" +
-				"                          Note: the database needs to be created using ascii Character Set:" +
-				"                                `CREATE DATABASE <dbname> DEFAULT CHARACTER SET ascii`\n" +
-				"Example for sqlite3   - sqlite:/absolute/path/to/database.db\n" +
-				"            or        - sqlite:relative/path/to/database.db\n",
+			Name:        "database-connection-string",
+			Usage:       "Connection string to the database",
 			DefaultText: "sqlite:" + must.String(os.UserHomeDir()) + "/.singularity/singularity.db",
 			Value:       "sqlite:" + must.String(os.UserHomeDir()) + "/.singularity/singularity.db",
 			EnvVars:     []string{"DATABASE_CONNECTION_STRING"},
@@ -54,12 +65,14 @@ var App = &cli.App{
 			Category: "Lotus",
 			Usage:    "Lotus RPC API endpoint",
 			Value:    "https://api.node.glif.io/rpc/v1",
+			EnvVars:  []string{"LOTUS_API"},
 		},
 		&cli.StringFlag{
 			Name:     "lotus-token",
 			Category: "Lotus",
 			Usage:    "Lotus RPC API token",
 			Value:    "",
+			EnvVars:  []string{"LOTUS_TOKEN"},
 		},
 	},
 	Commands: []*cli.Command{

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -45,7 +45,8 @@ Network Support:
       * Set MARKET_DEAL_URL to https://marketdeals-calibration.s3.amazonaws.com/StateMarketDeals.json.zst
     For all other networks:
       * Set LOTUS_API to your network's Lotus API endpoint
-      * Set MARKET_DEAL_URL to empty string`,
+      * Set MARKET_DEAL_URL to empty string
+    Switching between different networks with the same database instance is not recommended.`,
 	EnableBashCompletion: true,
 	Flags: []cli.Flag{
 		&cli.StringFlag{

--- a/cmd/deal/send-manual.go
+++ b/cmd/deal/send-manual.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/data-preservation-programs/singularity/cmd/cliutil"
 	"github.com/data-preservation-programs/singularity/replication"
+	"github.com/data-preservation-programs/singularity/service/epochutil"
 	"github.com/data-preservation-programs/singularity/util"
 	"github.com/pkg/errors"
 
@@ -95,18 +96,6 @@ var SendManualCmd = &cli.Command{
 			Value:       "12840h",
 			DefaultText: "12840h[535 days]",
 		},
-		&cli.StringFlag{
-			Name:     "lotus-api",
-			Category: "Lotus",
-			Usage:    "Lotus RPC API endpoint, only used to get miner info",
-			Value:    "https://api.node.glif.io/rpc/v1",
-		},
-		&cli.StringFlag{
-			Name:     "lotus-token",
-			Category: "Lotus",
-			Usage:    "Lotus RPC API token, only used to get miner info",
-			Value:    "",
-		},
 		&cli.DurationFlag{
 			Name:        "timeout",
 			Usage:       "Timeout for the deal proposal",
@@ -115,6 +104,12 @@ var SendManualCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
+		lotusAPI := cctx.String("lotus-api")
+		lotusToken := cctx.String("lotus-token")
+		err := epochutil.Initialize(cctx.Context, lotusAPI, lotusToken)
+		if err != nil {
+			return err
+		}
 		proposal := deal.Proposal{
 			HTTPHeaders:     cctx.StringSlice("http-header"),
 			URLTemplate:     cctx.String("url-template"),

--- a/cmd/run/dealmaker.go
+++ b/cmd/run/dealmaker.go
@@ -5,6 +5,7 @@ import (
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/service/dealmaker"
+	"github.com/data-preservation-programs/singularity/service/epochutil"
 	"github.com/urfave/cli/v2"
 )
 
@@ -19,6 +20,14 @@ var DealMakerCmd = &cli.Command{
 		if err := model.AutoMigrate(db); err != nil {
 			return handler.NewHandlerError(err)
 		}
+
+		lotusAPI := c.String("lotus-api")
+		lotusToken := c.String("lotus-token")
+		err = epochutil.Initialize(c.Context, lotusAPI, lotusToken)
+		if err != nil {
+			return err
+		}
+
 		dealMaker, err := dealmaker.NewDealMakerService(db, c.String("lotus-api"), c.String("lotus-token"))
 		if err != nil {
 			return cli.Exit(err.Error(), 1)

--- a/cmd/run/dealtracker.go
+++ b/cmd/run/dealtracker.go
@@ -7,6 +7,7 @@ import (
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/service/dealtracker"
+	"github.com/data-preservation-programs/singularity/service/epochutil"
 	"github.com/urfave/cli/v2"
 )
 
@@ -18,6 +19,7 @@ var DealTrackerCmd = &cli.Command{
 			Name:    "market-deal-url",
 			Usage:   "The URL for ZST compressed state market deals json. Set to empty to use Lotus API.",
 			Aliases: []string{"m"},
+			EnvVars: []string{"MARKET_DEAL_URL"},
 			Value:   "https://marketdeals.s3.amazonaws.com/StateMarketDeals.json.zst",
 		},
 		&cli.DurationFlag{
@@ -34,6 +36,13 @@ var DealTrackerCmd = &cli.Command{
 		}
 		if err := model.AutoMigrate(db); err != nil {
 			return handler.NewHandlerError(err)
+		}
+
+		lotusAPI := c.String("lotus-api")
+		lotusToken := c.String("lotus-token")
+		err = epochutil.Initialize(c.Context, lotusAPI, lotusToken)
+		if err != nil {
+			return err
 		}
 
 		tracker := dealtracker.NewDealTracker(db,

--- a/handler/wallet/addremote.go
+++ b/handler/wallet/addremote.go
@@ -41,7 +41,6 @@ func addRemoteHandler(
 	lotusClient jsonrpc.RPCClient,
 	request AddRemoteRequest,
 ) (*model.Wallet, error) {
-	address.CurrentNetwork = address.Mainnet
 	addr, err := address.NewFromString(request.Address)
 	if err != nil {
 		return nil, handler.NewBadRequestString("invalid address")
@@ -64,7 +63,7 @@ func addRemoteHandler(
 
 	wallet := model.Wallet{
 		ID:         result,
-		Address:    addr.String(),
+		Address:    request.Address,
 		RemotePeer: request.RemotePeer,
 	}
 

--- a/handler/wallet/import.go
+++ b/handler/wallet/import.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
+	"github.com/filecoin-project/go-address"
 	"github.com/jsign/go-filsigner/wallet"
 	"github.com/ybbus/jsonrpc/v3"
 	"gorm.io/gorm"
@@ -47,6 +48,11 @@ func importHandler(
 	err = lotusClient.CallFor(ctx, &result, "Filecoin.StateLookupID", addr.String(), nil)
 	if err != nil {
 		return nil, handler.NewBadRequestString("invalid private key")
+	}
+
+	_, err = address.NewFromString(result)
+	if err != nil {
+		return nil, handler.NewBadRequestString("invalid actor ID from GLIF result: " + result)
 	}
 
 	wallet := model.Wallet{

--- a/handler/wallet/import.go
+++ b/handler/wallet/import.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
-	"github.com/filecoin-project/go-address"
 	"github.com/jsign/go-filsigner/wallet"
 	"github.com/ybbus/jsonrpc/v3"
 	"gorm.io/gorm"
@@ -39,7 +38,6 @@ func importHandler(
 	lotusClient jsonrpc.RPCClient,
 	request ImportRequest,
 ) (*model.Wallet, error) {
-	address.CurrentNetwork = address.Mainnet
 	addr, err := wallet.PublicKey(request.PrivateKey)
 	if err != nil {
 		return nil, handler.NewBadRequestString("invalid private key")
@@ -53,7 +51,7 @@ func importHandler(
 
 	wallet := model.Wallet{
 		ID:         result,
-		Address:    addr.String(),
+		Address:    result[:1] + addr.String()[1:],
 		PrivateKey: request.PrivateKey,
 	}
 

--- a/model/replication.go
+++ b/model/replication.go
@@ -8,18 +8,6 @@ import (
 
 type DealState string
 
-func EpochToTime(epoch int32) time.Time {
-	//nolint:gomnd
-	return time.Unix(int64(epoch)*30+1598306400, 0)
-}
-func EpochToUnix(epoch int32) int32 {
-	return epoch*30 + 1598306400
-}
-
-func UnixToEpoch(unix int64) int32 {
-	return (int32(unix) - 1598306400) / 30
-}
-
 type ScheduleState string
 
 const (

--- a/replication/makedeal.go
+++ b/replication/makedeal.go
@@ -11,6 +11,7 @@ import (
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/replication/internal/proposal110"
 	"github.com/data-preservation-programs/singularity/replication/internal/proposal120"
+	"github.com/data-preservation-programs/singularity/service/epochutil"
 	"github.com/filecoin-project/go-address"
 	cborutil "github.com/filecoin-project/go-cbor-util"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -33,14 +34,6 @@ const (
 	StorageProposalV120 = "/fil/storage/mk/1.2.0"
 	StorageProposalV111 = "/fil/storage/mk/1.1.1"
 )
-
-func TimeToEpoch(t time.Time) abi.ChainEpoch {
-	return abi.ChainEpoch((t.Unix() - 1598306400) / 30)
-}
-
-func EpochToTime(epoch abi.ChainEpoch) time.Time {
-	return time.Unix(int64(epoch*30+1598306400), 0)
-}
 
 // nolint: tagliatelle
 type MinerInfo struct {
@@ -356,8 +349,8 @@ func (d DealMakerImpl) MakeDeal(ctx context.Context, walletObj model.Wallet,
 		return nil, errors.Wrap(err, "failed to get supported protocol")
 	}
 
-	startEpoch := TimeToEpoch(now.Add(dealConfig.StartDelay))
-	endEpoch := TimeToEpoch(now.Add(dealConfig.StartDelay + dealConfig.Duration))
+	startEpoch := epochutil.TimeToEpoch(now.Add(dealConfig.StartDelay))
+	endEpoch := epochutil.TimeToEpoch(now.Add(dealConfig.StartDelay + dealConfig.Duration))
 	price := dealConfig.GetPrice(car.PieceSize, dealConfig.Duration)
 	verified := dealConfig.Verified
 	pieceCID := cid.Cid(car.PieceCID)

--- a/service/dealmaker/dealmaker_test.go
+++ b/service/dealmaker/dealmaker_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/pack"
 	"github.com/data-preservation-programs/singularity/replication"
+	"github.com/data-preservation-programs/singularity/service/epochutil"
 	commp "github.com/filecoin-project/go-fil-commp-hashhash"
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
@@ -35,8 +36,8 @@ func (m *MockDealMaker) MakeDeal(ctx context.Context, walletObj model.Wallet, ca
 	deal.ProposalID = uuid.NewString()
 	deal.State = model.DealProposed
 	now := time.Now()
-	startEpoch := replication.TimeToEpoch(now.Add(dealConfig.StartDelay))
-	endEpoch := replication.TimeToEpoch(now.Add(dealConfig.StartDelay + dealConfig.Duration))
+	startEpoch := epochutil.TimeToEpoch(now.Add(dealConfig.StartDelay))
+	endEpoch := epochutil.TimeToEpoch(now.Add(dealConfig.StartDelay + dealConfig.Duration))
 	if deal.StartEpoch == 0 {
 		deal.StartEpoch = int32(startEpoch)
 	}

--- a/service/dealtracker/dealtracker.go
+++ b/service/dealtracker/dealtracker.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/data-preservation-programs/singularity/service/epochutil"
 	"github.com/data-preservation-programs/singularity/service/healthcheck"
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
@@ -42,12 +43,12 @@ func (d Deal) GetState() model.DealState {
 		return model.DealSlashed
 	}
 	if d.State.SectorStartEpoch < 0 {
-		if model.EpochToTime(d.Proposal.StartEpoch).Before(time.Now()) {
+		if epochutil.EpochToTime(d.Proposal.StartEpoch).Before(time.Now()) {
 			return model.DealProposalExpired
 		}
 		return model.DealPublished
 	}
-	if model.EpochToTime(d.Proposal.EndEpoch).Before(time.Now()) {
+	if epochutil.EpochToTime(d.Proposal.EndEpoch).Before(time.Now()) {
 		return model.DealExpired
 	}
 	return model.DealActive
@@ -237,7 +238,7 @@ func (d *DealTracker) runOnce(ctx context.Context) error {
 	// Clean up the deals table before querying
 	// We want to mark all deals that has expired as expired
 	err = d.db.WithContext(ctx).Model(&model.Deal{}).
-		Where("end_epoch < ?", model.UnixToEpoch(time.Now().Unix())).
+		Where("end_epoch < ?", epochutil.UnixToEpoch(time.Now().Unix())).
 		Update("state", model.DealExpired).Error
 	if err != nil {
 		return errors.Wrap(err, "failed to update deals to expired")

--- a/service/epochutil/epoch.go
+++ b/service/epochutil/epoch.go
@@ -1,0 +1,53 @@
+package epochutil
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/data-preservation-programs/singularity/util"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/pkg/errors"
+)
+
+var GENESIS_TIMESTAMP = int32(1598306400)
+
+type result struct {
+	Blocks []block
+}
+
+type block struct {
+	Timestamp int32
+}
+
+func Initialize(ctx context.Context, lotusAPI string, lotusToken string) error {
+	if strings.HasPrefix(lotusAPI, "https://api.node.glif.io/rpc") {
+		return nil
+	}
+
+	client := util.NewLotusClient(lotusAPI, lotusToken)
+	var r result
+	err := client.CallFor(ctx, &r, "Filecoin.ChainGetGenesis")
+	if err != nil {
+		return errors.Wrap(err, "failed to decide genesis timestamp")
+	}
+
+	if len(r.Blocks) == 0 {
+		return errors.New("length of blocks from genesis is 0")
+	}
+
+	GENESIS_TIMESTAMP = r.Blocks[0].Timestamp
+	return nil
+}
+
+func EpochToTime(epoch int32) time.Time {
+	return time.Unix(int64(epoch)*30+int64(GENESIS_TIMESTAMP), 0)
+}
+
+func UnixToEpoch(unix int64) int32 {
+	return (int32(unix) - GENESIS_TIMESTAMP) / 30
+}
+
+func TimeToEpoch(t time.Time) abi.ChainEpoch {
+	return abi.ChainEpoch((t.Unix() - int64(GENESIS_TIMESTAMP)) / 30)
+}

--- a/service/epochutil/epoch.go
+++ b/service/epochutil/epoch.go
@@ -22,6 +22,7 @@ type block struct {
 
 func Initialize(ctx context.Context, lotusAPI string, lotusToken string) error {
 	if strings.HasPrefix(lotusAPI, "https://api.node.glif.io/rpc") {
+		GenesisTimestamp = int32(1598306400)
 		return nil
 	}
 

--- a/service/epochutil/epoch.go
+++ b/service/epochutil/epoch.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var GENESIS_TIMESTAMP = int32(1598306400)
+var GenesisTimestamp = int32(1598306400)
 
 type result struct {
 	Blocks []block
@@ -36,18 +36,18 @@ func Initialize(ctx context.Context, lotusAPI string, lotusToken string) error {
 		return errors.New("length of blocks from genesis is 0")
 	}
 
-	GENESIS_TIMESTAMP = r.Blocks[0].Timestamp
+	GenesisTimestamp = r.Blocks[0].Timestamp
 	return nil
 }
 
 func EpochToTime(epoch int32) time.Time {
-	return time.Unix(int64(epoch)*30+int64(GENESIS_TIMESTAMP), 0)
+	return time.Unix(int64(epoch)*30+int64(GenesisTimestamp), 0)
 }
 
 func UnixToEpoch(unix int64) int32 {
-	return (int32(unix) - GENESIS_TIMESTAMP) / 30
+	return (int32(unix) - GenesisTimestamp) / 30
 }
 
 func TimeToEpoch(t time.Time) abi.ChainEpoch {
-	return abi.ChainEpoch((t.Unix() - int64(GENESIS_TIMESTAMP)) / 30)
+	return abi.ChainEpoch((t.Unix() - int64(GenesisTimestamp)) / 30)
 }

--- a/service/epochutil/epoch.go
+++ b/service/epochutil/epoch.go
@@ -45,8 +45,8 @@ func EpochToTime(epoch int32) time.Time {
 	return time.Unix(int64(epoch)*30+int64(GenesisTimestamp), 0)
 }
 
-func UnixToEpoch(unix int64) int32 {
-	return (int32(unix) - GenesisTimestamp) / 30
+func UnixToEpoch(unix int64) abi.ChainEpoch {
+	return abi.ChainEpoch(unix-int64(GenesisTimestamp)) / 30
 }
 
 func TimeToEpoch(t time.Time) abi.ChainEpoch {

--- a/service/epochutil/epoch_test.go
+++ b/service/epochutil/epoch_test.go
@@ -14,6 +14,7 @@ func TestDefaultValue(t *testing.T) {
 }
 
 func TestCalibNet(t *testing.T) {
+	// This test may fail when calibnet resets
 	err := Initialize(context.Background(), "https://api.calibration.node.glif.io/rpc/v0", "")
 	require.NoError(t, err)
 	require.EqualValues(t, 1667326380, GenesisTimestamp)

--- a/service/epochutil/epoch_test.go
+++ b/service/epochutil/epoch_test.go
@@ -10,11 +10,11 @@ import (
 func TestDefaultValue(t *testing.T) {
 	err := Initialize(context.Background(), "https://api.node.glif.io/rpc/v0", "")
 	require.NoError(t, err)
-	require.EqualValues(t, 1598306400, GENESIS_TIMESTAMP)
+	require.EqualValues(t, 1598306400, GenesisTimestamp)
 }
 
 func TestCalibNet(t *testing.T) {
 	err := Initialize(context.Background(), "https://api.calibration.node.glif.io/rpc/v0", "")
 	require.NoError(t, err)
-	require.EqualValues(t, 1667326380, GENESIS_TIMESTAMP)
+	require.EqualValues(t, 1667326380, GenesisTimestamp)
 }

--- a/service/epochutil/epoch_test.go
+++ b/service/epochutil/epoch_test.go
@@ -1,0 +1,20 @@
+package epochutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultValue(t *testing.T) {
+	err := Initialize(context.Background(), "https://api.node.glif.io/rpc/v0", "")
+	require.NoError(t, err)
+	require.EqualValues(t, 1598306400, GENESIS_TIMESTAMP)
+}
+
+func TestCalibNet(t *testing.T) {
+	err := Initialize(context.Background(), "https://api.calibration.node.glif.io/rpc/v0", "")
+	require.NoError(t, err)
+	require.EqualValues(t, 1667326380, GENESIS_TIMESTAMP)
+}


### PR DESCRIPTION
- [x] Testnet/Calibnet can be enabled by setting
  * LOTUS_API
  * MARKET_DEAL_URL
  * The genesis timestamp will be figured out by calling lotus.ChainGetGenesis, or default to mainnet genesis timestamp if LOTUS_API is the default GLIF mainnet API endpoint
- [x] Remove places that set address.CurrentNetwork