### PR TITLE
Fix missing `id` URL parameter in swagger definitions

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -49,7 +49,7 @@ type Server struct {
 // @Description Get metadata for a piece for how it may be reassembled from the data source
 // @Tags Metadata
 // @Produce json
-// @Param piece path string true "Piece CID"
+// @Param id path string true "Piece CID"
 // @Success 200 {object} store.PieceReader
 // @Failure 400 {string} string "Bad Request"
 // @Failure 404 {string} string "Not Found"

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -590,7 +590,7 @@ const docTemplate = `{
                     {
                         "type": "string",
                         "description": "Piece CID",
-                        "name": "piece",
+                        "name": "id",
                         "in": "path",
                         "required": true
                     }
@@ -3334,6 +3334,13 @@ const docTemplate = `{
                 ],
                 "summary": "Push an item to be queued",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
                     {
                         "description": "Item",
                         "name": "item",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -583,7 +583,7 @@
                     {
                         "type": "string",
                         "description": "Piece CID",
-                        "name": "piece",
+                        "name": "id",
                         "in": "path",
                         "required": true
                     }
@@ -3327,6 +3327,13 @@
                 ],
                 "summary": "Push an item to be queued",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
                     {
                         "description": "Item",
                         "name": "item",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -5475,7 +5475,7 @@ paths:
       parameters:
       - description: Piece CID
         in: path
-        name: piece
+        name: id
         required: true
         type: string
       produces:
@@ -5875,6 +5875,11 @@ paths:
       description: Tells Singularity that something is ready to be grabbed for data
         preparation
       parameters:
+      - description: Source ID
+        in: path
+        name: id
+        required: true
+        type: string
       - description: Item
         in: body
         name: item

--- a/handler/datasource/pushitem.go
+++ b/handler/datasource/pushitem.go
@@ -32,6 +32,7 @@ func PushItemHandler(
 // @Tags Data Source
 // @Accept json
 // @Produce json
+// @Param id path string true "Source ID"
 // @Param item body ItemInfo true "Item"
 // @Success 201 {object} model.Item
 // @Failure 400 {string} string "Bad Request"


### PR DESCRIPTION
Add the missing `{id}` URL parameter to the swagger definition.