### PR TITLE
Use `any` instead of `interface{}`

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -107,7 +107,7 @@ func Run(c *cli.Context) error {
 	}.Run(c)
 }
 
-func (s Server) toEchoHandler(handlerFunc interface{}) echo.HandlerFunc {
+func (s Server) toEchoHandler(handlerFunc any) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		handlerFuncValue := reflect.ValueOf(handlerFunc)
 		handlerFuncType := handlerFuncValue.Type()
@@ -450,7 +450,7 @@ func (s Server) GetDirectoryEntries(c echo.Context) error {
 		return echo.NewHTTPError(500, err.Error())
 	}
 
-	return c.JSON(200, map[string]interface{}{
+	return c.JSON(200, map[string]any{
 		"Directories": dirs,
 		"Items":       items,
 	})

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -184,7 +184,7 @@ var App = &cli.App{
 func RunApp(ctx context.Context, args []string) error {
 	printer := cli.HelpPrinter
 	//nolint:errcheck
-	cli.HelpPrinter = func(w io.Writer, templ string, data interface{}) {
+	cli.HelpPrinter = func(w io.Writer, templ string, data any) {
 		var helpText bytes.Buffer
 		printer(&helpText, templ, data)
 		numLines := strings.Count(helpText.String(), "\n")

--- a/cmd/cliutil/util.go
+++ b/cmd/cliutil/util.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-func PrintAsJSON(obj interface{}) {
+func PrintAsJSON(obj any) {
 	objJSON, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {
 		fmt.Println("Error: Unable to marshal object to JSON.")
@@ -21,7 +21,7 @@ func PrintAsJSON(obj interface{}) {
 	fmt.Println(string(objJSON))
 }
 
-func PrintToConsole(obj interface{}, useJSON bool, except []string) {
+func PrintToConsole(obj any, useJSON bool, except []string) {
 	if useJSON {
 		PrintAsJSON(obj)
 		return
@@ -41,8 +41,8 @@ func isNotEligibleType(field reflect.StructField, except []string) bool {
 		(field.Type.Kind() == reflect.Slice && field.Type.Elem().Kind() == reflect.Uint8)
 }
 
-func getValue(fieldValue reflect.Value) interface{} {
-	var finalValue interface{}
+func getValue(fieldValue reflect.Value) any {
+	var finalValue any
 	if fieldValue.Kind() == reflect.Ptr {
 		if fieldValue.IsNil() {
 			finalValue = ""
@@ -57,7 +57,7 @@ func getValue(fieldValue reflect.Value) interface{} {
 	return finalValue
 }
 
-func printTable(objects interface{}, except []string) {
+func printTable(objects any, except []string) {
 	value := reflect.ValueOf(objects)
 	if value.Len() == 0 {
 		return
@@ -70,7 +70,7 @@ func printTable(objects interface{}, except []string) {
 	objType := firstObj.Type()
 
 	// Prepare headers using the first object
-	headers := make([]interface{}, 0, objType.NumField())
+	headers := make([]any, 0, objType.NumField())
 	for i := 0; i < objType.NumField(); i++ {
 		field := objType.Field(i)
 		if isNotEligibleType(field, except) {
@@ -84,7 +84,7 @@ func printTable(objects interface{}, except []string) {
 
 	for i := 0; i < value.Len(); i++ {
 		objValue := reflect.Indirect(value.Index(i))
-		row := make([]interface{}, 0, objType.NumField())
+		row := make([]any, 0, objType.NumField())
 		for j := 0; j < objType.NumField(); j++ {
 			field := objType.Field(j)
 			fieldValue := objValue.Field(j)
@@ -99,14 +99,14 @@ func printTable(objects interface{}, except []string) {
 	tbl.Print()
 	fmt.Println()
 }
-func printSingleObject(obj interface{}, except []string) {
+func printSingleObject(obj any, except []string) {
 	value := reflect.Indirect(reflect.ValueOf(obj))
 	objType := value.Type()
 
 	headerFmt := color.New(color.FgGreen, color.Underline).SprintfFunc()
 	columnFmt := color.New(color.FgYellow).SprintfFunc()
 
-	headers := make([]interface{}, 0, objType.NumField())
+	headers := make([]any, 0, objType.NumField())
 	for i := 0; i < objType.NumField(); i++ {
 		field := objType.Field(i)
 		if isNotEligibleType(field, except) {
@@ -118,7 +118,7 @@ func printSingleObject(obj interface{}, except []string) {
 	tbl := table.New(headers...).WithWriter(os.Stdout)
 	tbl.WithHeaderFormatter(headerFmt).WithFirstColumnFormatter(columnFmt)
 
-	row := make([]interface{}, 0, objType.NumField())
+	row := make([]any, 0, objType.NumField())
 	for i := 0; i < objType.NumField(); i++ {
 		field := objType.Field(i)
 		fieldValue := value.Field(i)

--- a/cmd/datasource/update.go
+++ b/cmd/datasource/update.go
@@ -42,7 +42,7 @@ var UpdateCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
-		config := map[string]interface{}{}
+		config := map[string]any{}
 		for _, name := range c.LocalFlagNames() {
 			if c.IsSet(name) {
 				if name == "delete-after-export" {

--- a/database/util.go
+++ b/database/util.go
@@ -32,15 +32,15 @@ func (d *databaseLogger) LogMode(level logger2.LogLevel) logger2.Interface {
 	return d
 }
 
-func (d *databaseLogger) Info(ctx context.Context, s string, i ...interface{}) {
+func (d *databaseLogger) Info(ctx context.Context, s string, i ...any) {
 	d.logger.Infof(s, i...)
 }
 
-func (d *databaseLogger) Warn(ctx context.Context, s string, i ...interface{}) {
+func (d *databaseLogger) Warn(ctx context.Context, s string, i ...any) {
 	d.logger.Warnf(s, i...)
 }
 
-func (d *databaseLogger) Error(ctx context.Context, s string, i ...interface{}) {
+func (d *databaseLogger) Error(ctx context.Context, s string, i ...any) {
 	d.logger.Errorf(s, i...)
 }
 

--- a/handler/datasource/add.go
+++ b/handler/datasource/add.go
@@ -22,7 +22,7 @@ func CreateDatasourceHandler(
 	datasourceHandlerResolver datasource.HandlerResolver,
 	sourceType string,
 	datasetName string,
-	sourceParameters map[string]interface{},
+	sourceParameters map[string]any,
 ) (*model.Source, error) {
 	return createDatasourceHandler(db, ctx, sourceType, datasetName, sourceParameters)
 }
@@ -42,7 +42,7 @@ func createDatasourceHandler(
 	ctx context.Context,
 	sourceType string,
 	datasetName string,
-	sourceParameters map[string]interface{},
+	sourceParameters map[string]any,
 ) (*model.Source, error) {
 	dataset, err := database.FindDatasetByName(db, datasetName)
 	if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/handler/datasource/rescan.go
+++ b/handler/datasource/rescan.go
@@ -33,7 +33,7 @@ func rescanSourceHandler(
 		}
 		if source.ScanningState == model.Error || source.ScanningState == model.Complete {
 			return database.DoRetry(func() error {
-				return db.Model(&source).Updates(map[string]interface{}{
+				return db.Model(&source).Updates(map[string]any{
 					"scanning_state":         model.Ready,
 					"last_scanned_timestamp": 0,
 					"error_message":          "",

--- a/handler/datasource/update.go
+++ b/handler/datasource/update.go
@@ -17,7 +17,7 @@ import (
 	"gorm.io/gorm"
 )
 
-type Config map[string]interface{}
+type Config map[string]any
 
 func UpdateSourceHandler(
 	db *gorm.DB,
@@ -119,7 +119,7 @@ func updateSourceHandler(
 	}
 
 	err = database.DoRetry(func() error {
-		return db.Model(&source).Updates(map[string]interface{}{
+		return db.Model(&source).Updates(map[string]any{
 			"metadata":              source.Metadata,
 			"scan_interval_seconds": source.ScanIntervalSeconds,
 			"delete_after_export":   source.DeleteAfterExport,

--- a/handler/deal/schedule/create_test.go
+++ b/handler/deal/schedule/create_test.go
@@ -16,7 +16,7 @@ type MockRPCClient struct {
 	mock.Mock
 }
 
-func (m *MockRPCClient) Call(ctx context.Context, method string, params ...interface{}) (*jsonrpc.RPCResponse, error) {
+func (m *MockRPCClient) Call(ctx context.Context, method string, params ...any) (*jsonrpc.RPCResponse, error) {
 	//TODO implement me
 	panic("implement me")
 }
@@ -26,7 +26,7 @@ func (m *MockRPCClient) CallRaw(ctx context.Context, request *jsonrpc.RPCRequest
 	panic("implement me")
 }
 
-func (m *MockRPCClient) CallFor(ctx context.Context, out interface{}, method string, params ...interface{}) error {
+func (m *MockRPCClient) CallFor(ctx context.Context, out any, method string, params ...any) error {
 	return m.Called(ctx, out, method, params).Error(0)
 }
 

--- a/model/dataset.go
+++ b/model/dataset.go
@@ -72,7 +72,7 @@ func (c CID) Value() (driver.Value, error) {
 	return cid.Cid(c).Bytes(), nil
 }
 
-func (c *CID) Scan(src interface{}) error {
+func (c *CID) Scan(src any) error {
 	if src == nil {
 		*c = CID(cid.Undef)
 		return nil
@@ -104,7 +104,7 @@ func (m Metadata) Value() (driver.Value, error) {
 	return json.Marshal(m)
 }
 
-func (ss *StringSlice) Scan(src interface{}) error {
+func (ss *StringSlice) Scan(src any) error {
 	if src == nil {
 		*ss = nil
 		return nil
@@ -118,7 +118,7 @@ func (ss *StringSlice) Scan(src interface{}) error {
 	return json.Unmarshal(source, ss)
 }
 
-func (m *Metadata) Scan(src interface{}) error {
+func (m *Metadata) Scan(src any) error {
 	if src == nil {
 		*m = nil
 		return nil

--- a/model/migrate.go
+++ b/model/migrate.go
@@ -11,7 +11,7 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-var Tables = []interface{}{
+var Tables = []any{
 	&Global{},
 	&Worker{},
 	&Dataset{},

--- a/pack/daggen/dummynode.go
+++ b/pack/daggen/dummynode.go
@@ -29,11 +29,11 @@ func (f DummyNode) String() string {
 	return "DummyNode - " + f.cid.String()
 }
 
-func (f DummyNode) Loggable() map[string]interface{} {
+func (f DummyNode) Loggable() map[string]any {
 	return nil
 }
 
-func (f DummyNode) Resolve(path []string) (interface{}, []string, error) {
+func (f DummyNode) Resolve(path []string) (any, []string, error) {
 	return nil, nil, ErrEmptyNode
 }
 

--- a/replication/makedeal_test.go
+++ b/replication/makedeal_test.go
@@ -300,7 +300,7 @@ func TestDealMaker_GetProviderInfo(t *testing.T) {
 	maker := NewDealMaker(nil, nil, time.Hour, time.Second)
 	maker.lotusClient = lotusClient
 
-	lotusClient.On("CallFor", mock.Anything, mock.Anything, "Filecoin.StateMinerInfo", []interface{}{"address1", nil}).
+	lotusClient.On("CallFor", mock.Anything, mock.Anything, "Filecoin.StateMinerInfo", []any{"address1", nil}).
 		Return(nil).Run(func(args mock.Arguments) {
 		resultPtr := args.Get(1).(*MinerInfo)
 		*resultPtr = MinerInfo{

--- a/replication/wallet_test.go
+++ b/replication/wallet_test.go
@@ -17,7 +17,7 @@ type MockRPCClient struct {
 	mock.Mock
 }
 
-func (m *MockRPCClient) Call(ctx context.Context, method string, params ...interface{}) (*jsonrpc.RPCResponse, error) {
+func (m *MockRPCClient) Call(ctx context.Context, method string, params ...any) (*jsonrpc.RPCResponse, error) {
 	//TODO implement me
 	panic("implement me")
 }
@@ -27,7 +27,7 @@ func (m *MockRPCClient) CallRaw(ctx context.Context, request *jsonrpc.RPCRequest
 	panic("implement me")
 }
 
-func (m *MockRPCClient) CallFor(ctx context.Context, out interface{}, method string, params ...interface{}) error {
+func (m *MockRPCClient) CallFor(ctx context.Context, out any, method string, params ...any) error {
 	return m.Called(ctx, out, method, params).Error(0)
 }
 
@@ -55,22 +55,22 @@ func TestDatacapWalletChooser_Choose(t *testing.T) {
 	}
 
 	// Set up expectations for the lotusClient mock
-	lotusClient.On("CallFor", mock.Anything, mock.AnythingOfType("*string"), "Filecoin.StateMarketBalance", []interface{}{"address1", nil}).
+	lotusClient.On("CallFor", mock.Anything, mock.AnythingOfType("*string"), "Filecoin.StateMarketBalance", []any{"address1", nil}).
 		Return(nil).Run(func(args mock.Arguments) {
 		resultPtr := args.Get(1).(*string)
 		*resultPtr = "1000000"
 	})
 
-	lotusClient.On("CallFor", mock.Anything, mock.AnythingOfType("*string"), "Filecoin.StateMarketBalance", []interface{}{"address2", nil}).
+	lotusClient.On("CallFor", mock.Anything, mock.AnythingOfType("*string"), "Filecoin.StateMarketBalance", []any{"address2", nil}).
 		Return(errors.New("failed to get datacap"))
 
-	lotusClient.On("CallFor", mock.Anything, mock.AnythingOfType("*string"), "Filecoin.StateMarketBalance", []interface{}{"address3", nil}).
+	lotusClient.On("CallFor", mock.Anything, mock.AnythingOfType("*string"), "Filecoin.StateMarketBalance", []any{"address3", nil}).
 		Return(nil).Run(func(args mock.Arguments) {
 		resultPtr := args.Get(1).(*string)
 		*resultPtr = "1000000"
 	})
 
-	lotusClient.On("CallFor", mock.Anything, mock.AnythingOfType("*string"), "Filecoin.StateMarketBalance", []interface{}{"address4", nil}).
+	lotusClient.On("CallFor", mock.Anything, mock.AnythingOfType("*string"), "Filecoin.StateMarketBalance", []any{"address4", nil}).
 		Return(nil).Run(func(args mock.Arguments) {
 		resultPtr := args.Get(1).(*string)
 		*resultPtr = "900000"

--- a/service/datasetworker/datasetworker.go
+++ b/service/datasetworker/datasetworker.go
@@ -157,7 +157,7 @@ func (w *DatasetWorkerThread) run(ctx context.Context, errChan chan<- error, wg 
 				}
 				err = database.DoRetry(func() error {
 					return w.db.Model(&model.Source{}).Where("id = ?", source.ID).Updates(
-						map[string]interface{}{
+						map[string]any{
 							"dag_gen_state":         newState,
 							"dag_gen_worker_id":     nil,
 							"dag_gen_error_message": newErrorMessage,
@@ -172,7 +172,7 @@ func (w *DatasetWorkerThread) run(ctx context.Context, errChan chan<- error, wg 
 
 			err = database.DoRetry(func() error {
 				return w.db.Model(&model.Source{}).Where("id = ?", source.ID).Updates(
-					map[string]interface{}{
+					map[string]any{
 						"dag_gen_state":     model.Complete,
 						"dag_gen_worker_id": nil,
 					},
@@ -206,7 +206,7 @@ func (w *DatasetWorkerThread) run(ctx context.Context, errChan chan<- error, wg 
 				}
 				err = database.DoRetry(func() error {
 					return w.db.Model(&model.Source{}).Where("id = ?", source.ID).Updates(
-						map[string]interface{}{
+						map[string]any{
 							"scanning_state":         newState,
 							"scanning_worker_id":     nil,
 							"error_message":          newErrorMessage,
@@ -222,7 +222,7 @@ func (w *DatasetWorkerThread) run(ctx context.Context, errChan chan<- error, wg 
 
 			err = database.DoRetry(func() error {
 				return w.db.Model(&model.Source{}).Where("id = ?", source.ID).Updates(
-					map[string]interface{}{
+					map[string]any{
 						"scanning_state":         model.Complete,
 						"scanning_worker_id":     nil,
 						"last_scanned_timestamp": time.Now().UTC().Unix(),
@@ -263,7 +263,7 @@ func (w *DatasetWorkerThread) run(ctx context.Context, errChan chan<- error, wg 
 					}
 					err = database.DoRetry(func() error {
 						return w.db.Model(&model.Chunk{}).Where("id = ?", chunk.ID).Updates(
-							map[string]interface{}{
+							map[string]any{
 								"packing_state":     newState,
 								"packing_worker_id": nil,
 								"error_message":     newErrorMessage,
@@ -277,7 +277,7 @@ func (w *DatasetWorkerThread) run(ctx context.Context, errChan chan<- error, wg 
 				}
 				err = database.DoRetry(func() error {
 					return w.db.Model(&model.Chunk{}).Where("id = ?", chunk.ID).Updates(
-						map[string]interface{}{
+						map[string]any{
 							"packing_state":     model.Complete,
 							"packing_worker_id": nil,
 						},

--- a/service/datasetworker/find.go
+++ b/service/datasetworker/find.go
@@ -33,7 +33,7 @@ func (w *DatasetWorkerThread) findDagWork() (*model.Source, error) {
 
 			// Then, perform the update using the found id
 			return db.Model(&sources[0]).
-				Updates(map[string]interface{}{
+				Updates(map[string]any{
 					"dag_gen_state":         model.Processing,
 					"dag_gen_worker_id":     w.id,
 					"dag_gen_error_message": "",
@@ -81,7 +81,7 @@ func (w *DatasetWorkerThread) findPackWork() (*model.Chunk, error) {
 
 			// Then, perform the update using the found id
 			return db.Model(&chunks[0]).
-				Updates(map[string]interface{}{
+				Updates(map[string]any{
 					"packing_state":     model.Processing,
 					"packing_worker_id": w.id,
 					"error_message":     "",
@@ -136,7 +136,7 @@ func (w *DatasetWorkerThread) findScanWork() (*model.Source, error) {
 				return nil
 			}
 			err = db.Model(&sources[0]).
-				Updates(map[string]interface{}{
+				Updates(map[string]any{
 					"scanning_state":     model.Processing,
 					"scanning_worker_id": w.id,
 					"error_message":      "",

--- a/service/datasetworker/pack.go
+++ b/service/datasetworker/pack.go
@@ -196,7 +196,7 @@ func (w *DatasetWorkerThread) pack(
 				if err != nil {
 					return errors.Wrap(err, "failed to marshall directory data")
 				}
-				err = db.Model(&model.Directory{}).Where("id = ?", dirID).Updates(map[string]interface{}{
+				err = db.Model(&model.Directory{}).Where("id = ?", dirID).Updates(map[string]any{
 					"cid":      model.CID(dirData.Node.Cid()),
 					"data":     bytes,
 					"exported": false,

--- a/service/dealmaker/dealmaker.go
+++ b/service/dealmaker/dealmaker.go
@@ -42,11 +42,11 @@ type sumResult struct {
 
 type cronLogger struct{}
 
-func (c cronLogger) Info(msg string, keysAndValues ...interface{}) {
+func (c cronLogger) Info(msg string, keysAndValues ...any) {
 	logger.Infow(msg, keysAndValues...)
 }
 
-func (c cronLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+func (c cronLogger) Error(err error, msg string, keysAndValues ...any) {
 	keysAndValues = append(keysAndValues, "err", err)
 	logger.Errorw(msg, keysAndValues...)
 }
@@ -60,7 +60,7 @@ func (d *DealMakerService) hasSchedule(scheduleID uint32) bool {
 
 func (d *DealMakerService) runScheduleAndUpdateState(ctx context.Context, schedule *model.Schedule) {
 	state, err := d.runSchedule(ctx, schedule)
-	updates := make(map[string]interface{})
+	updates := make(map[string]any)
 	if state != "" {
 		updates["state"] = state
 	}

--- a/service/dealtracker/dealtracker.go
+++ b/service/dealtracker/dealtracker.go
@@ -284,7 +284,7 @@ func (d *DealTracker) runOnce(ctx context.Context) error {
 			f := found[0]
 			logger.Debugw("Deal matched on-chain", "dealID", dealID, "state", newState)
 			err = database.DoRetry(func() error {
-				return d.db.WithContext(ctx).Model(&model.Deal{}).Where("id = ?", f.ID).Updates(map[string]interface{}{
+				return d.db.WithContext(ctx).Model(&model.Deal{}).Where("id = ?", f.ID).Updates(map[string]any{
 					"deal_id":            dealID,
 					"state":              newState,
 					"sector_start_epoch": deal.State.SectorStartEpoch,

--- a/service/dealtracker/dealtracker_test.go
+++ b/service/dealtracker/dealtracker_test.go
@@ -56,7 +56,7 @@ func TestDealStateStreamFromHttpRequest_Compressed(t *testing.T) {
 	require.Len(t, kvs, 1)
 	require.Equal(t, "0", kvs[0].Key)
 	require.Equal(t, "bagboea4b5abcatlxechwbp7kjpjguna6r6q7ejrhe6mdp3lf34pmswn27pkkiekz",
-		kvs[0].Value.(map[string]interface{})["Proposal"].(map[string]interface{})["Label"].(string))
+		kvs[0].Value.(map[string]any)["Proposal"].(map[string]any)["Label"].(string))
 }
 
 func TestDealStateStreamFromHttpRequest_UnCompressed(t *testing.T) {
@@ -81,7 +81,7 @@ func TestDealStateStreamFromHttpRequest_UnCompressed(t *testing.T) {
 	require.Len(t, kvs, 1)
 	require.Equal(t, "0", kvs[0].Key)
 	require.Equal(t, "bagboea4b5abcatlxechwbp7kjpjguna6r6q7ejrhe6mdp3lf34pmswn27pkkiekz",
-		kvs[0].Value.(map[string]interface{})["Proposal"].(map[string]interface{})["Label"].(string))
+		kvs[0].Value.(map[string]any)["Proposal"].(map[string]any)["Label"].(string))
 }
 
 func TestTrackDeal(t *testing.T) {

--- a/service/healthcheck/healthcheck.go
+++ b/service/healthcheck/healthcheck.go
@@ -45,7 +45,7 @@ func HealthCheckCleanup(db *gorm.DB) {
 	err = database.DoRetry(func() error {
 		return db.Model(&model.Source{}).Where("(dag_gen_worker_id NOT IN (?) OR dag_gen_worker_id IS NULL) AND dag_gen_state = ?",
 			db.Table("workers").Select("id"), model.Processing).
-			Updates(map[string]interface{}{
+			Updates(map[string]any{
 				"dag_gen_worker_id": nil,
 				"dag_gen_state":     model.Ready,
 			}).Error
@@ -57,7 +57,7 @@ func HealthCheckCleanup(db *gorm.DB) {
 	err = database.DoRetry(func() error {
 		return db.Model(&model.Source{}).Where("(scanning_worker_id NOT IN (?) OR scanning_worker_id IS NULL) AND scanning_state = ?",
 			db.Table("workers").Select("id"), model.Processing).
-			Updates(map[string]interface{}{
+			Updates(map[string]any{
 				"scanning_worker_id": nil,
 				"scanning_state":     model.Ready,
 			}).Error
@@ -69,7 +69,7 @@ func HealthCheckCleanup(db *gorm.DB) {
 	err = database.DoRetry(func() error {
 		return db.Model(&model.Chunk{}).Where("(packing_worker_id NOT IN (?) OR packing_worker_id IS NULL) AND packing_state = ?",
 			db.Table("workers").Select("id"), model.Processing).
-			Updates(map[string]interface{}{
+			Updates(map[string]any{
 				"packing_worker_id": nil,
 				"packing_state":     model.Ready,
 			}).Error


### PR DESCRIPTION
Update code to use `any` keyword instead of `interface{}` since the go mod version is 1.19.

The changes here are purely cosmetic and have no effect on net functionality.