### PR TITLE
Ignore coverage for generated swagger client code

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,7 @@ coverage:
       default:
         threshold: 1%
         target: 50%
+ignore:
+  - "client/swagger/http"
+  - "client/swagger/models"
+  - "client/swagger/operations"


### PR DESCRIPTION
Do not consider autogenerated packages containing swagger client library when calculating code coverage.