### PR TITLE
Allow setting of scanning state on datasources in the API

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -24,7 +24,7 @@ func TestHandlePostSource(t *testing.T) {
 	require.NoError(t, err)
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/source/local/dataset/test", bytes.NewBuffer([]byte(
-		`{"deleteAfterExport":true,"sourcePath":"`+tmp+`","rescanInterval":"1h","caseInsensitive":"false"}`,
+		`{"deleteAfterExport":true,"sourcePath":"`+tmp+`","rescanInterval":"1h","caseInsensitive":"false","scanningState":"ready"}`,
 	)))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -14,6 +14,7 @@ import (
 	httpclient "github.com/data-preservation-programs/singularity/client/http"
 	libclient "github.com/data-preservation-programs/singularity/client/lib"
 	"github.com/data-preservation-programs/singularity/database"
+	"github.com/data-preservation-programs/singularity/model"
 
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/handler/dataset"
@@ -53,11 +54,13 @@ func TestHTTPClient(t *testing.T) {
 		source, err := client.CreateLocalSource(ctx, "test", datasource.LocalRequest{
 			SourcePath:     path,
 			RescanInterval: "0h",
+			ScanningState:  model.Ready,
 		})
 		require.NoError(t, err)
 		require.Equal(t, "local", source.Type)
 		require.Equal(t, ds.ID, source.DatasetID)
 		require.Equal(t, path, source.Path)
+		require.Equal(t, model.Ready, source.ScanningState)
 
 		// create datasource when dataset not found
 		notFoundSource, err := client.CreateLocalSource(ctx, "apples", datasource.LocalRequest{

--- a/client/swagger/models/datasource_acd_request.go
+++ b/client/swagger/models/datasource_acd_request.go
@@ -42,6 +42,12 @@ type DatasourceAcdRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -68,6 +74,10 @@ func (m *DatasourceAcdRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -99,6 +109,11 @@ func (m *DatasourceAcdRequest) validateRescanInterval(formats strfmt.Registry) e
 	return nil
 }
 
+func (m *DatasourceAcdRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceAcdRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -108,8 +123,22 @@ func (m *DatasourceAcdRequest) validateSourcePath(formats strfmt.Registry) error
 	return nil
 }
 
-// ContextValidate validates this datasource acd request based on context it is used
+// ContextValidate validate this datasource acd request based on the context it is used
 func (m *DatasourceAcdRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceAcdRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_all_config.go
+++ b/client/swagger/models/datasource_all_config.go
@@ -1180,6 +1180,11 @@ type DatasourceAllConfig struct {
 	// Include old versions in directory listings.
 	S3Versions *string `json:"s3Versions,omitempty"`
 
+	// Starting state for scanning
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState,omitempty"`
+
 	// Two-factor authentication ('true' if the account has 2FA enabled).
 	Seafile2fa *string `json:"seafile2fa,omitempty"`
 
@@ -1555,6 +1560,10 @@ type DatasourceAllConfig struct {
 func (m *DatasourceAllConfig) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateScanningState(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateSourcePath(formats); err != nil {
 		res = append(res, err)
 	}
@@ -1562,6 +1571,14 @@ func (m *DatasourceAllConfig) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *DatasourceAllConfig) validateScanningState(formats strfmt.Registry) error {
+	if swag.IsZero(m.ScanningState) { // not required
+		return nil
+	}
+
 	return nil
 }
 
@@ -1574,8 +1591,22 @@ func (m *DatasourceAllConfig) validateSourcePath(formats strfmt.Registry) error 
 	return nil
 }
 
-// ContextValidate validates this datasource all config based on context it is used
+// ContextValidate validate this datasource all config based on the context it is used
 func (m *DatasourceAllConfig) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceAllConfig) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_azureblob_request.go
+++ b/client/swagger/models/datasource_azureblob_request.go
@@ -102,6 +102,12 @@ type DatasourceAzureblobRequest struct {
 	// SAS URL for container level access only.
 	SasURL string `json:"sasUrl,omitempty"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// Path to file containing credentials for use with a service principal.
 	ServicePrincipalFile string `json:"servicePrincipalFile,omitempty"`
 
@@ -140,6 +146,10 @@ func (m *DatasourceAzureblobRequest) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateScanningState(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateSourcePath(formats); err != nil {
 		res = append(res, err)
 	}
@@ -168,6 +178,11 @@ func (m *DatasourceAzureblobRequest) validateRescanInterval(formats strfmt.Regis
 	return nil
 }
 
+func (m *DatasourceAzureblobRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceAzureblobRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -177,8 +192,22 @@ func (m *DatasourceAzureblobRequest) validateSourcePath(formats strfmt.Registry)
 	return nil
 }
 
-// ContextValidate validates this datasource azureblob request based on context it is used
+// ContextValidate validate this datasource azureblob request based on the context it is used
 func (m *DatasourceAzureblobRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceAzureblobRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_b2_request.go
+++ b/client/swagger/models/datasource_b2_request.go
@@ -63,6 +63,12 @@ type DatasourceB2Request struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -89,6 +95,10 @@ func (m *DatasourceB2Request) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -120,6 +130,11 @@ func (m *DatasourceB2Request) validateRescanInterval(formats strfmt.Registry) er
 	return nil
 }
 
+func (m *DatasourceB2Request) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceB2Request) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -129,8 +144,22 @@ func (m *DatasourceB2Request) validateSourcePath(formats strfmt.Registry) error 
 	return nil
 }
 
-// ContextValidate validates this datasource b2 request based on context it is used
+// ContextValidate validate this datasource b2 request based on the context it is used
 func (m *DatasourceB2Request) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceB2Request) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_box_request.go
+++ b/client/swagger/models/datasource_box_request.go
@@ -60,6 +60,12 @@ type DatasourceBoxRequest struct {
 	// Fill in for rclone to use a non root folder as its starting point.
 	RootFolderID *string `json:"rootFolderId,omitempty"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -83,6 +89,10 @@ func (m *DatasourceBoxRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -114,6 +124,11 @@ func (m *DatasourceBoxRequest) validateRescanInterval(formats strfmt.Registry) e
 	return nil
 }
 
+func (m *DatasourceBoxRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceBoxRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -123,8 +138,22 @@ func (m *DatasourceBoxRequest) validateSourcePath(formats strfmt.Registry) error
 	return nil
 }
 
-// ContextValidate validates this datasource box request based on context it is used
+// ContextValidate validate this datasource box request based on the context it is used
 func (m *DatasourceBoxRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceBoxRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_drive_request.go
+++ b/client/swagger/models/datasource_drive_request.go
@@ -90,6 +90,12 @@ type DatasourceDriveRequest struct {
 	// ID of the root folder.
 	RootFolderID string `json:"rootFolderId,omitempty"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// Scope that rclone should use when requesting access from drive.
 	Scope string `json:"scope,omitempty"`
 
@@ -173,6 +179,10 @@ func (m *DatasourceDriveRequest) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateScanningState(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateSourcePath(formats); err != nil {
 		res = append(res, err)
 	}
@@ -201,6 +211,11 @@ func (m *DatasourceDriveRequest) validateRescanInterval(formats strfmt.Registry)
 	return nil
 }
 
+func (m *DatasourceDriveRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceDriveRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -210,8 +225,22 @@ func (m *DatasourceDriveRequest) validateSourcePath(formats strfmt.Registry) err
 	return nil
 }
 
-// ContextValidate validates this datasource drive request based on context it is used
+// ContextValidate validate this datasource drive request based on the context it is used
 func (m *DatasourceDriveRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceDriveRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_dropbox_request.go
+++ b/client/swagger/models/datasource_dropbox_request.go
@@ -57,6 +57,12 @@ type DatasourceDropboxRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// Instructs rclone to work on individual shared files.
 	SharedFiles *string `json:"sharedFiles,omitempty"`
 
@@ -83,6 +89,10 @@ func (m *DatasourceDropboxRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -114,6 +124,11 @@ func (m *DatasourceDropboxRequest) validateRescanInterval(formats strfmt.Registr
 	return nil
 }
 
+func (m *DatasourceDropboxRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceDropboxRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -123,8 +138,22 @@ func (m *DatasourceDropboxRequest) validateSourcePath(formats strfmt.Registry) e
 	return nil
 }
 
-// ContextValidate validates this datasource dropbox request based on context it is used
+// ContextValidate validate this datasource dropbox request based on the context it is used
 func (m *DatasourceDropboxRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceDropboxRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_fichier_request.go
+++ b/client/swagger/models/datasource_fichier_request.go
@@ -39,6 +39,12 @@ type DatasourceFichierRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// If you want to download a shared folder, add this parameter.
 	SharedFolder string `json:"sharedFolder,omitempty"`
 
@@ -56,6 +62,10 @@ func (m *DatasourceFichierRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -87,6 +97,11 @@ func (m *DatasourceFichierRequest) validateRescanInterval(formats strfmt.Registr
 	return nil
 }
 
+func (m *DatasourceFichierRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceFichierRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -96,8 +111,22 @@ func (m *DatasourceFichierRequest) validateSourcePath(formats strfmt.Registry) e
 	return nil
 }
 
-// ContextValidate validates this datasource fichier request based on context it is used
+// ContextValidate validate this datasource fichier request based on the context it is used
 func (m *DatasourceFichierRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceFichierRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_filefabric_request.go
+++ b/client/swagger/models/datasource_filefabric_request.go
@@ -36,6 +36,12 @@ type DatasourceFilefabricRequest struct {
 	// ID of the root folder.
 	RootFolderID string `json:"rootFolderId,omitempty"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -62,6 +68,10 @@ func (m *DatasourceFilefabricRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -93,6 +103,11 @@ func (m *DatasourceFilefabricRequest) validateRescanInterval(formats strfmt.Regi
 	return nil
 }
 
+func (m *DatasourceFilefabricRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceFilefabricRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -102,8 +117,22 @@ func (m *DatasourceFilefabricRequest) validateSourcePath(formats strfmt.Registry
 	return nil
 }
 
-// ContextValidate validates this datasource filefabric request based on context it is used
+// ContextValidate validate this datasource filefabric request based on the context it is used
 func (m *DatasourceFilefabricRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceFilefabricRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_ftp_request.go
+++ b/client/swagger/models/datasource_ftp_request.go
@@ -72,6 +72,12 @@ type DatasourceFtpRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// Maximum time to wait for data connection closing status.
 	ShutTimeout *string `json:"shutTimeout,omitempty"`
 
@@ -104,6 +110,10 @@ func (m *DatasourceFtpRequest) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateScanningState(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateSourcePath(formats); err != nil {
 		res = append(res, err)
 	}
@@ -132,6 +142,11 @@ func (m *DatasourceFtpRequest) validateRescanInterval(formats strfmt.Registry) e
 	return nil
 }
 
+func (m *DatasourceFtpRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceFtpRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -141,8 +156,22 @@ func (m *DatasourceFtpRequest) validateSourcePath(formats strfmt.Registry) error
 	return nil
 }
 
-// ContextValidate validates this datasource ftp request based on context it is used
+// ContextValidate validate this datasource ftp request based on the context it is used
 func (m *DatasourceFtpRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceFtpRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_gcs_request.go
+++ b/client/swagger/models/datasource_gcs_request.go
@@ -69,6 +69,12 @@ type DatasourceGcsRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// Service Account Credentials JSON blob.
 	ServiceAccountCredentials string `json:"serviceAccountCredentials,omitempty"`
 
@@ -101,6 +107,10 @@ func (m *DatasourceGcsRequest) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateScanningState(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateSourcePath(formats); err != nil {
 		res = append(res, err)
 	}
@@ -129,6 +139,11 @@ func (m *DatasourceGcsRequest) validateRescanInterval(formats strfmt.Registry) e
 	return nil
 }
 
+func (m *DatasourceGcsRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceGcsRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -138,8 +153,22 @@ func (m *DatasourceGcsRequest) validateSourcePath(formats strfmt.Registry) error
 	return nil
 }
 
-// ContextValidate validates this datasource gcs request based on context it is used
+// ContextValidate validate this datasource gcs request based on the context it is used
 func (m *DatasourceGcsRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceGcsRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_gphotos_request.go
+++ b/client/swagger/models/datasource_gphotos_request.go
@@ -48,6 +48,12 @@ type DatasourceGphotosRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -71,6 +77,10 @@ func (m *DatasourceGphotosRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -102,6 +112,11 @@ func (m *DatasourceGphotosRequest) validateRescanInterval(formats strfmt.Registr
 	return nil
 }
 
+func (m *DatasourceGphotosRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceGphotosRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -111,8 +126,22 @@ func (m *DatasourceGphotosRequest) validateSourcePath(formats strfmt.Registry) e
 	return nil
 }
 
-// ContextValidate validates this datasource gphotos request based on context it is used
+// ContextValidate validate this datasource gphotos request based on the context it is used
 func (m *DatasourceGphotosRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceGphotosRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_hdfs_request.go
+++ b/client/swagger/models/datasource_hdfs_request.go
@@ -36,6 +36,12 @@ type DatasourceHdfsRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// Kerberos service principal name for the namenode.
 	ServicePrincipalName string `json:"servicePrincipalName,omitempty"`
 
@@ -56,6 +62,10 @@ func (m *DatasourceHdfsRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -87,6 +97,11 @@ func (m *DatasourceHdfsRequest) validateRescanInterval(formats strfmt.Registry) 
 	return nil
 }
 
+func (m *DatasourceHdfsRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceHdfsRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -96,8 +111,22 @@ func (m *DatasourceHdfsRequest) validateSourcePath(formats strfmt.Registry) erro
 	return nil
 }
 
-// ContextValidate validates this datasource hdfs request based on context it is used
+// ContextValidate validate this datasource hdfs request based on the context it is used
 func (m *DatasourceHdfsRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceHdfsRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_hidrive_request.go
+++ b/client/swagger/models/datasource_hidrive_request.go
@@ -51,6 +51,12 @@ type DatasourceHidriveRequest struct {
 	// The root/parent folder for all paths.
 	RootPrefix *string `json:"rootPrefix,omitempty"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// Access permissions that rclone should use when requesting access from HiDrive.
 	ScopeAccess *string `json:"scopeAccess,omitempty"`
 
@@ -86,6 +92,10 @@ func (m *DatasourceHidriveRequest) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateScanningState(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateSourcePath(formats); err != nil {
 		res = append(res, err)
 	}
@@ -114,6 +124,11 @@ func (m *DatasourceHidriveRequest) validateRescanInterval(formats strfmt.Registr
 	return nil
 }
 
+func (m *DatasourceHidriveRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceHidriveRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -123,8 +138,22 @@ func (m *DatasourceHidriveRequest) validateSourcePath(formats strfmt.Registry) e
 	return nil
 }
 
-// ContextValidate validates this datasource hidrive request based on context it is used
+// ContextValidate validate this datasource hidrive request based on the context it is used
 func (m *DatasourceHidriveRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceHidriveRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_http_request.go
+++ b/client/swagger/models/datasource_http_request.go
@@ -36,6 +36,12 @@ type DatasourceHTTPRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -53,6 +59,10 @@ func (m *DatasourceHTTPRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -84,6 +94,11 @@ func (m *DatasourceHTTPRequest) validateRescanInterval(formats strfmt.Registry) 
 	return nil
 }
 
+func (m *DatasourceHTTPRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceHTTPRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -93,8 +108,22 @@ func (m *DatasourceHTTPRequest) validateSourcePath(formats strfmt.Registry) erro
 	return nil
 }
 
-// ContextValidate validates this datasource Http request based on context it is used
+// ContextValidate validate this datasource Http request based on the context it is used
 func (m *DatasourceHTTPRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceHTTPRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_internetarchive_request.go
+++ b/client/swagger/models/datasource_internetarchive_request.go
@@ -42,6 +42,12 @@ type DatasourceInternetarchiveRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// IAS3 Secret Key (password).
 	SecretAccessKey string `json:"secretAccessKey,omitempty"`
 
@@ -62,6 +68,10 @@ func (m *DatasourceInternetarchiveRequest) Validate(formats strfmt.Registry) err
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -93,6 +103,11 @@ func (m *DatasourceInternetarchiveRequest) validateRescanInterval(formats strfmt
 	return nil
 }
 
+func (m *DatasourceInternetarchiveRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceInternetarchiveRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -102,8 +117,22 @@ func (m *DatasourceInternetarchiveRequest) validateSourcePath(formats strfmt.Reg
 	return nil
 }
 
-// ContextValidate validates this datasource internetarchive request based on context it is used
+// ContextValidate validate this datasource internetarchive request based on the context it is used
 func (m *DatasourceInternetarchiveRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceInternetarchiveRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_jottacloud_request.go
+++ b/client/swagger/models/datasource_jottacloud_request.go
@@ -39,6 +39,12 @@ type DatasourceJottacloudRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -59,6 +65,10 @@ func (m *DatasourceJottacloudRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -90,6 +100,11 @@ func (m *DatasourceJottacloudRequest) validateRescanInterval(formats strfmt.Regi
 	return nil
 }
 
+func (m *DatasourceJottacloudRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceJottacloudRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -99,8 +114,22 @@ func (m *DatasourceJottacloudRequest) validateSourcePath(formats strfmt.Registry
 	return nil
 }
 
-// ContextValidate validates this datasource jottacloud request based on context it is used
+// ContextValidate validate this datasource jottacloud request based on the context it is used
 func (m *DatasourceJottacloudRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceJottacloudRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_koofr_request.go
+++ b/client/swagger/models/datasource_koofr_request.go
@@ -42,6 +42,12 @@ type DatasourceKoofrRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// Does the backend support setting modification time.
 	Setmtime *string `json:"setmtime,omitempty"`
 
@@ -62,6 +68,10 @@ func (m *DatasourceKoofrRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -93,6 +103,11 @@ func (m *DatasourceKoofrRequest) validateRescanInterval(formats strfmt.Registry)
 	return nil
 }
 
+func (m *DatasourceKoofrRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceKoofrRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -102,8 +117,22 @@ func (m *DatasourceKoofrRequest) validateSourcePath(formats strfmt.Registry) err
 	return nil
 }
 
-// ContextValidate validates this datasource koofr request based on context it is used
+// ContextValidate validate this datasource koofr request based on the context it is used
 func (m *DatasourceKoofrRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceKoofrRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_local_request.go
+++ b/client/swagger/models/datasource_local_request.go
@@ -60,6 +60,12 @@ type DatasourceLocalRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// Don't warn about skipped symlinks.
 	SkipLinks *string `json:"skipLinks,omitempty"`
 
@@ -83,6 +89,10 @@ func (m *DatasourceLocalRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -114,6 +124,11 @@ func (m *DatasourceLocalRequest) validateRescanInterval(formats strfmt.Registry)
 	return nil
 }
 
+func (m *DatasourceLocalRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceLocalRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -123,8 +138,22 @@ func (m *DatasourceLocalRequest) validateSourcePath(formats strfmt.Registry) err
 	return nil
 }
 
-// ContextValidate validates this datasource local request based on context it is used
+// ContextValidate validate this datasource local request based on the context it is used
 func (m *DatasourceLocalRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceLocalRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_mailru_request.go
+++ b/client/swagger/models/datasource_mailru_request.go
@@ -39,6 +39,12 @@ type DatasourceMailruRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -74,6 +80,10 @@ func (m *DatasourceMailruRequest) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateScanningState(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateSourcePath(formats); err != nil {
 		res = append(res, err)
 	}
@@ -102,6 +112,11 @@ func (m *DatasourceMailruRequest) validateRescanInterval(formats strfmt.Registry
 	return nil
 }
 
+func (m *DatasourceMailruRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceMailruRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -111,8 +126,22 @@ func (m *DatasourceMailruRequest) validateSourcePath(formats strfmt.Registry) er
 	return nil
 }
 
-// ContextValidate validates this datasource mailru request based on context it is used
+// ContextValidate validate this datasource mailru request based on the context it is used
 func (m *DatasourceMailruRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceMailruRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_mega_request.go
+++ b/client/swagger/models/datasource_mega_request.go
@@ -39,6 +39,12 @@ type DatasourceMegaRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -59,6 +65,10 @@ func (m *DatasourceMegaRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -90,6 +100,11 @@ func (m *DatasourceMegaRequest) validateRescanInterval(formats strfmt.Registry) 
 	return nil
 }
 
+func (m *DatasourceMegaRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceMegaRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -99,8 +114,22 @@ func (m *DatasourceMegaRequest) validateSourcePath(formats strfmt.Registry) erro
 	return nil
 }
 
-// ContextValidate validates this datasource mega request based on context it is used
+// ContextValidate validate this datasource mega request based on the context it is used
 func (m *DatasourceMegaRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceMegaRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_netstorage_request.go
+++ b/client/swagger/models/datasource_netstorage_request.go
@@ -36,6 +36,12 @@ type DatasourceNetstorageRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// Set the NetStorage account secret/G2O key for authentication.
 	Secret string `json:"secret,omitempty"`
 
@@ -53,6 +59,10 @@ func (m *DatasourceNetstorageRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -84,6 +94,11 @@ func (m *DatasourceNetstorageRequest) validateRescanInterval(formats strfmt.Regi
 	return nil
 }
 
+func (m *DatasourceNetstorageRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceNetstorageRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -93,8 +108,22 @@ func (m *DatasourceNetstorageRequest) validateSourcePath(formats strfmt.Registry
 	return nil
 }
 
-// ContextValidate validates this datasource netstorage request based on context it is used
+// ContextValidate validate this datasource netstorage request based on the context it is used
 func (m *DatasourceNetstorageRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceNetstorageRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_onedrive_request.go
+++ b/client/swagger/models/datasource_onedrive_request.go
@@ -81,6 +81,12 @@ type DatasourceOnedriveRequest struct {
 	// ID of the root folder.
 	RootFolderID string `json:"rootFolderId,omitempty"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// Allow server-side operations (e.g. copy) to work across different onedrive configs.
 	ServerSideAcrossConfigs *string `json:"serverSideAcrossConfigs,omitempty"`
 
@@ -104,6 +110,10 @@ func (m *DatasourceOnedriveRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -135,6 +145,11 @@ func (m *DatasourceOnedriveRequest) validateRescanInterval(formats strfmt.Regist
 	return nil
 }
 
+func (m *DatasourceOnedriveRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceOnedriveRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -144,8 +159,22 @@ func (m *DatasourceOnedriveRequest) validateSourcePath(formats strfmt.Registry) 
 	return nil
 }
 
-// ContextValidate validates this datasource onedrive request based on context it is used
+// ContextValidate validate this datasource onedrive request based on the context it is used
 func (m *DatasourceOnedriveRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceOnedriveRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_oos_request.go
+++ b/client/swagger/models/datasource_oos_request.go
@@ -69,6 +69,12 @@ type DatasourceOosRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -110,6 +116,10 @@ func (m *DatasourceOosRequest) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateScanningState(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateSourcePath(formats); err != nil {
 		res = append(res, err)
 	}
@@ -138,6 +148,11 @@ func (m *DatasourceOosRequest) validateRescanInterval(formats strfmt.Registry) e
 	return nil
 }
 
+func (m *DatasourceOosRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceOosRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -147,8 +162,22 @@ func (m *DatasourceOosRequest) validateSourcePath(formats strfmt.Registry) error
 	return nil
 }
 
-// ContextValidate validates this datasource oos request based on context it is used
+// ContextValidate validate this datasource oos request based on the context it is used
 func (m *DatasourceOosRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceOosRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_opendrive_request.go
+++ b/client/swagger/models/datasource_opendrive_request.go
@@ -36,6 +36,12 @@ type DatasourceOpendriveRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -53,6 +59,10 @@ func (m *DatasourceOpendriveRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -84,6 +94,11 @@ func (m *DatasourceOpendriveRequest) validateRescanInterval(formats strfmt.Regis
 	return nil
 }
 
+func (m *DatasourceOpendriveRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceOpendriveRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -93,8 +108,22 @@ func (m *DatasourceOpendriveRequest) validateSourcePath(formats strfmt.Registry)
 	return nil
 }
 
-// ContextValidate validates this datasource opendrive request based on context it is used
+// ContextValidate validate this datasource opendrive request based on the context it is used
 func (m *DatasourceOpendriveRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceOpendriveRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_pcloud_request.go
+++ b/client/swagger/models/datasource_pcloud_request.go
@@ -48,6 +48,12 @@ type DatasourcePcloudRequest struct {
 	// Fill in for rclone to use a non root folder as its starting point.
 	RootFolderID *string `json:"rootFolderId,omitempty"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -71,6 +77,10 @@ func (m *DatasourcePcloudRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -102,6 +112,11 @@ func (m *DatasourcePcloudRequest) validateRescanInterval(formats strfmt.Registry
 	return nil
 }
 
+func (m *DatasourcePcloudRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourcePcloudRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -111,8 +126,22 @@ func (m *DatasourcePcloudRequest) validateSourcePath(formats strfmt.Registry) er
 	return nil
 }
 
-// ContextValidate validates this datasource pcloud request based on context it is used
+// ContextValidate validate this datasource pcloud request based on the context it is used
 func (m *DatasourcePcloudRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourcePcloudRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_premiumizeme_request.go
+++ b/client/swagger/models/datasource_premiumizeme_request.go
@@ -33,6 +33,12 @@ type DatasourcePremiumizemeRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -47,6 +53,10 @@ func (m *DatasourcePremiumizemeRequest) Validate(formats strfmt.Registry) error 
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -78,6 +88,11 @@ func (m *DatasourcePremiumizemeRequest) validateRescanInterval(formats strfmt.Re
 	return nil
 }
 
+func (m *DatasourcePremiumizemeRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourcePremiumizemeRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -87,8 +102,22 @@ func (m *DatasourcePremiumizemeRequest) validateSourcePath(formats strfmt.Regist
 	return nil
 }
 
-// ContextValidate validates this datasource premiumizeme request based on context it is used
+// ContextValidate validate this datasource premiumizeme request based on the context it is used
 func (m *DatasourcePremiumizemeRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourcePremiumizemeRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_putio_request.go
+++ b/client/swagger/models/datasource_putio_request.go
@@ -30,6 +30,12 @@ type DatasourcePutioRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -44,6 +50,10 @@ func (m *DatasourcePutioRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -75,6 +85,11 @@ func (m *DatasourcePutioRequest) validateRescanInterval(formats strfmt.Registry)
 	return nil
 }
 
+func (m *DatasourcePutioRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourcePutioRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -84,8 +99,22 @@ func (m *DatasourcePutioRequest) validateSourcePath(formats strfmt.Registry) err
 	return nil
 }
 
-// ContextValidate validates this datasource putio request based on context it is used
+// ContextValidate validate this datasource putio request based on the context it is used
 func (m *DatasourcePutioRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourcePutioRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_qingstor_request.go
+++ b/client/swagger/models/datasource_qingstor_request.go
@@ -45,6 +45,12 @@ type DatasourceQingstorRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// QingStor Secret Access Key (password).
 	SecretAccessKey string `json:"secretAccessKey,omitempty"`
 
@@ -71,6 +77,10 @@ func (m *DatasourceQingstorRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -102,6 +112,11 @@ func (m *DatasourceQingstorRequest) validateRescanInterval(formats strfmt.Regist
 	return nil
 }
 
+func (m *DatasourceQingstorRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceQingstorRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -111,8 +126,22 @@ func (m *DatasourceQingstorRequest) validateSourcePath(formats strfmt.Registry) 
 	return nil
 }
 
-// ContextValidate validates this datasource qingstor request based on context it is used
+// ContextValidate validate this datasource qingstor request based on the context it is used
 func (m *DatasourceQingstorRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceQingstorRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_s3_request.go
+++ b/client/swagger/models/datasource_s3_request.go
@@ -117,6 +117,12 @@ type DatasourceS3Request struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// AWS Secret Access Key (password).
 	SecretAccessKey string `json:"secretAccessKey,omitempty"`
 
@@ -191,6 +197,10 @@ func (m *DatasourceS3Request) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateScanningState(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateSourcePath(formats); err != nil {
 		res = append(res, err)
 	}
@@ -219,6 +229,11 @@ func (m *DatasourceS3Request) validateRescanInterval(formats strfmt.Registry) er
 	return nil
 }
 
+func (m *DatasourceS3Request) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceS3Request) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -228,8 +243,22 @@ func (m *DatasourceS3Request) validateSourcePath(formats strfmt.Registry) error 
 	return nil
 }
 
-// ContextValidate validates this datasource s3 request based on context it is used
+// ContextValidate validate this datasource s3 request based on the context it is used
 func (m *DatasourceS3Request) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceS3Request) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_seafile_request.go
+++ b/client/swagger/models/datasource_seafile_request.go
@@ -48,6 +48,12 @@ type DatasourceSeafileRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -68,6 +74,10 @@ func (m *DatasourceSeafileRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -99,6 +109,11 @@ func (m *DatasourceSeafileRequest) validateRescanInterval(formats strfmt.Registr
 	return nil
 }
 
+func (m *DatasourceSeafileRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceSeafileRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -108,8 +123,22 @@ func (m *DatasourceSeafileRequest) validateSourcePath(formats strfmt.Registry) e
 	return nil
 }
 
-// ContextValidate validates this datasource seafile request based on context it is used
+// ContextValidate validate this datasource seafile request based on the context it is used
 func (m *DatasourceSeafileRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceSeafileRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_sftp_request.go
+++ b/client/swagger/models/datasource_sftp_request.go
@@ -90,6 +90,12 @@ type DatasourceSftpRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// Specifies the path or command to run a sftp server on the remote host.
 	ServerCommand string `json:"serverCommand,omitempty"`
 
@@ -137,6 +143,10 @@ func (m *DatasourceSftpRequest) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateScanningState(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateSourcePath(formats); err != nil {
 		res = append(res, err)
 	}
@@ -165,6 +175,11 @@ func (m *DatasourceSftpRequest) validateRescanInterval(formats strfmt.Registry) 
 	return nil
 }
 
+func (m *DatasourceSftpRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceSftpRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -174,8 +189,22 @@ func (m *DatasourceSftpRequest) validateSourcePath(formats strfmt.Registry) erro
 	return nil
 }
 
-// ContextValidate validates this datasource sftp request based on context it is used
+// ContextValidate validate this datasource sftp request based on the context it is used
 func (m *DatasourceSftpRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceSftpRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_sharefile_request.go
+++ b/client/swagger/models/datasource_sharefile_request.go
@@ -39,6 +39,12 @@ type DatasourceSharefileRequest struct {
 	// ID of the root folder.
 	RootFolderID string `json:"rootFolderId,omitempty"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -56,6 +62,10 @@ func (m *DatasourceSharefileRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -87,6 +97,11 @@ func (m *DatasourceSharefileRequest) validateRescanInterval(formats strfmt.Regis
 	return nil
 }
 
+func (m *DatasourceSharefileRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceSharefileRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -96,8 +111,22 @@ func (m *DatasourceSharefileRequest) validateSourcePath(formats strfmt.Registry)
 	return nil
 }
 
-// ContextValidate validates this datasource sharefile request based on context it is used
+// ContextValidate validate this datasource sharefile request based on the context it is used
 func (m *DatasourceSharefileRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceSharefileRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_sia_request.go
+++ b/client/swagger/models/datasource_sia_request.go
@@ -36,6 +36,12 @@ type DatasourceSiaRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -53,6 +59,10 @@ func (m *DatasourceSiaRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -84,6 +94,11 @@ func (m *DatasourceSiaRequest) validateRescanInterval(formats strfmt.Registry) e
 	return nil
 }
 
+func (m *DatasourceSiaRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceSiaRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -93,8 +108,22 @@ func (m *DatasourceSiaRequest) validateSourcePath(formats strfmt.Registry) error
 	return nil
 }
 
-// ContextValidate validates this datasource sia request based on context it is used
+// ContextValidate validate this datasource sia request based on the context it is used
 func (m *DatasourceSiaRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceSiaRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_smb_request.go
+++ b/client/swagger/models/datasource_smb_request.go
@@ -51,6 +51,12 @@ type DatasourceSmbRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -71,6 +77,10 @@ func (m *DatasourceSmbRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -102,6 +112,11 @@ func (m *DatasourceSmbRequest) validateRescanInterval(formats strfmt.Registry) e
 	return nil
 }
 
+func (m *DatasourceSmbRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceSmbRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -111,8 +126,22 @@ func (m *DatasourceSmbRequest) validateSourcePath(formats strfmt.Registry) error
 	return nil
 }
 
-// ContextValidate validates this datasource smb request based on context it is used
+// ContextValidate validate this datasource smb request based on the context it is used
 func (m *DatasourceSmbRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceSmbRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_storj_request.go
+++ b/client/swagger/models/datasource_storj_request.go
@@ -42,6 +42,12 @@ type DatasourceStorjRequest struct {
 	// Satellite address.
 	SatelliteAddress *string `json:"satelliteAddress,omitempty"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -56,6 +62,10 @@ func (m *DatasourceStorjRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -87,6 +97,11 @@ func (m *DatasourceStorjRequest) validateRescanInterval(formats strfmt.Registry)
 	return nil
 }
 
+func (m *DatasourceStorjRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceStorjRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -96,8 +111,22 @@ func (m *DatasourceStorjRequest) validateSourcePath(formats strfmt.Registry) err
 	return nil
 }
 
-// ContextValidate validates this datasource storj request based on context it is used
+// ContextValidate validate this datasource storj request based on the context it is used
 func (m *DatasourceStorjRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceStorjRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_sugarsync_request.go
+++ b/client/swagger/models/datasource_sugarsync_request.go
@@ -57,6 +57,12 @@ type DatasourceSugarsyncRequest struct {
 	// Sugarsync root id.
 	RootID string `json:"rootId,omitempty"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -74,6 +80,10 @@ func (m *DatasourceSugarsyncRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -105,6 +115,11 @@ func (m *DatasourceSugarsyncRequest) validateRescanInterval(formats strfmt.Regis
 	return nil
 }
 
+func (m *DatasourceSugarsyncRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceSugarsyncRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -114,8 +129,22 @@ func (m *DatasourceSugarsyncRequest) validateSourcePath(formats strfmt.Registry)
 	return nil
 }
 
-// ContextValidate validates this datasource sugarsync request based on context it is used
+// ContextValidate validate this datasource sugarsync request based on the context it is used
 func (m *DatasourceSugarsyncRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceSugarsyncRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_swift_request.go
+++ b/client/swagger/models/datasource_swift_request.go
@@ -75,6 +75,12 @@ type DatasourceSwiftRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -113,6 +119,10 @@ func (m *DatasourceSwiftRequest) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateScanningState(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateSourcePath(formats); err != nil {
 		res = append(res, err)
 	}
@@ -141,6 +151,11 @@ func (m *DatasourceSwiftRequest) validateRescanInterval(formats strfmt.Registry)
 	return nil
 }
 
+func (m *DatasourceSwiftRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceSwiftRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -150,8 +165,22 @@ func (m *DatasourceSwiftRequest) validateSourcePath(formats strfmt.Registry) err
 	return nil
 }
 
-// ContextValidate validates this datasource swift request based on context it is used
+// ContextValidate validate this datasource swift request based on the context it is used
 func (m *DatasourceSwiftRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceSwiftRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_uptobox_request.go
+++ b/client/swagger/models/datasource_uptobox_request.go
@@ -33,6 +33,12 @@ type DatasourceUptoboxRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -47,6 +53,10 @@ func (m *DatasourceUptoboxRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -78,6 +88,11 @@ func (m *DatasourceUptoboxRequest) validateRescanInterval(formats strfmt.Registr
 	return nil
 }
 
+func (m *DatasourceUptoboxRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceUptoboxRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -87,8 +102,22 @@ func (m *DatasourceUptoboxRequest) validateSourcePath(formats strfmt.Registry) e
 	return nil
 }
 
-// ContextValidate validates this datasource uptobox request based on context it is used
+// ContextValidate validate this datasource uptobox request based on the context it is used
 func (m *DatasourceUptoboxRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceUptoboxRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_webdav_request.go
+++ b/client/swagger/models/datasource_webdav_request.go
@@ -42,6 +42,12 @@ type DatasourceWebdavRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -65,6 +71,10 @@ func (m *DatasourceWebdavRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -96,6 +106,11 @@ func (m *DatasourceWebdavRequest) validateRescanInterval(formats strfmt.Registry
 	return nil
 }
 
+func (m *DatasourceWebdavRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceWebdavRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -105,8 +120,22 @@ func (m *DatasourceWebdavRequest) validateSourcePath(formats strfmt.Registry) er
 	return nil
 }
 
-// ContextValidate validates this datasource webdav request based on context it is used
+// ContextValidate validate this datasource webdav request based on the context it is used
 func (m *DatasourceWebdavRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceWebdavRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_yandex_request.go
+++ b/client/swagger/models/datasource_yandex_request.go
@@ -42,6 +42,12 @@ type DatasourceYandexRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -62,6 +68,10 @@ func (m *DatasourceYandexRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -93,6 +103,11 @@ func (m *DatasourceYandexRequest) validateRescanInterval(formats strfmt.Registry
 	return nil
 }
 
+func (m *DatasourceYandexRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceYandexRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -102,8 +117,22 @@ func (m *DatasourceYandexRequest) validateSourcePath(formats strfmt.Registry) er
 	return nil
 }
 
-// ContextValidate validates this datasource yandex request based on context it is used
+// ContextValidate validate this datasource yandex request based on the context it is used
 func (m *DatasourceYandexRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceYandexRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/client/swagger/models/datasource_zoho_request.go
+++ b/client/swagger/models/datasource_zoho_request.go
@@ -42,6 +42,12 @@ type DatasourceZohoRequest struct {
 	// Required: true
 	RescanInterval *string `json:"rescanInterval"`
 
+	// Starting state for scanning
+	// Required: true
+	ScanningState struct {
+		ModelWorkState
+	} `json:"scanningState"`
+
 	// The path of the source to scan items
 	// Required: true
 	SourcePath *string `json:"sourcePath"`
@@ -62,6 +68,10 @@ func (m *DatasourceZohoRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRescanInterval(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateScanningState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -93,6 +103,11 @@ func (m *DatasourceZohoRequest) validateRescanInterval(formats strfmt.Registry) 
 	return nil
 }
 
+func (m *DatasourceZohoRequest) validateScanningState(formats strfmt.Registry) error {
+
+	return nil
+}
+
 func (m *DatasourceZohoRequest) validateSourcePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("sourcePath", "body", m.SourcePath); err != nil {
@@ -102,8 +117,22 @@ func (m *DatasourceZohoRequest) validateSourcePath(formats strfmt.Registry) erro
 	return nil
 }
 
-// ContextValidate validates this datasource zoho request based on context it is used
+// ContextValidate validate this datasource zoho request based on the context it is used
 func (m *DatasourceZohoRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateScanningState(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DatasourceZohoRequest) contextValidateScanningState(ctx context.Context, formats strfmt.Registry) error {
+
 	return nil
 }
 

--- a/cmd/app_test.go
+++ b/cmd/app_test.go
@@ -369,7 +369,7 @@ func TestRunAPI(t *testing.T) {
 		require.Contains(t, body, `active`)
 
 		resp, body, errs = gorequest.New().Post("http://127.0.0.1:9090/api/source/local/dataset/test").
-			Send(`{"sourcePath":"/tmp","caseInsensitive":"false","deleteAfterExport":false,"rescanInterval":"1h"}`).End()
+			Send(`{"sourcePath":"/tmp","caseInsensitive":"false","deleteAfterExport":false,"rescanInterval":"1h","scanningState":"ready"}`).End()
 		require.Len(t, errs, 0)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		require.Contains(t, body, `"id": 1`)

--- a/cmd/datasource/add.go
+++ b/cmd/datasource/add.go
@@ -27,6 +27,7 @@ var AddCmd = &cli.Command{
 	Subcommands: underscore.Map(underscore.Filter(fs.Registry, func(r *fs.RegInfo) bool {
 		return !slices.Contains([]string{"crypt", "memory", "tardigrade"}, r.Prefix)
 	}), func(r *fs.RegInfo) *cli.Command {
+		ws := model.Ready
 		cmd := datasource.OptionsToCLIFlags(r)
 		cmd.Flags = append(cmd.Flags, &cli.BoolFlag{
 			Name:     "delete-after-export",
@@ -37,6 +38,12 @@ var AddCmd = &cli.Command{
 			Usage:       "Automatically rescan the source directory when this interval has passed from last successful scan",
 			Category:    "Data Preparation Options",
 			DefaultText: "disabled",
+		}, &cli.GenericFlag{
+			Name:        "scanning-state",
+			Usage:       "set the initial scanning state",
+			Category:    "Data Preparation Options",
+			DefaultText: "ready",
+			Value:       &ws,
 		})
 		cmd.Action = func(c *cli.Context) error {
 			datasetName := c.Args().Get(0)
@@ -83,7 +90,7 @@ var AddCmd = &cli.Command{
 				Path:                path,
 				Metadata:            model.Metadata(result),
 				ScanIntervalSeconds: 0,
-				ScanningState:       model.Ready,
+				ScanningState:       ws,
 				DeleteAfterExport:   deleteAfterExport,
 				DagGenState:         model.Created,
 			}

--- a/docs/en/cli-reference/datasource/add/acd.md
+++ b/docs/en/cli-reference/datasource/add/acd.md
@@ -83,6 +83,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for acd
 

--- a/docs/en/cli-reference/datasource/add/azureblob.md
+++ b/docs/en/cli-reference/datasource/add/azureblob.md
@@ -273,6 +273,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for azureblob
 

--- a/docs/en/cli-reference/datasource/add/b2.md
+++ b/docs/en/cli-reference/datasource/add/b2.md
@@ -126,6 +126,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for b2
 

--- a/docs/en/cli-reference/datasource/add/box.md
+++ b/docs/en/cli-reference/datasource/add/box.md
@@ -79,6 +79,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for box
 

--- a/docs/en/cli-reference/datasource/add/drive.md
+++ b/docs/en/cli-reference/datasource/add/drive.md
@@ -327,6 +327,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for drive
 

--- a/docs/en/cli-reference/datasource/add/dropbox.md
+++ b/docs/en/cli-reference/datasource/add/dropbox.md
@@ -148,6 +148,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for dropbox
 

--- a/docs/en/cli-reference/datasource/add/fichier.md
+++ b/docs/en/cli-reference/datasource/add/fichier.md
@@ -34,6 +34,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for fichier
 

--- a/docs/en/cli-reference/datasource/add/filefabric.md
+++ b/docs/en/cli-reference/datasource/add/filefabric.md
@@ -72,6 +72,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for filefabric
 

--- a/docs/en/cli-reference/datasource/add/ftp.md
+++ b/docs/en/cli-reference/datasource/add/ftp.md
@@ -122,6 +122,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for ftp
 

--- a/docs/en/cli-reference/datasource/add/gcs.md
+++ b/docs/en/cli-reference/datasource/add/gcs.md
@@ -200,6 +200,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for gcs
 

--- a/docs/en/cli-reference/datasource/add/gphotos.md
+++ b/docs/en/cli-reference/datasource/add/gphotos.md
@@ -78,6 +78,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for gphotos
 

--- a/docs/en/cli-reference/datasource/add/hdfs.md
+++ b/docs/en/cli-reference/datasource/add/hdfs.md
@@ -51,6 +51,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for hdfs
 

--- a/docs/en/cli-reference/datasource/add/hidrive.md
+++ b/docs/en/cli-reference/datasource/add/hidrive.md
@@ -115,6 +115,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for hidrive
 

--- a/docs/en/cli-reference/datasource/add/http.md
+++ b/docs/en/cli-reference/datasource/add/http.md
@@ -64,6 +64,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for http
 

--- a/docs/en/cli-reference/datasource/add/internetarchive.md
+++ b/docs/en/cli-reference/datasource/add/internetarchive.md
@@ -55,6 +55,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for internetarchive
 

--- a/docs/en/cli-reference/datasource/add/jottacloud.md
+++ b/docs/en/cli-reference/datasource/add/jottacloud.md
@@ -39,6 +39,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for jottacloud
 

--- a/docs/en/cli-reference/datasource/add/koofr.md
+++ b/docs/en/cli-reference/datasource/add/koofr.md
@@ -57,6 +57,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for koofr
 

--- a/docs/en/cli-reference/datasource/add/local.md
+++ b/docs/en/cli-reference/datasource/add/local.md
@@ -139,6 +139,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for local
 

--- a/docs/en/cli-reference/datasource/add/mailru.md
+++ b/docs/en/cli-reference/datasource/add/mailru.md
@@ -99,6 +99,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for mailru
 

--- a/docs/en/cli-reference/datasource/add/mega.md
+++ b/docs/en/cli-reference/datasource/add/mega.md
@@ -50,6 +50,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for mega
 

--- a/docs/en/cli-reference/datasource/add/netstorage.md
+++ b/docs/en/cli-reference/datasource/add/netstorage.md
@@ -40,6 +40,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for netstorage
 

--- a/docs/en/cli-reference/datasource/add/onedrive.md
+++ b/docs/en/cli-reference/datasource/add/onedrive.md
@@ -183,6 +183,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for onedrive
 

--- a/docs/en/cli-reference/datasource/add/oos.md
+++ b/docs/en/cli-reference/datasource/add/oos.md
@@ -199,6 +199,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for oos
 

--- a/docs/en/cli-reference/datasource/add/opendrive.md
+++ b/docs/en/cli-reference/datasource/add/opendrive.md
@@ -34,6 +34,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for opendrive
 

--- a/docs/en/cli-reference/datasource/add/pcloud.md
+++ b/docs/en/cli-reference/datasource/add/pcloud.md
@@ -70,6 +70,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for pcloud
 

--- a/docs/en/cli-reference/datasource/add/premiumizeme.md
+++ b/docs/en/cli-reference/datasource/add/premiumizeme.md
@@ -28,6 +28,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for premiumizeme
 

--- a/docs/en/cli-reference/datasource/add/putio.md
+++ b/docs/en/cli-reference/datasource/add/putio.md
@@ -22,6 +22,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for putio
 

--- a/docs/en/cli-reference/datasource/add/qingstor.md
+++ b/docs/en/cli-reference/datasource/add/qingstor.md
@@ -93,6 +93,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for qingstor
 

--- a/docs/en/cli-reference/datasource/add/s3.md
+++ b/docs/en/cli-reference/datasource/add/s3.md
@@ -1205,6 +1205,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for s3
 

--- a/docs/en/cli-reference/datasource/add/seafile.md
+++ b/docs/en/cli-reference/datasource/add/seafile.md
@@ -53,6 +53,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for seafile
 

--- a/docs/en/cli-reference/datasource/add/sftp.md
+++ b/docs/en/cli-reference/datasource/add/sftp.md
@@ -287,6 +287,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for sftp
 

--- a/docs/en/cli-reference/datasource/add/sharefile.md
+++ b/docs/en/cli-reference/datasource/add/sharefile.md
@@ -55,6 +55,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for sharefile
 

--- a/docs/en/cli-reference/datasource/add/sia.md
+++ b/docs/en/cli-reference/datasource/add/sia.md
@@ -38,6 +38,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for sia
 

--- a/docs/en/cli-reference/datasource/add/smb.md
+++ b/docs/en/cli-reference/datasource/add/smb.md
@@ -67,6 +67,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for smb
 

--- a/docs/en/cli-reference/datasource/add/storj.md
+++ b/docs/en/cli-reference/datasource/add/storj.md
@@ -49,6 +49,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for storj
 

--- a/docs/en/cli-reference/datasource/add/sugarsync.md
+++ b/docs/en/cli-reference/datasource/add/sugarsync.md
@@ -71,6 +71,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for sugarsync
 

--- a/docs/en/cli-reference/datasource/add/swift.md
+++ b/docs/en/cli-reference/datasource/add/swift.md
@@ -151,6 +151,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for swift
 

--- a/docs/en/cli-reference/datasource/add/uptobox.md
+++ b/docs/en/cli-reference/datasource/add/uptobox.md
@@ -27,6 +27,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for uptobox
 

--- a/docs/en/cli-reference/datasource/add/webdav.md
+++ b/docs/en/cli-reference/datasource/add/webdav.md
@@ -66,6 +66,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for webdav
 

--- a/docs/en/cli-reference/datasource/add/yandex.md
+++ b/docs/en/cli-reference/datasource/add/yandex.md
@@ -48,6 +48,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for yandex
 

--- a/docs/en/cli-reference/datasource/add/zoho.md
+++ b/docs/en/cli-reference/datasource/add/zoho.md
@@ -60,6 +60,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for zoho
 

--- a/docs/en/cli-reference/datasource/update.md
+++ b/docs/en/cli-reference/datasource/update.md
@@ -15,6 +15,7 @@ OPTIONS:
 
    --delete-after-export    [Dangerous] Delete the files of the dataset after exporting it to CAR files.  (default: false)
    --rescan-interval value  Automatically rescan the source directory when this interval has passed from last successful scan (default: disabled)
+   --scanning-state value   set the initial scanning state (default: ready)
 
    Options for acd
 

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -3720,6 +3720,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -3751,6 +3752,14 @@ const docTemplate = `{
                 "rescanInterval": {
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
+                },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
                 },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
@@ -5548,6 +5557,14 @@ const docTemplate = `{
                     "type": "string",
                     "default": "false"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "seafile2fa": {
                     "description": "Two-factor authentication ('true' if the account has 2FA enabled).",
                     "type": "string",
@@ -6094,6 +6111,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -6216,6 +6234,14 @@ const docTemplate = `{
                     "description": "SAS URL for container level access only.",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "servicePrincipalFile": {
                     "description": "Path to file containing credentials for use with a service principal.",
                     "type": "string"
@@ -6258,6 +6284,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -6325,6 +6352,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -6355,6 +6390,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -6414,6 +6450,14 @@ const docTemplate = `{
                     "type": "string",
                     "default": "0"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -6464,6 +6508,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -6571,6 +6616,14 @@ const docTemplate = `{
                 "rootFolderId": {
                     "description": "ID of the root folder.",
                     "type": "string"
+                },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
                 },
                 "scope": {
                     "description": "Scope that rclone should use when requesting access from drive.",
@@ -6687,6 +6740,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -6744,6 +6798,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sharedFiles": {
                     "description": "Instructs rclone to work on individual shared files.",
                     "type": "string",
@@ -6773,6 +6835,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -6801,6 +6864,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sharedFolder": {
                     "description": "If you want to download a shared folder, add this parameter.",
                     "type": "string"
@@ -6816,6 +6887,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -6839,6 +6911,14 @@ const docTemplate = `{
                 "rootFolderId": {
                     "description": "ID of the root folder.",
                     "type": "string"
+                },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
                 },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
@@ -6867,6 +6947,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -6951,6 +7032,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "shutTimeout": {
                     "description": "Maximum time to wait for data connection closing status.",
                     "type": "string",
@@ -6987,6 +7076,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7060,6 +7150,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "serviceAccountCredentials": {
                     "description": "Service Account Credentials JSON blob.",
                     "type": "string"
@@ -7091,6 +7189,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7134,6 +7233,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -7158,6 +7265,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7182,6 +7290,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "servicePrincipalName": {
                     "description": "Kerberos service principal name for the namenode.",
                     "type": "string"
@@ -7201,6 +7317,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7249,6 +7366,14 @@ const docTemplate = `{
                     "type": "string",
                     "default": "/"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "scopeAccess": {
                     "description": "Access permissions that rclone should use when requesting access from HiDrive.",
                     "type": "string",
@@ -7288,6 +7413,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7313,6 +7439,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -7328,6 +7462,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7363,6 +7498,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "secretAccessKey": {
                     "description": "IAS3 Secret Key (password).",
                     "type": "string"
@@ -7392,6 +7535,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7423,6 +7567,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -7444,6 +7596,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7476,6 +7629,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "setmtime": {
                     "description": "Does the backend support setting modification time.",
                     "type": "string",
@@ -7496,6 +7657,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7562,6 +7724,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "skipLinks": {
                     "description": "Don't warn about skipped symlinks.",
                     "type": "string",
@@ -7588,6 +7758,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7616,6 +7787,14 @@ const docTemplate = `{
                 "rescanInterval": {
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
+                },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
                 },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
@@ -7656,6 +7835,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7686,6 +7866,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -7706,6 +7894,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7730,6 +7919,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "secret": {
                     "description": "Set the NetStorage account secret/G2O key for authentication.",
                     "type": "string"
@@ -7745,6 +7942,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7839,6 +8037,14 @@ const docTemplate = `{
                     "description": "ID of the root folder.",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "serverSideAcrossConfigs": {
                     "description": "Allow server-side operations (e.g. copy) to work across different onedrive configs.",
                     "type": "string",
@@ -7863,6 +8069,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7940,6 +8147,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -7986,6 +8201,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8011,6 +8227,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8026,6 +8250,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8068,6 +8293,14 @@ const docTemplate = `{
                     "type": "string",
                     "default": "d0"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8091,6 +8324,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8111,6 +8345,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8122,6 +8364,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8138,6 +8381,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8149,6 +8400,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8188,6 +8440,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "secretAccessKey": {
                     "description": "QingStor Secret Access Key (password).",
                     "type": "string"
@@ -8217,6 +8477,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8369,6 +8630,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "secretAccessKey": {
                     "description": "AWS Secret Access Key (password).",
                     "type": "string"
@@ -8464,6 +8733,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8506,6 +8776,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8525,6 +8803,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8629,6 +8908,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "serverCommand": {
                     "description": "Specifies the path or command to run a sftp server on the remote host.",
                     "type": "string"
@@ -8686,6 +8973,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8715,6 +9003,14 @@ const docTemplate = `{
                     "description": "ID of the root folder.",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8731,6 +9027,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8756,6 +9053,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8772,6 +9077,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8821,6 +9127,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8841,6 +9155,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8874,6 +9189,14 @@ const docTemplate = `{
                     "type": "string",
                     "default": "us1.storj.io"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8885,6 +9208,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8938,6 +9262,14 @@ const docTemplate = `{
                     "description": "Sugarsync root id.",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8953,6 +9285,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -9036,6 +9369,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -9075,6 +9416,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -9095,6 +9437,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -9106,6 +9456,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -9137,6 +9488,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -9160,6 +9519,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -9193,6 +9553,14 @@ const docTemplate = `{
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -9212,6 +9580,7 @@ const docTemplate = `{
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -9243,6 +9612,14 @@ const docTemplate = `{
                 "rescanInterval": {
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
+                },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
                 },
                 "sourcePath": {
                     "description": "The path of the source to scan items",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -3713,6 +3713,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -3744,6 +3745,14 @@
                 "rescanInterval": {
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
+                },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
                 },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
@@ -5541,6 +5550,14 @@
                     "type": "string",
                     "default": "false"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "seafile2fa": {
                     "description": "Two-factor authentication ('true' if the account has 2FA enabled).",
                     "type": "string",
@@ -6087,6 +6104,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -6209,6 +6227,14 @@
                     "description": "SAS URL for container level access only.",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "servicePrincipalFile": {
                     "description": "Path to file containing credentials for use with a service principal.",
                     "type": "string"
@@ -6251,6 +6277,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -6318,6 +6345,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -6348,6 +6383,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -6407,6 +6443,14 @@
                     "type": "string",
                     "default": "0"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -6457,6 +6501,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -6564,6 +6609,14 @@
                 "rootFolderId": {
                     "description": "ID of the root folder.",
                     "type": "string"
+                },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
                 },
                 "scope": {
                     "description": "Scope that rclone should use when requesting access from drive.",
@@ -6680,6 +6733,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -6737,6 +6791,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sharedFiles": {
                     "description": "Instructs rclone to work on individual shared files.",
                     "type": "string",
@@ -6766,6 +6828,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -6794,6 +6857,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sharedFolder": {
                     "description": "If you want to download a shared folder, add this parameter.",
                     "type": "string"
@@ -6809,6 +6880,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -6832,6 +6904,14 @@
                 "rootFolderId": {
                     "description": "ID of the root folder.",
                     "type": "string"
+                },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
                 },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
@@ -6860,6 +6940,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -6944,6 +7025,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "shutTimeout": {
                     "description": "Maximum time to wait for data connection closing status.",
                     "type": "string",
@@ -6980,6 +7069,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7053,6 +7143,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "serviceAccountCredentials": {
                     "description": "Service Account Credentials JSON blob.",
                     "type": "string"
@@ -7084,6 +7182,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7127,6 +7226,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -7151,6 +7258,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7175,6 +7283,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "servicePrincipalName": {
                     "description": "Kerberos service principal name for the namenode.",
                     "type": "string"
@@ -7194,6 +7310,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7242,6 +7359,14 @@
                     "type": "string",
                     "default": "/"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "scopeAccess": {
                     "description": "Access permissions that rclone should use when requesting access from HiDrive.",
                     "type": "string",
@@ -7281,6 +7406,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7306,6 +7432,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -7321,6 +7455,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7356,6 +7491,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "secretAccessKey": {
                     "description": "IAS3 Secret Key (password).",
                     "type": "string"
@@ -7385,6 +7528,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7416,6 +7560,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -7437,6 +7589,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7469,6 +7622,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "setmtime": {
                     "description": "Does the backend support setting modification time.",
                     "type": "string",
@@ -7489,6 +7650,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7555,6 +7717,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "skipLinks": {
                     "description": "Don't warn about skipped symlinks.",
                     "type": "string",
@@ -7581,6 +7751,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7609,6 +7780,14 @@
                 "rescanInterval": {
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
+                },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
                 },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
@@ -7649,6 +7828,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7679,6 +7859,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -7699,6 +7887,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7723,6 +7912,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "secret": {
                     "description": "Set the NetStorage account secret/G2O key for authentication.",
                     "type": "string"
@@ -7738,6 +7935,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7832,6 +8030,14 @@
                     "description": "ID of the root folder.",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "serverSideAcrossConfigs": {
                     "description": "Allow server-side operations (e.g. copy) to work across different onedrive configs.",
                     "type": "string",
@@ -7856,6 +8062,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -7933,6 +8140,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -7979,6 +8194,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8004,6 +8220,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8019,6 +8243,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8061,6 +8286,14 @@
                     "type": "string",
                     "default": "d0"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8084,6 +8317,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8104,6 +8338,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8115,6 +8357,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8131,6 +8374,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8142,6 +8393,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8181,6 +8433,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "secretAccessKey": {
                     "description": "QingStor Secret Access Key (password).",
                     "type": "string"
@@ -8210,6 +8470,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8362,6 +8623,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "secretAccessKey": {
                     "description": "AWS Secret Access Key (password).",
                     "type": "string"
@@ -8457,6 +8726,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8499,6 +8769,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8518,6 +8796,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8622,6 +8901,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "serverCommand": {
                     "description": "Specifies the path or command to run a sftp server on the remote host.",
                     "type": "string"
@@ -8679,6 +8966,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8708,6 +8996,14 @@
                     "description": "ID of the root folder.",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8724,6 +9020,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8749,6 +9046,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8765,6 +9070,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8814,6 +9120,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8834,6 +9148,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8867,6 +9182,14 @@
                     "type": "string",
                     "default": "us1.storj.io"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8878,6 +9201,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -8931,6 +9255,14 @@
                     "description": "Sugarsync root id.",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -8946,6 +9278,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -9029,6 +9362,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -9068,6 +9409,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -9088,6 +9430,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -9099,6 +9449,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -9130,6 +9481,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -9153,6 +9512,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -9186,6 +9546,14 @@
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
                 },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
+                },
                 "sourcePath": {
                     "description": "The path of the source to scan items",
                     "type": "string"
@@ -9205,6 +9573,7 @@
             "required": [
                 "deleteAfterExport",
                 "rescanInterval",
+                "scanningState",
                 "sourcePath"
             ],
             "properties": {
@@ -9236,6 +9605,14 @@
                 "rescanInterval": {
                     "description": "Automatically rescan the source directory when this interval has passed from last successful scan",
                     "type": "string"
+                },
+                "scanningState": {
+                    "description": "Starting state for scanning",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.WorkState"
+                        }
+                    ]
                 },
                 "sourcePath": {
                     "description": "The path of the source to scan items",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -101,6 +101,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -122,6 +126,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.AllConfig:
@@ -1554,6 +1559,10 @@ definitions:
         default: "false"
         description: Include old versions in directory listings.
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       seafile2fa:
         default: "false"
         description: Two-factor authentication ('true' if the account has 2FA enabled).
@@ -2081,6 +2090,10 @@ definitions:
       sasUrl:
         description: SAS URL for container level access only.
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       servicePrincipalFile:
         description: Path to file containing credentials for use with a service principal.
         type: string
@@ -2113,6 +2126,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.B2Request:
@@ -2169,6 +2183,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -2190,6 +2208,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.BoxRequest:
@@ -2238,6 +2257,10 @@ definitions:
         default: "0"
         description: Fill in for rclone to use a non root folder as its starting point.
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -2254,6 +2277,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.CheckSourceRequest:
@@ -2360,6 +2384,10 @@ definitions:
       rootFolderId:
         description: ID of the root folder.
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       scope:
         description: Scope that rclone should use when requesting access from drive.
         type: string
@@ -2449,6 +2477,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.DropboxRequest:
@@ -2496,6 +2525,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sharedFiles:
         default: "false"
         description: Instructs rclone to work on individual shared files.
@@ -2516,6 +2549,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.FichierRequest:
@@ -2542,6 +2576,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sharedFolder:
         description: If you want to download a shared folder, add this parameter.
         type: string
@@ -2551,6 +2589,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.FilefabricRequest:
@@ -2572,6 +2611,10 @@ definitions:
       rootFolderId:
         description: ID of the root folder.
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -2590,6 +2633,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.FtpRequest:
@@ -2660,6 +2704,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       shutTimeout:
         default: 1m0s
         description: Maximum time to wait for data connection closing status.
@@ -2686,6 +2734,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.GcsRequest:
@@ -2746,6 +2795,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       serviceAccountCredentials:
         description: Service Account Credentials JSON blob.
         type: string
@@ -2768,6 +2821,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.GphotosRequest:
@@ -2804,6 +2858,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -2821,6 +2879,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.HdfsRequest:
@@ -2842,6 +2901,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       servicePrincipalName:
         description: Kerberos service principal name for the namenode.
         type: string
@@ -2854,6 +2917,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.HidriveRequest:
@@ -2895,6 +2959,10 @@ definitions:
         default: /
         description: The root/parent folder for all paths.
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       scopeAccess:
         default: rw
         description: Access permissions that rclone should use when requesting access
@@ -2925,6 +2993,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.HttpRequest:
@@ -2947,6 +3016,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -2956,6 +3029,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.InternetarchiveRequest:
@@ -2987,6 +3061,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       secretAccessKey:
         description: IAS3 Secret Key (password).
         type: string
@@ -3001,6 +3079,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.ItemInfo:
@@ -3036,6 +3115,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -3050,6 +3133,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.KoofrRequest:
@@ -3077,6 +3161,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       setmtime:
         default: "true"
         description: Does the backend support setting modification time.
@@ -3090,6 +3178,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.LocalRequest:
@@ -3146,6 +3235,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       skipLinks:
         default: "false"
         description: Don't warn about skipped symlinks.
@@ -3165,6 +3258,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.MailruRequest:
@@ -3190,6 +3284,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -3221,6 +3319,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.MegaRequest:
@@ -3247,6 +3346,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -3260,6 +3363,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.NetstorageRequest:
@@ -3281,6 +3385,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       secret:
         description: Set the NetStorage account secret/G2O key for authentication.
         type: string
@@ -3290,6 +3398,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.OnedriveRequest:
@@ -3368,6 +3477,10 @@ definitions:
       rootFolderId:
         description: ID of the root folder.
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       serverSideAcrossConfigs:
         default: "false"
         description: Allow server-side operations (e.g. copy) to work across different
@@ -3385,6 +3498,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.OosRequest:
@@ -3449,6 +3563,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -3488,6 +3606,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.OpendriveRequest:
@@ -3510,6 +3629,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -3519,6 +3642,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.PcloudRequest:
@@ -3554,6 +3678,10 @@ definitions:
         default: d0
         description: Fill in for rclone to use a non root folder as its starting point.
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -3569,6 +3697,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.PremiumizemeRequest:
@@ -3587,12 +3716,17 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.PutioRequest:
@@ -3608,12 +3742,17 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.QingstorRequest:
@@ -3647,6 +3786,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       secretAccessKey:
         description: QingStor Secret Access Key (password).
         type: string
@@ -3667,6 +3810,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.S3Request:
@@ -3792,6 +3936,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       secretAccessKey:
         description: AWS Secret Access Key (password).
         type: string
@@ -3869,6 +4017,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.SeafileRequest:
@@ -3904,6 +4053,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -3916,6 +4069,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.SftpRequest:
@@ -4002,6 +4156,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       serverCommand:
         description: Specifies the path or command to run a sftp server on the remote
           host.
@@ -4045,6 +4203,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.SharefileRequest:
@@ -4070,6 +4229,10 @@ definitions:
       rootFolderId:
         description: ID of the root folder.
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -4080,6 +4243,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.SiaRequest:
@@ -4102,6 +4266,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -4112,6 +4280,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.SmbRequest:
@@ -4154,6 +4323,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -4167,6 +4340,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.StorjRequest:
@@ -4195,12 +4369,17 @@ definitions:
         default: us1.storj.io
         description: Satellite address.
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.SugarsyncRequest:
@@ -4244,6 +4423,10 @@ definitions:
       rootId:
         description: Sugarsync root id.
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -4253,6 +4436,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.SwiftRequest:
@@ -4322,6 +4506,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -4352,6 +4540,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.UptoboxRequest:
@@ -4370,12 +4559,17 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.WebdavRequest:
@@ -4402,6 +4596,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -4417,6 +4615,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.YandexRequest:
@@ -4445,6 +4644,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -4457,6 +4660,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   datasource.ZohoRequest:
@@ -4484,6 +4688,10 @@ definitions:
         description: Automatically rescan the source directory when this interval
           has passed from last successful scan
         type: string
+      scanningState:
+        allOf:
+        - $ref: '#/definitions/model.WorkState'
+        description: Starting state for scanning
       sourcePath:
         description: The path of the source to scan items
         type: string
@@ -4496,6 +4704,7 @@ definitions:
     required:
     - deleteAfterExport
     - rescanInterval
+    - scanningState
     - sourcePath
     type: object
   deal.ListDealRequest:

--- a/handler/datasource/add_gen.go
+++ b/handler/datasource/add_gen.go
@@ -3,19 +3,24 @@
 //lint:file-ignore U1000 Ignore all unused code, it's generated
 package datasource
 
+import (
+	"github.com/data-preservation-programs/singularity/model"
+)
+
 type AcdRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`           // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`    // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`       // Automatically rescan the source directory when this interval has passed from last successful scan
-	AuthUrl           string `json:"authUrl"`                                  // Auth server URL.
-	Checkpoint        string `json:"checkpoint"`                               // Checkpoint for internal polling (debug).
-	ClientId          string `json:"clientId"`                                 // OAuth Client Id.
-	ClientSecret      string `json:"clientSecret"`                             // OAuth Client Secret.
-	Encoding          string `json:"encoding" default:"Slash,InvalidUtf8,Dot"` // The encoding for the backend.
-	TemplinkThreshold string `json:"templinkThreshold" default:"9Gi"`          // Files >= this size will be downloaded via their tempLink.
-	Token             string `json:"token"`                                    // OAuth Access Token as a JSON blob.
-	TokenUrl          string `json:"tokenUrl"`                                 // Token server url.
-	UploadWaitPerGb   string `json:"uploadWaitPerGb" default:"3m0s"`           // Additional time per GiB to wait after a failed complete upload to see if it appears.
+	SourcePath        string          `validate:"required" json:"sourcePath"`           // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`    // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`       // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`        // Starting state for scanning
+	AuthUrl           string          `json:"authUrl"`                                  // Auth server URL.
+	Checkpoint        string          `json:"checkpoint"`                               // Checkpoint for internal polling (debug).
+	ClientId          string          `json:"clientId"`                                 // OAuth Client Id.
+	ClientSecret      string          `json:"clientSecret"`                             // OAuth Client Secret.
+	Encoding          string          `json:"encoding" default:"Slash,InvalidUtf8,Dot"` // The encoding for the backend.
+	TemplinkThreshold string          `json:"templinkThreshold" default:"9Gi"`          // Files >= this size will be downloaded via their tempLink.
+	Token             string          `json:"token"`                                    // OAuth Access Token as a JSON blob.
+	TokenUrl          string          `json:"tokenUrl"`                                 // Token server url.
+	UploadWaitPerGb   string          `json:"uploadWaitPerGb" default:"3m0s"`           // Additional time per GiB to wait after a failed complete upload to see if it appears.
 }
 
 // @Summary Add acd source for a dataset
@@ -31,41 +36,42 @@ type AcdRequest struct {
 func handleAcd() {}
 
 type AzureblobRequest struct {
-	SourcePath                 string `validate:"required" json:"sourcePath"`                                     // The path of the source to scan items
-	DeleteAfterExport          bool   `validate:"required" json:"deleteAfterExport"`                              // Delete the source after exporting to CAR files
-	RescanInterval             string `validate:"required" json:"rescanInterval"`                                 // Automatically rescan the source directory when this interval has passed from last successful scan
-	AccessTier                 string `json:"accessTier"`                                                         // Access tier of blob: hot, cool or archive.
-	Account                    string `json:"account"`                                                            // Azure Storage Account Name.
-	ArchiveTierDelete          string `json:"archiveTierDelete" default:"false"`                                  // Delete archive tier blobs before overwriting.
-	ChunkSize                  string `json:"chunkSize" default:"4Mi"`                                            // Upload chunk size.
-	ClientCertificatePassword  string `json:"clientCertificatePassword"`                                          // Password for the certificate file (optional).
-	ClientCertificatePath      string `json:"clientCertificatePath"`                                              // Path to a PEM or PKCS12 certificate file including the private key.
-	ClientId                   string `json:"clientId"`                                                           // The ID of the client in use.
-	ClientSecret               string `json:"clientSecret"`                                                       // One of the service principal's client secrets
-	ClientSendCertificateChain string `json:"clientSendCertificateChain" default:"false"`                         // Send the certificate chain when using certificate auth.
-	DisableChecksum            string `json:"disableChecksum" default:"false"`                                    // Don't store MD5 checksum with object metadata.
-	Encoding                   string `json:"encoding" default:"Slash,BackSlash,Del,Ctl,RightPeriod,InvalidUtf8"` // The encoding for the backend.
-	Endpoint                   string `json:"endpoint"`                                                           // Endpoint for the service.
-	EnvAuth                    string `json:"envAuth" default:"false"`                                            // Read credentials from runtime (environment variables, CLI or MSI).
-	Key                        string `json:"key"`                                                                // Storage Account Shared Key.
-	ListChunk                  string `json:"listChunk" default:"5000"`                                           // Size of blob list.
-	MemoryPoolFlushTime        string `json:"memoryPoolFlushTime" default:"1m0s"`                                 // How often internal memory buffer pools will be flushed.
-	MemoryPoolUseMmap          string `json:"memoryPoolUseMmap" default:"false"`                                  // Whether to use mmap buffers in internal memory pool.
-	MsiClientId                string `json:"msiClientId"`                                                        // Object ID of the user-assigned MSI to use, if any.
-	MsiMiResId                 string `json:"msiMiResId"`                                                         // Azure resource ID of the user-assigned MSI to use, if any.
-	MsiObjectId                string `json:"msiObjectId"`                                                        // Object ID of the user-assigned MSI to use, if any.
-	NoCheckContainer           string `json:"noCheckContainer" default:"false"`                                   // If set, don't attempt to check the container exists or create it.
-	NoHeadObject               string `json:"noHeadObject" default:"false"`                                       // If set, do not do HEAD before GET when getting objects.
-	Password                   string `json:"password"`                                                           // The user's password
-	PublicAccess               string `json:"publicAccess"`                                                       // Public access level of a container: blob or container.
-	SasUrl                     string `json:"sasUrl"`                                                             // SAS URL for container level access only.
-	ServicePrincipalFile       string `json:"servicePrincipalFile"`                                               // Path to file containing credentials for use with a service principal.
-	Tenant                     string `json:"tenant"`                                                             // ID of the service principal's tenant. Also called its directory ID.
-	UploadConcurrency          string `json:"uploadConcurrency" default:"16"`                                     // Concurrency for multipart uploads.
-	UploadCutoff               string `json:"uploadCutoff"`                                                       // Cutoff for switching to chunked upload (<= 256 MiB) (deprecated).
-	UseEmulator                string `json:"useEmulator" default:"false"`                                        // Uses local storage emulator if provided as 'true'.
-	UseMsi                     string `json:"useMsi" default:"false"`                                             // Use a managed service identity to authenticate (only works in Azure).
-	Username                   string `json:"username"`                                                           // User name (usually an email address)
+	SourcePath                 string          `validate:"required" json:"sourcePath"`                                     // The path of the source to scan items
+	DeleteAfterExport          bool            `validate:"required" json:"deleteAfterExport"`                              // Delete the source after exporting to CAR files
+	RescanInterval             string          `validate:"required" json:"rescanInterval"`                                 // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState              model.WorkState `validate:"required" json:"scanningState"`                                  // Starting state for scanning
+	AccessTier                 string          `json:"accessTier"`                                                         // Access tier of blob: hot, cool or archive.
+	Account                    string          `json:"account"`                                                            // Azure Storage Account Name.
+	ArchiveTierDelete          string          `json:"archiveTierDelete" default:"false"`                                  // Delete archive tier blobs before overwriting.
+	ChunkSize                  string          `json:"chunkSize" default:"4Mi"`                                            // Upload chunk size.
+	ClientCertificatePassword  string          `json:"clientCertificatePassword"`                                          // Password for the certificate file (optional).
+	ClientCertificatePath      string          `json:"clientCertificatePath"`                                              // Path to a PEM or PKCS12 certificate file including the private key.
+	ClientId                   string          `json:"clientId"`                                                           // The ID of the client in use.
+	ClientSecret               string          `json:"clientSecret"`                                                       // One of the service principal's client secrets
+	ClientSendCertificateChain string          `json:"clientSendCertificateChain" default:"false"`                         // Send the certificate chain when using certificate auth.
+	DisableChecksum            string          `json:"disableChecksum" default:"false"`                                    // Don't store MD5 checksum with object metadata.
+	Encoding                   string          `json:"encoding" default:"Slash,BackSlash,Del,Ctl,RightPeriod,InvalidUtf8"` // The encoding for the backend.
+	Endpoint                   string          `json:"endpoint"`                                                           // Endpoint for the service.
+	EnvAuth                    string          `json:"envAuth" default:"false"`                                            // Read credentials from runtime (environment variables, CLI or MSI).
+	Key                        string          `json:"key"`                                                                // Storage Account Shared Key.
+	ListChunk                  string          `json:"listChunk" default:"5000"`                                           // Size of blob list.
+	MemoryPoolFlushTime        string          `json:"memoryPoolFlushTime" default:"1m0s"`                                 // How often internal memory buffer pools will be flushed.
+	MemoryPoolUseMmap          string          `json:"memoryPoolUseMmap" default:"false"`                                  // Whether to use mmap buffers in internal memory pool.
+	MsiClientId                string          `json:"msiClientId"`                                                        // Object ID of the user-assigned MSI to use, if any.
+	MsiMiResId                 string          `json:"msiMiResId"`                                                         // Azure resource ID of the user-assigned MSI to use, if any.
+	MsiObjectId                string          `json:"msiObjectId"`                                                        // Object ID of the user-assigned MSI to use, if any.
+	NoCheckContainer           string          `json:"noCheckContainer" default:"false"`                                   // If set, don't attempt to check the container exists or create it.
+	NoHeadObject               string          `json:"noHeadObject" default:"false"`                                       // If set, do not do HEAD before GET when getting objects.
+	Password                   string          `json:"password"`                                                           // The user's password
+	PublicAccess               string          `json:"publicAccess"`                                                       // Public access level of a container: blob or container.
+	SasUrl                     string          `json:"sasUrl"`                                                             // SAS URL for container level access only.
+	ServicePrincipalFile       string          `json:"servicePrincipalFile"`                                               // Path to file containing credentials for use with a service principal.
+	Tenant                     string          `json:"tenant"`                                                             // ID of the service principal's tenant. Also called its directory ID.
+	UploadConcurrency          string          `json:"uploadConcurrency" default:"16"`                                     // Concurrency for multipart uploads.
+	UploadCutoff               string          `json:"uploadCutoff"`                                                       // Cutoff for switching to chunked upload (<= 256 MiB) (deprecated).
+	UseEmulator                string          `json:"useEmulator" default:"false"`                                        // Uses local storage emulator if provided as 'true'.
+	UseMsi                     string          `json:"useMsi" default:"false"`                                             // Use a managed service identity to authenticate (only works in Azure).
+	Username                   string          `json:"username"`                                                           // User name (usually an email address)
 }
 
 // @Summary Add azureblob source for a dataset
@@ -81,25 +87,26 @@ type AzureblobRequest struct {
 func handleAzureblob() {}
 
 type B2Request struct {
-	SourcePath           string `validate:"required" json:"sourcePath"`                             // The path of the source to scan items
-	DeleteAfterExport    bool   `validate:"required" json:"deleteAfterExport"`                      // Delete the source after exporting to CAR files
-	RescanInterval       string `validate:"required" json:"rescanInterval"`                         // Automatically rescan the source directory when this interval has passed from last successful scan
-	Account              string `json:"account"`                                                    // Account ID or Application Key ID.
-	ChunkSize            string `json:"chunkSize" default:"96Mi"`                                   // Upload chunk size.
-	CopyCutoff           string `json:"copyCutoff" default:"4Gi"`                                   // Cutoff for switching to multipart copy.
-	DisableChecksum      string `json:"disableChecksum" default:"false"`                            // Disable checksums for large (> upload cutoff) files.
-	DownloadAuthDuration string `json:"downloadAuthDuration" default:"1w"`                          // Time before the authorization token will expire in s or suffix ms|s|m|h|d.
-	DownloadUrl          string `json:"downloadUrl"`                                                // Custom endpoint for downloads.
-	Encoding             string `json:"encoding" default:"Slash,BackSlash,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
-	Endpoint             string `json:"endpoint"`                                                   // Endpoint for the service.
-	HardDelete           string `json:"hardDelete" default:"false"`                                 // Permanently delete files on remote removal, otherwise hide files.
-	Key                  string `json:"key"`                                                        // Application Key.
-	MemoryPoolFlushTime  string `json:"memoryPoolFlushTime" default:"1m0s"`                         // How often internal memory buffer pools will be flushed.
-	MemoryPoolUseMmap    string `json:"memoryPoolUseMmap" default:"false"`                          // Whether to use mmap buffers in internal memory pool.
-	TestMode             string `json:"testMode"`                                                   // A flag string for X-Bz-Test-Mode header for debugging.
-	UploadCutoff         string `json:"uploadCutoff" default:"200Mi"`                               // Cutoff for switching to chunked upload.
-	VersionAt            string `json:"versionAt" default:"off"`                                    // Show file versions as they were at the specified time.
-	Versions             string `json:"versions" default:"false"`                                   // Include old versions in directory listings.
+	SourcePath           string          `validate:"required" json:"sourcePath"`                             // The path of the source to scan items
+	DeleteAfterExport    bool            `validate:"required" json:"deleteAfterExport"`                      // Delete the source after exporting to CAR files
+	RescanInterval       string          `validate:"required" json:"rescanInterval"`                         // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState        model.WorkState `validate:"required" json:"scanningState"`                          // Starting state for scanning
+	Account              string          `json:"account"`                                                    // Account ID or Application Key ID.
+	ChunkSize            string          `json:"chunkSize" default:"96Mi"`                                   // Upload chunk size.
+	CopyCutoff           string          `json:"copyCutoff" default:"4Gi"`                                   // Cutoff for switching to multipart copy.
+	DisableChecksum      string          `json:"disableChecksum" default:"false"`                            // Disable checksums for large (> upload cutoff) files.
+	DownloadAuthDuration string          `json:"downloadAuthDuration" default:"1w"`                          // Time before the authorization token will expire in s or suffix ms|s|m|h|d.
+	DownloadUrl          string          `json:"downloadUrl"`                                                // Custom endpoint for downloads.
+	Encoding             string          `json:"encoding" default:"Slash,BackSlash,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
+	Endpoint             string          `json:"endpoint"`                                                   // Endpoint for the service.
+	HardDelete           string          `json:"hardDelete" default:"false"`                                 // Permanently delete files on remote removal, otherwise hide files.
+	Key                  string          `json:"key"`                                                        // Application Key.
+	MemoryPoolFlushTime  string          `json:"memoryPoolFlushTime" default:"1m0s"`                         // How often internal memory buffer pools will be flushed.
+	MemoryPoolUseMmap    string          `json:"memoryPoolUseMmap" default:"false"`                          // Whether to use mmap buffers in internal memory pool.
+	TestMode             string          `json:"testMode"`                                                   // A flag string for X-Bz-Test-Mode header for debugging.
+	UploadCutoff         string          `json:"uploadCutoff" default:"200Mi"`                               // Cutoff for switching to chunked upload.
+	VersionAt            string          `json:"versionAt" default:"off"`                                    // Show file versions as they were at the specified time.
+	Versions             string          `json:"versions" default:"false"`                                   // Include old versions in directory listings.
 }
 
 // @Summary Add b2 source for a dataset
@@ -115,23 +122,24 @@ type B2Request struct {
 func handleB2() {}
 
 type BoxRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`                                        // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`                                 // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`                                    // Automatically rescan the source directory when this interval has passed from last successful scan
-	AccessToken       string `json:"accessToken"`                                                           // Box App Primary Access Token
-	AuthUrl           string `json:"authUrl"`                                                               // Auth server URL.
-	BoxConfigFile     string `json:"boxConfigFile"`                                                         // Box App config.json location
-	BoxSubType        string `json:"boxSubType" default:"user"`                                             //
-	ClientId          string `json:"clientId"`                                                              // OAuth Client Id.
-	ClientSecret      string `json:"clientSecret"`                                                          // OAuth Client Secret.
-	CommitRetries     string `json:"commitRetries" default:"100"`                                           // Max number of times to try committing a multipart file.
-	Encoding          string `json:"encoding" default:"Slash,BackSlash,Del,Ctl,RightSpace,InvalidUtf8,Dot"` // The encoding for the backend.
-	ListChunk         string `json:"listChunk" default:"1000"`                                              // Size of listing chunk 1-1000.
-	OwnedBy           string `json:"ownedBy"`                                                               // Only show items owned by the login (email address) passed in.
-	RootFolderId      string `json:"rootFolderId" default:"0"`                                              // Fill in for rclone to use a non root folder as its starting point.
-	Token             string `json:"token"`                                                                 // OAuth Access Token as a JSON blob.
-	TokenUrl          string `json:"tokenUrl"`                                                              // Token server url.
-	UploadCutoff      string `json:"uploadCutoff" default:"50Mi"`                                           // Cutoff for switching to multipart upload (>= 50 MiB).
+	SourcePath        string          `validate:"required" json:"sourcePath"`                                        // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`                                 // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`                                    // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`                                     // Starting state for scanning
+	AccessToken       string          `json:"accessToken"`                                                           // Box App Primary Access Token
+	AuthUrl           string          `json:"authUrl"`                                                               // Auth server URL.
+	BoxConfigFile     string          `json:"boxConfigFile"`                                                         // Box App config.json location
+	BoxSubType        string          `json:"boxSubType" default:"user"`                                             //
+	ClientId          string          `json:"clientId"`                                                              // OAuth Client Id.
+	ClientSecret      string          `json:"clientSecret"`                                                          // OAuth Client Secret.
+	CommitRetries     string          `json:"commitRetries" default:"100"`                                           // Max number of times to try committing a multipart file.
+	Encoding          string          `json:"encoding" default:"Slash,BackSlash,Del,Ctl,RightSpace,InvalidUtf8,Dot"` // The encoding for the backend.
+	ListChunk         string          `json:"listChunk" default:"1000"`                                              // Size of listing chunk 1-1000.
+	OwnedBy           string          `json:"ownedBy"`                                                               // Only show items owned by the login (email address) passed in.
+	RootFolderId      string          `json:"rootFolderId" default:"0"`                                              // Fill in for rclone to use a non root folder as its starting point.
+	Token             string          `json:"token"`                                                                 // OAuth Access Token as a JSON blob.
+	TokenUrl          string          `json:"tokenUrl"`                                                              // Token server url.
+	UploadCutoff      string          `json:"uploadCutoff" default:"50Mi"`                                           // Cutoff for switching to multipart upload (>= 50 MiB).
 }
 
 // @Summary Add box source for a dataset
@@ -147,52 +155,53 @@ type BoxRequest struct {
 func handleBox() {}
 
 type DriveRequest struct {
-	SourcePath                string `validate:"required" json:"sourcePath"`             // The path of the source to scan items
-	DeleteAfterExport         bool   `validate:"required" json:"deleteAfterExport"`      // Delete the source after exporting to CAR files
-	RescanInterval            string `validate:"required" json:"rescanInterval"`         // Automatically rescan the source directory when this interval has passed from last successful scan
-	AcknowledgeAbuse          string `json:"acknowledgeAbuse" default:"false"`           // Set to allow files which return cannotDownloadAbusiveFile to be downloaded.
-	AllowImportNameChange     string `json:"allowImportNameChange" default:"false"`      // Allow the filetype to change when uploading Google docs.
-	AlternateExport           string `json:"alternateExport" default:"false"`            // Deprecated: No longer needed.
-	AuthOwnerOnly             string `json:"authOwnerOnly" default:"false"`              // Only consider files owned by the authenticated user.
-	AuthUrl                   string `json:"authUrl"`                                    // Auth server URL.
-	ChunkSize                 string `json:"chunkSize" default:"8Mi"`                    // Upload chunk size.
-	ClientId                  string `json:"clientId"`                                   // Google Application Client Id
-	ClientSecret              string `json:"clientSecret"`                               // OAuth Client Secret.
-	CopyShortcutContent       string `json:"copyShortcutContent" default:"false"`        // Server side copy contents of shortcuts instead of the shortcut.
-	DisableHttp2              string `json:"disableHttp2" default:"true"`                // Disable drive using http2.
-	Encoding                  string `json:"encoding" default:"InvalidUtf8"`             // The encoding for the backend.
-	ExportFormats             string `json:"exportFormats" default:"docx,xlsx,pptx,svg"` // Comma separated list of preferred formats for downloading Google docs.
-	Formats                   string `json:"formats"`                                    // Deprecated: See export_formats.
-	Impersonate               string `json:"impersonate"`                                // Impersonate this user when using a service account.
-	ImportFormats             string `json:"importFormats"`                              // Comma separated list of preferred formats for uploading Google docs.
-	KeepRevisionForever       string `json:"keepRevisionForever" default:"false"`        // Keep new head revision of each file forever.
-	ListChunk                 string `json:"listChunk" default:"1000"`                   // Size of listing chunk 100-1000, 0 to disable.
-	PacerBurst                string `json:"pacerBurst" default:"100"`                   // Number of API calls to allow without sleeping.
-	PacerMinSleep             string `json:"pacerMinSleep" default:"100ms"`              // Minimum time to sleep between API calls.
-	ResourceKey               string `json:"resourceKey"`                                // Resource key for accessing a link-shared file.
-	RootFolderId              string `json:"rootFolderId"`                               // ID of the root folder.
-	Scope                     string `json:"scope"`                                      // Scope that rclone should use when requesting access from drive.
-	ServerSideAcrossConfigs   string `json:"serverSideAcrossConfigs" default:"false"`    // Allow server-side operations (e.g. copy) to work across different drive configs.
-	ServiceAccountCredentials string `json:"serviceAccountCredentials"`                  // Service Account Credentials JSON blob.
-	ServiceAccountFile        string `json:"serviceAccountFile"`                         // Service Account Credentials JSON file path.
-	SharedWithMe              string `json:"sharedWithMe" default:"false"`               // Only show files that are shared with me.
-	SizeAsQuota               string `json:"sizeAsQuota" default:"false"`                // Show sizes as storage quota usage, not actual size.
-	SkipChecksumGphotos       string `json:"skipChecksumGphotos" default:"false"`        // Skip MD5 checksum on Google photos and videos only.
-	SkipDanglingShortcuts     string `json:"skipDanglingShortcuts" default:"false"`      // If set skip dangling shortcut files.
-	SkipGdocs                 string `json:"skipGdocs" default:"false"`                  // Skip google documents in all listings.
-	SkipShortcuts             string `json:"skipShortcuts" default:"false"`              // If set skip shortcut files.
-	StarredOnly               string `json:"starredOnly" default:"false"`                // Only show files that are starred.
-	StopOnDownloadLimit       string `json:"stopOnDownloadLimit" default:"false"`        // Make download limit errors be fatal.
-	StopOnUploadLimit         string `json:"stopOnUploadLimit" default:"false"`          // Make upload limit errors be fatal.
-	TeamDrive                 string `json:"teamDrive"`                                  // ID of the Shared Drive (Team Drive).
-	Token                     string `json:"token"`                                      // OAuth Access Token as a JSON blob.
-	TokenUrl                  string `json:"tokenUrl"`                                   // Token server url.
-	TrashedOnly               string `json:"trashedOnly" default:"false"`                // Only show files that are in the trash.
-	UploadCutoff              string `json:"uploadCutoff" default:"8Mi"`                 // Cutoff for switching to chunked upload.
-	UseCreatedDate            string `json:"useCreatedDate" default:"false"`             // Use file created date instead of modified date.
-	UseSharedDate             string `json:"useSharedDate" default:"false"`              // Use date file was shared instead of modified date.
-	UseTrash                  string `json:"useTrash" default:"true"`                    // Send files to the trash instead of deleting permanently.
-	V2DownloadMinSize         string `json:"v2DownloadMinSize" default:"off"`            // If Object's are greater, use drive v2 API to download.
+	SourcePath                string          `validate:"required" json:"sourcePath"`             // The path of the source to scan items
+	DeleteAfterExport         bool            `validate:"required" json:"deleteAfterExport"`      // Delete the source after exporting to CAR files
+	RescanInterval            string          `validate:"required" json:"rescanInterval"`         // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState             model.WorkState `validate:"required" json:"scanningState"`          // Starting state for scanning
+	AcknowledgeAbuse          string          `json:"acknowledgeAbuse" default:"false"`           // Set to allow files which return cannotDownloadAbusiveFile to be downloaded.
+	AllowImportNameChange     string          `json:"allowImportNameChange" default:"false"`      // Allow the filetype to change when uploading Google docs.
+	AlternateExport           string          `json:"alternateExport" default:"false"`            // Deprecated: No longer needed.
+	AuthOwnerOnly             string          `json:"authOwnerOnly" default:"false"`              // Only consider files owned by the authenticated user.
+	AuthUrl                   string          `json:"authUrl"`                                    // Auth server URL.
+	ChunkSize                 string          `json:"chunkSize" default:"8Mi"`                    // Upload chunk size.
+	ClientId                  string          `json:"clientId"`                                   // Google Application Client Id
+	ClientSecret              string          `json:"clientSecret"`                               // OAuth Client Secret.
+	CopyShortcutContent       string          `json:"copyShortcutContent" default:"false"`        // Server side copy contents of shortcuts instead of the shortcut.
+	DisableHttp2              string          `json:"disableHttp2" default:"true"`                // Disable drive using http2.
+	Encoding                  string          `json:"encoding" default:"InvalidUtf8"`             // The encoding for the backend.
+	ExportFormats             string          `json:"exportFormats" default:"docx,xlsx,pptx,svg"` // Comma separated list of preferred formats for downloading Google docs.
+	Formats                   string          `json:"formats"`                                    // Deprecated: See export_formats.
+	Impersonate               string          `json:"impersonate"`                                // Impersonate this user when using a service account.
+	ImportFormats             string          `json:"importFormats"`                              // Comma separated list of preferred formats for uploading Google docs.
+	KeepRevisionForever       string          `json:"keepRevisionForever" default:"false"`        // Keep new head revision of each file forever.
+	ListChunk                 string          `json:"listChunk" default:"1000"`                   // Size of listing chunk 100-1000, 0 to disable.
+	PacerBurst                string          `json:"pacerBurst" default:"100"`                   // Number of API calls to allow without sleeping.
+	PacerMinSleep             string          `json:"pacerMinSleep" default:"100ms"`              // Minimum time to sleep between API calls.
+	ResourceKey               string          `json:"resourceKey"`                                // Resource key for accessing a link-shared file.
+	RootFolderId              string          `json:"rootFolderId"`                               // ID of the root folder.
+	Scope                     string          `json:"scope"`                                      // Scope that rclone should use when requesting access from drive.
+	ServerSideAcrossConfigs   string          `json:"serverSideAcrossConfigs" default:"false"`    // Allow server-side operations (e.g. copy) to work across different drive configs.
+	ServiceAccountCredentials string          `json:"serviceAccountCredentials"`                  // Service Account Credentials JSON blob.
+	ServiceAccountFile        string          `json:"serviceAccountFile"`                         // Service Account Credentials JSON file path.
+	SharedWithMe              string          `json:"sharedWithMe" default:"false"`               // Only show files that are shared with me.
+	SizeAsQuota               string          `json:"sizeAsQuota" default:"false"`                // Show sizes as storage quota usage, not actual size.
+	SkipChecksumGphotos       string          `json:"skipChecksumGphotos" default:"false"`        // Skip MD5 checksum on Google photos and videos only.
+	SkipDanglingShortcuts     string          `json:"skipDanglingShortcuts" default:"false"`      // If set skip dangling shortcut files.
+	SkipGdocs                 string          `json:"skipGdocs" default:"false"`                  // Skip google documents in all listings.
+	SkipShortcuts             string          `json:"skipShortcuts" default:"false"`              // If set skip shortcut files.
+	StarredOnly               string          `json:"starredOnly" default:"false"`                // Only show files that are starred.
+	StopOnDownloadLimit       string          `json:"stopOnDownloadLimit" default:"false"`        // Make download limit errors be fatal.
+	StopOnUploadLimit         string          `json:"stopOnUploadLimit" default:"false"`          // Make upload limit errors be fatal.
+	TeamDrive                 string          `json:"teamDrive"`                                  // ID of the Shared Drive (Team Drive).
+	Token                     string          `json:"token"`                                      // OAuth Access Token as a JSON blob.
+	TokenUrl                  string          `json:"tokenUrl"`                                   // Token server url.
+	TrashedOnly               string          `json:"trashedOnly" default:"false"`                // Only show files that are in the trash.
+	UploadCutoff              string          `json:"uploadCutoff" default:"8Mi"`                 // Cutoff for switching to chunked upload.
+	UseCreatedDate            string          `json:"useCreatedDate" default:"false"`             // Use file created date instead of modified date.
+	UseSharedDate             string          `json:"useSharedDate" default:"false"`              // Use date file was shared instead of modified date.
+	UseTrash                  string          `json:"useTrash" default:"true"`                    // Send files to the trash instead of deleting permanently.
+	V2DownloadMinSize         string          `json:"v2DownloadMinSize" default:"off"`            // If Object's are greater, use drive v2 API to download.
 }
 
 // @Summary Add drive source for a dataset
@@ -208,23 +217,24 @@ type DriveRequest struct {
 func handleDrive() {}
 
 type DropboxRequest struct {
-	SourcePath         string `validate:"required" json:"sourcePath"`                                    // The path of the source to scan items
-	DeleteAfterExport  bool   `validate:"required" json:"deleteAfterExport"`                             // Delete the source after exporting to CAR files
-	RescanInterval     string `validate:"required" json:"rescanInterval"`                                // Automatically rescan the source directory when this interval has passed from last successful scan
-	AuthUrl            string `json:"authUrl"`                                                           // Auth server URL.
-	BatchCommitTimeout string `json:"batchCommitTimeout" default:"10m0s"`                                // Max time to wait for a batch to finish committing
-	BatchMode          string `json:"batchMode" default:"sync"`                                          // Upload file batching sync|async|off.
-	BatchSize          string `json:"batchSize" default:"0"`                                             // Max number of files in upload batch.
-	BatchTimeout       string `json:"batchTimeout" default:"0s"`                                         // Max time to allow an idle upload batch before uploading.
-	ChunkSize          string `json:"chunkSize" default:"48Mi"`                                          // Upload chunk size (< 150Mi).
-	ClientId           string `json:"clientId"`                                                          // OAuth Client Id.
-	ClientSecret       string `json:"clientSecret"`                                                      // OAuth Client Secret.
-	Encoding           string `json:"encoding" default:"Slash,BackSlash,Del,RightSpace,InvalidUtf8,Dot"` // The encoding for the backend.
-	Impersonate        string `json:"impersonate"`                                                       // Impersonate this user when using a business account.
-	SharedFiles        string `json:"sharedFiles" default:"false"`                                       // Instructs rclone to work on individual shared files.
-	SharedFolders      string `json:"sharedFolders" default:"false"`                                     // Instructs rclone to work on shared folders.
-	Token              string `json:"token"`                                                             // OAuth Access Token as a JSON blob.
-	TokenUrl           string `json:"tokenUrl"`                                                          // Token server url.
+	SourcePath         string          `validate:"required" json:"sourcePath"`                                    // The path of the source to scan items
+	DeleteAfterExport  bool            `validate:"required" json:"deleteAfterExport"`                             // Delete the source after exporting to CAR files
+	RescanInterval     string          `validate:"required" json:"rescanInterval"`                                // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState      model.WorkState `validate:"required" json:"scanningState"`                                 // Starting state for scanning
+	AuthUrl            string          `json:"authUrl"`                                                           // Auth server URL.
+	BatchCommitTimeout string          `json:"batchCommitTimeout" default:"10m0s"`                                // Max time to wait for a batch to finish committing
+	BatchMode          string          `json:"batchMode" default:"sync"`                                          // Upload file batching sync|async|off.
+	BatchSize          string          `json:"batchSize" default:"0"`                                             // Max number of files in upload batch.
+	BatchTimeout       string          `json:"batchTimeout" default:"0s"`                                         // Max time to allow an idle upload batch before uploading.
+	ChunkSize          string          `json:"chunkSize" default:"48Mi"`                                          // Upload chunk size (< 150Mi).
+	ClientId           string          `json:"clientId"`                                                          // OAuth Client Id.
+	ClientSecret       string          `json:"clientSecret"`                                                      // OAuth Client Secret.
+	Encoding           string          `json:"encoding" default:"Slash,BackSlash,Del,RightSpace,InvalidUtf8,Dot"` // The encoding for the backend.
+	Impersonate        string          `json:"impersonate"`                                                       // Impersonate this user when using a business account.
+	SharedFiles        string          `json:"sharedFiles" default:"false"`                                       // Instructs rclone to work on individual shared files.
+	SharedFolders      string          `json:"sharedFolders" default:"false"`                                     // Instructs rclone to work on shared folders.
+	Token              string          `json:"token"`                                                             // OAuth Access Token as a JSON blob.
+	TokenUrl           string          `json:"tokenUrl"`                                                          // Token server url.
 }
 
 // @Summary Add dropbox source for a dataset
@@ -240,14 +250,15 @@ type DropboxRequest struct {
 func handleDropbox() {}
 
 type FichierRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`                                                                                                // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`                                                                                         // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`                                                                                            // Automatically rescan the source directory when this interval has passed from last successful scan
-	ApiKey            string `json:"apiKey"`                                                                                                                        // Your API Key, get it from https://1fichier.com/console/params.pl.
-	Encoding          string `json:"encoding" default:"Slash,LtGt,DoubleQuote,SingleQuote,BackQuote,Dollar,BackSlash,Del,Ctl,LeftSpace,RightSpace,InvalidUtf8,Dot"` // The encoding for the backend.
-	FilePassword      string `json:"filePassword"`                                                                                                                  // If you want to download a shared file that is password protected, add this parameter.
-	FolderPassword    string `json:"folderPassword"`                                                                                                                // If you want to list the files in a shared folder that is password protected, add this parameter.
-	SharedFolder      string `json:"sharedFolder"`                                                                                                                  // If you want to download a shared folder, add this parameter.
+	SourcePath        string          `validate:"required" json:"sourcePath"`                                                                                                // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`                                                                                         // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`                                                                                            // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`                                                                                             // Starting state for scanning
+	ApiKey            string          `json:"apiKey"`                                                                                                                        // Your API Key, get it from https://1fichier.com/console/params.pl.
+	Encoding          string          `json:"encoding" default:"Slash,LtGt,DoubleQuote,SingleQuote,BackQuote,Dollar,BackSlash,Del,Ctl,LeftSpace,RightSpace,InvalidUtf8,Dot"` // The encoding for the backend.
+	FilePassword      string          `json:"filePassword"`                                                                                                                  // If you want to download a shared file that is password protected, add this parameter.
+	FolderPassword    string          `json:"folderPassword"`                                                                                                                // If you want to list the files in a shared folder that is password protected, add this parameter.
+	SharedFolder      string          `json:"sharedFolder"`                                                                                                                  // If you want to download a shared folder, add this parameter.
 }
 
 // @Summary Add fichier source for a dataset
@@ -263,16 +274,17 @@ type FichierRequest struct {
 func handleFichier() {}
 
 type FilefabricRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`                   // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`            // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`               // Automatically rescan the source directory when this interval has passed from last successful scan
-	Encoding          string `json:"encoding" default:"Slash,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
-	PermanentToken    string `json:"permanentToken"`                                   // Permanent Authentication Token.
-	RootFolderId      string `json:"rootFolderId"`                                     // ID of the root folder.
-	Token             string `json:"token"`                                            // Session Token.
-	TokenExpiry       string `json:"tokenExpiry"`                                      // Token expiry time.
-	Url               string `json:"url"`                                              // URL of the Enterprise File Fabric to connect to.
-	Version           string `json:"version"`                                          // Version read from the file fabric.
+	SourcePath        string          `validate:"required" json:"sourcePath"`                   // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`            // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`               // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`                // Starting state for scanning
+	Encoding          string          `json:"encoding" default:"Slash,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
+	PermanentToken    string          `json:"permanentToken"`                                   // Permanent Authentication Token.
+	RootFolderId      string          `json:"rootFolderId"`                                     // ID of the root folder.
+	Token             string          `json:"token"`                                            // Session Token.
+	TokenExpiry       string          `json:"tokenExpiry"`                                      // Token expiry time.
+	Url               string          `json:"url"`                                              // URL of the Enterprise File Fabric to connect to.
+	Version           string          `json:"version"`                                          // Version read from the file fabric.
 }
 
 // @Summary Add filefabric source for a dataset
@@ -288,29 +300,30 @@ type FilefabricRequest struct {
 func handleFilefabric() {}
 
 type FtpRequest struct {
-	SourcePath         string `validate:"required" json:"sourcePath"`                  // The path of the source to scan items
-	DeleteAfterExport  bool   `validate:"required" json:"deleteAfterExport"`           // Delete the source after exporting to CAR files
-	RescanInterval     string `validate:"required" json:"rescanInterval"`              // Automatically rescan the source directory when this interval has passed from last successful scan
-	AskPassword        string `json:"askPassword" default:"false"`                     // Allow asking for FTP password when needed.
-	CloseTimeout       string `json:"closeTimeout" default:"1m0s"`                     // Maximum time to wait for a response to close.
-	Concurrency        string `json:"concurrency" default:"0"`                         // Maximum number of FTP simultaneous connections, 0 for unlimited.
-	DisableEpsv        string `json:"disableEpsv" default:"false"`                     // Disable using EPSV even if server advertises support.
-	DisableMlsd        string `json:"disableMlsd" default:"false"`                     // Disable using MLSD even if server advertises support.
-	DisableTls13       string `json:"disableTls13" default:"false"`                    // Disable TLS 1.3 (workaround for FTP servers with buggy TLS)
-	DisableUtf8        string `json:"disableUtf8" default:"false"`                     // Disable using UTF-8 even if server advertises support.
-	Encoding           string `json:"encoding" default:"Slash,Del,Ctl,RightSpace,Dot"` // The encoding for the backend.
-	ExplicitTls        string `json:"explicitTls" default:"false"`                     // Use Explicit FTPS (FTP over TLS).
-	ForceListHidden    string `json:"forceListHidden" default:"false"`                 // Use LIST -a to force listing of hidden files and folders. This will disable the use of MLSD.
-	Host               string `json:"host"`                                            // FTP host to connect to.
-	IdleTimeout        string `json:"idleTimeout" default:"1m0s"`                      // Max time before closing idle connections.
-	NoCheckCertificate string `json:"noCheckCertificate" default:"false"`              // Do not verify the TLS certificate of the server.
-	Pass               string `json:"pass"`                                            // FTP password.
-	Port               string `json:"port" default:"21"`                               // FTP port number.
-	ShutTimeout        string `json:"shutTimeout" default:"1m0s"`                      // Maximum time to wait for data connection closing status.
-	Tls                string `json:"tls" default:"false"`                             // Use Implicit FTPS (FTP over TLS).
-	TlsCacheSize       string `json:"tlsCacheSize" default:"32"`                       // Size of TLS session cache for all control and data connections.
-	User               string `json:"user" default:"$USER"`                            // FTP username.
-	WritingMdtm        string `json:"writingMdtm" default:"false"`                     // Use MDTM to set modification time (VsFtpd quirk)
+	SourcePath         string          `validate:"required" json:"sourcePath"`                  // The path of the source to scan items
+	DeleteAfterExport  bool            `validate:"required" json:"deleteAfterExport"`           // Delete the source after exporting to CAR files
+	RescanInterval     string          `validate:"required" json:"rescanInterval"`              // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState      model.WorkState `validate:"required" json:"scanningState"`               // Starting state for scanning
+	AskPassword        string          `json:"askPassword" default:"false"`                     // Allow asking for FTP password when needed.
+	CloseTimeout       string          `json:"closeTimeout" default:"1m0s"`                     // Maximum time to wait for a response to close.
+	Concurrency        string          `json:"concurrency" default:"0"`                         // Maximum number of FTP simultaneous connections, 0 for unlimited.
+	DisableEpsv        string          `json:"disableEpsv" default:"false"`                     // Disable using EPSV even if server advertises support.
+	DisableMlsd        string          `json:"disableMlsd" default:"false"`                     // Disable using MLSD even if server advertises support.
+	DisableTls13       string          `json:"disableTls13" default:"false"`                    // Disable TLS 1.3 (workaround for FTP servers with buggy TLS)
+	DisableUtf8        string          `json:"disableUtf8" default:"false"`                     // Disable using UTF-8 even if server advertises support.
+	Encoding           string          `json:"encoding" default:"Slash,Del,Ctl,RightSpace,Dot"` // The encoding for the backend.
+	ExplicitTls        string          `json:"explicitTls" default:"false"`                     // Use Explicit FTPS (FTP over TLS).
+	ForceListHidden    string          `json:"forceListHidden" default:"false"`                 // Use LIST -a to force listing of hidden files and folders. This will disable the use of MLSD.
+	Host               string          `json:"host"`                                            // FTP host to connect to.
+	IdleTimeout        string          `json:"idleTimeout" default:"1m0s"`                      // Max time before closing idle connections.
+	NoCheckCertificate string          `json:"noCheckCertificate" default:"false"`              // Do not verify the TLS certificate of the server.
+	Pass               string          `json:"pass"`                                            // FTP password.
+	Port               string          `json:"port" default:"21"`                               // FTP port number.
+	ShutTimeout        string          `json:"shutTimeout" default:"1m0s"`                      // Maximum time to wait for data connection closing status.
+	Tls                string          `json:"tls" default:"false"`                             // Use Implicit FTPS (FTP over TLS).
+	TlsCacheSize       string          `json:"tlsCacheSize" default:"32"`                       // Size of TLS session cache for all control and data connections.
+	User               string          `json:"user" default:"$USER"`                            // FTP username.
+	WritingMdtm        string          `json:"writingMdtm" default:"false"`                     // Use MDTM to set modification time (VsFtpd quirk)
 }
 
 // @Summary Add ftp source for a dataset
@@ -326,28 +339,29 @@ type FtpRequest struct {
 func handleFtp() {}
 
 type GcsRequest struct {
-	SourcePath                string `validate:"required" json:"sourcePath"`                // The path of the source to scan items
-	DeleteAfterExport         bool   `validate:"required" json:"deleteAfterExport"`         // Delete the source after exporting to CAR files
-	RescanInterval            string `validate:"required" json:"rescanInterval"`            // Automatically rescan the source directory when this interval has passed from last successful scan
-	Anonymous                 string `json:"anonymous" default:"false"`                     // Access public buckets and objects without credentials.
-	AuthUrl                   string `json:"authUrl"`                                       // Auth server URL.
-	BucketAcl                 string `json:"bucketAcl"`                                     // Access Control List for new buckets.
-	BucketPolicyOnly          string `json:"bucketPolicyOnly" default:"false"`              // Access checks should use bucket-level IAM policies.
-	ClientId                  string `json:"clientId"`                                      // OAuth Client Id.
-	ClientSecret              string `json:"clientSecret"`                                  // OAuth Client Secret.
-	Decompress                string `json:"decompress" default:"false"`                    // If set this will decompress gzip encoded objects.
-	Encoding                  string `json:"encoding" default:"Slash,CrLf,InvalidUtf8,Dot"` // The encoding for the backend.
-	Endpoint                  string `json:"endpoint"`                                      // Endpoint for the service.
-	EnvAuth                   string `json:"envAuth" default:"false"`                       // Get GCP IAM credentials from runtime (environment variables or instance meta data if no env vars).
-	Location                  string `json:"location"`                                      // Location for the newly created buckets.
-	NoCheckBucket             string `json:"noCheckBucket" default:"false"`                 // If set, don't attempt to check the bucket exists or create it.
-	ObjectAcl                 string `json:"objectAcl"`                                     // Access Control List for new objects.
-	ProjectNumber             string `json:"projectNumber"`                                 // Project number.
-	ServiceAccountCredentials string `json:"serviceAccountCredentials"`                     // Service Account Credentials JSON blob.
-	ServiceAccountFile        string `json:"serviceAccountFile"`                            // Service Account Credentials JSON file path.
-	StorageClass              string `json:"storageClass"`                                  // The storage class to use when storing objects in Google Cloud Storage.
-	Token                     string `json:"token"`                                         // OAuth Access Token as a JSON blob.
-	TokenUrl                  string `json:"tokenUrl"`                                      // Token server url.
+	SourcePath                string          `validate:"required" json:"sourcePath"`                // The path of the source to scan items
+	DeleteAfterExport         bool            `validate:"required" json:"deleteAfterExport"`         // Delete the source after exporting to CAR files
+	RescanInterval            string          `validate:"required" json:"rescanInterval"`            // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState             model.WorkState `validate:"required" json:"scanningState"`             // Starting state for scanning
+	Anonymous                 string          `json:"anonymous" default:"false"`                     // Access public buckets and objects without credentials.
+	AuthUrl                   string          `json:"authUrl"`                                       // Auth server URL.
+	BucketAcl                 string          `json:"bucketAcl"`                                     // Access Control List for new buckets.
+	BucketPolicyOnly          string          `json:"bucketPolicyOnly" default:"false"`              // Access checks should use bucket-level IAM policies.
+	ClientId                  string          `json:"clientId"`                                      // OAuth Client Id.
+	ClientSecret              string          `json:"clientSecret"`                                  // OAuth Client Secret.
+	Decompress                string          `json:"decompress" default:"false"`                    // If set this will decompress gzip encoded objects.
+	Encoding                  string          `json:"encoding" default:"Slash,CrLf,InvalidUtf8,Dot"` // The encoding for the backend.
+	Endpoint                  string          `json:"endpoint"`                                      // Endpoint for the service.
+	EnvAuth                   string          `json:"envAuth" default:"false"`                       // Get GCP IAM credentials from runtime (environment variables or instance meta data if no env vars).
+	Location                  string          `json:"location"`                                      // Location for the newly created buckets.
+	NoCheckBucket             string          `json:"noCheckBucket" default:"false"`                 // If set, don't attempt to check the bucket exists or create it.
+	ObjectAcl                 string          `json:"objectAcl"`                                     // Access Control List for new objects.
+	ProjectNumber             string          `json:"projectNumber"`                                 // Project number.
+	ServiceAccountCredentials string          `json:"serviceAccountCredentials"`                     // Service Account Credentials JSON blob.
+	ServiceAccountFile        string          `json:"serviceAccountFile"`                            // Service Account Credentials JSON file path.
+	StorageClass              string          `json:"storageClass"`                                  // The storage class to use when storing objects in Google Cloud Storage.
+	Token                     string          `json:"token"`                                         // OAuth Access Token as a JSON blob.
+	TokenUrl                  string          `json:"tokenUrl"`                                      // Token server url.
 }
 
 // @Summary Add gcs source for a dataset
@@ -363,19 +377,20 @@ type GcsRequest struct {
 func handleGcs() {}
 
 type GphotosRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`                // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`         // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`            // Automatically rescan the source directory when this interval has passed from last successful scan
-	AuthUrl           string `json:"authUrl"`                                       // Auth server URL.
-	ClientId          string `json:"clientId"`                                      // OAuth Client Id.
-	ClientSecret      string `json:"clientSecret"`                                  // OAuth Client Secret.
-	Encoding          string `json:"encoding" default:"Slash,CrLf,InvalidUtf8,Dot"` // The encoding for the backend.
-	IncludeArchived   string `json:"includeArchived" default:"false"`               // Also view and download archived media.
-	ReadOnly          string `json:"readOnly" default:"false"`                      // Set to make the Google Photos backend read only.
-	ReadSize          string `json:"readSize" default:"false"`                      // Set to read the size of media items.
-	StartYear         string `json:"startYear" default:"2000"`                      // Year limits the photos to be downloaded to those which are uploaded after the given year.
-	Token             string `json:"token"`                                         // OAuth Access Token as a JSON blob.
-	TokenUrl          string `json:"tokenUrl"`                                      // Token server url.
+	SourcePath        string          `validate:"required" json:"sourcePath"`                // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`         // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`            // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`             // Starting state for scanning
+	AuthUrl           string          `json:"authUrl"`                                       // Auth server URL.
+	ClientId          string          `json:"clientId"`                                      // OAuth Client Id.
+	ClientSecret      string          `json:"clientSecret"`                                  // OAuth Client Secret.
+	Encoding          string          `json:"encoding" default:"Slash,CrLf,InvalidUtf8,Dot"` // The encoding for the backend.
+	IncludeArchived   string          `json:"includeArchived" default:"false"`               // Also view and download archived media.
+	ReadOnly          string          `json:"readOnly" default:"false"`                      // Set to make the Google Photos backend read only.
+	ReadSize          string          `json:"readSize" default:"false"`                      // Set to read the size of media items.
+	StartYear         string          `json:"startYear" default:"2000"`                      // Year limits the photos to be downloaded to those which are uploaded after the given year.
+	Token             string          `json:"token"`                                         // OAuth Access Token as a JSON blob.
+	TokenUrl          string          `json:"tokenUrl"`                                      // Token server url.
 }
 
 // @Summary Add gphotos source for a dataset
@@ -391,14 +406,15 @@ type GphotosRequest struct {
 func handleGphotos() {}
 
 type HdfsRequest struct {
-	SourcePath             string `validate:"required" json:"sourcePath"`                         // The path of the source to scan items
-	DeleteAfterExport      bool   `validate:"required" json:"deleteAfterExport"`                  // Delete the source after exporting to CAR files
-	RescanInterval         string `validate:"required" json:"rescanInterval"`                     // Automatically rescan the source directory when this interval has passed from last successful scan
-	DataTransferProtection string `json:"dataTransferProtection"`                                 // Kerberos data transfer protection: authentication|integrity|privacy.
-	Encoding               string `json:"encoding" default:"Slash,Colon,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
-	Namenode               string `json:"namenode"`                                               // Hadoop name node and port.
-	ServicePrincipalName   string `json:"servicePrincipalName"`                                   // Kerberos service principal name for the namenode.
-	Username               string `json:"username"`                                               // Hadoop user name.
+	SourcePath             string          `validate:"required" json:"sourcePath"`                         // The path of the source to scan items
+	DeleteAfterExport      bool            `validate:"required" json:"deleteAfterExport"`                  // Delete the source after exporting to CAR files
+	RescanInterval         string          `validate:"required" json:"rescanInterval"`                     // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState          model.WorkState `validate:"required" json:"scanningState"`                      // Starting state for scanning
+	DataTransferProtection string          `json:"dataTransferProtection"`                                 // Kerberos data transfer protection: authentication|integrity|privacy.
+	Encoding               string          `json:"encoding" default:"Slash,Colon,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
+	Namenode               string          `json:"namenode"`                                               // Hadoop name node and port.
+	ServicePrincipalName   string          `json:"servicePrincipalName"`                                   // Kerberos service principal name for the namenode.
+	Username               string          `json:"username"`                                               // Hadoop user name.
 }
 
 // @Summary Add hdfs source for a dataset
@@ -414,23 +430,24 @@ type HdfsRequest struct {
 func handleHdfs() {}
 
 type HidriveRequest struct {
-	SourcePath                 string `validate:"required" json:"sourcePath"`                        // The path of the source to scan items
-	DeleteAfterExport          bool   `validate:"required" json:"deleteAfterExport"`                 // Delete the source after exporting to CAR files
-	RescanInterval             string `validate:"required" json:"rescanInterval"`                    // Automatically rescan the source directory when this interval has passed from last successful scan
-	AuthUrl                    string `json:"authUrl"`                                               // Auth server URL.
-	ChunkSize                  string `json:"chunkSize" default:"48Mi"`                              // Chunksize for chunked uploads.
-	ClientId                   string `json:"clientId"`                                              // OAuth Client Id.
-	ClientSecret               string `json:"clientSecret"`                                          // OAuth Client Secret.
-	DisableFetchingMemberCount string `json:"disableFetchingMemberCount" default:"false"`            // Do not fetch number of objects in directories unless it is absolutely necessary.
-	Encoding                   string `json:"encoding" default:"Slash,Dot"`                          // The encoding for the backend.
-	Endpoint                   string `json:"endpoint" default:"https://api.hidrive.strato.com/2.1"` // Endpoint for the service.
-	RootPrefix                 string `json:"rootPrefix" default:"/"`                                // The root/parent folder for all paths.
-	ScopeAccess                string `json:"scopeAccess" default:"rw"`                              // Access permissions that rclone should use when requesting access from HiDrive.
-	ScopeRole                  string `json:"scopeRole" default:"user"`                              // User-level that rclone should use when requesting access from HiDrive.
-	Token                      string `json:"token"`                                                 // OAuth Access Token as a JSON blob.
-	TokenUrl                   string `json:"tokenUrl"`                                              // Token server url.
-	UploadConcurrency          string `json:"uploadConcurrency" default:"4"`                         // Concurrency for chunked uploads.
-	UploadCutoff               string `json:"uploadCutoff" default:"96Mi"`                           // Cutoff/Threshold for chunked uploads.
+	SourcePath                 string          `validate:"required" json:"sourcePath"`                        // The path of the source to scan items
+	DeleteAfterExport          bool            `validate:"required" json:"deleteAfterExport"`                 // Delete the source after exporting to CAR files
+	RescanInterval             string          `validate:"required" json:"rescanInterval"`                    // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState              model.WorkState `validate:"required" json:"scanningState"`                     // Starting state for scanning
+	AuthUrl                    string          `json:"authUrl"`                                               // Auth server URL.
+	ChunkSize                  string          `json:"chunkSize" default:"48Mi"`                              // Chunksize for chunked uploads.
+	ClientId                   string          `json:"clientId"`                                              // OAuth Client Id.
+	ClientSecret               string          `json:"clientSecret"`                                          // OAuth Client Secret.
+	DisableFetchingMemberCount string          `json:"disableFetchingMemberCount" default:"false"`            // Do not fetch number of objects in directories unless it is absolutely necessary.
+	Encoding                   string          `json:"encoding" default:"Slash,Dot"`                          // The encoding for the backend.
+	Endpoint                   string          `json:"endpoint" default:"https://api.hidrive.strato.com/2.1"` // Endpoint for the service.
+	RootPrefix                 string          `json:"rootPrefix" default:"/"`                                // The root/parent folder for all paths.
+	ScopeAccess                string          `json:"scopeAccess" default:"rw"`                              // Access permissions that rclone should use when requesting access from HiDrive.
+	ScopeRole                  string          `json:"scopeRole" default:"user"`                              // User-level that rclone should use when requesting access from HiDrive.
+	Token                      string          `json:"token"`                                                 // OAuth Access Token as a JSON blob.
+	TokenUrl                   string          `json:"tokenUrl"`                                              // Token server url.
+	UploadConcurrency          string          `json:"uploadConcurrency" default:"4"`                         // Concurrency for chunked uploads.
+	UploadCutoff               string          `json:"uploadCutoff" default:"96Mi"`                           // Cutoff/Threshold for chunked uploads.
 }
 
 // @Summary Add hidrive source for a dataset
@@ -446,13 +463,14 @@ type HidriveRequest struct {
 func handleHidrive() {}
 
 type HttpRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`        // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"` // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`    // Automatically rescan the source directory when this interval has passed from last successful scan
-	Headers           string `json:"headers"`                               // Set HTTP headers for all transactions.
-	NoHead            string `json:"noHead" default:"false"`                // Don't use HEAD requests.
-	NoSlash           string `json:"noSlash" default:"false"`               // Set this if the site doesn't end directories with /.
-	Url               string `json:"url"`                                   // URL of HTTP host to connect to.
+	SourcePath        string          `validate:"required" json:"sourcePath"`        // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"` // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`    // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`     // Starting state for scanning
+	Headers           string          `json:"headers"`                               // Set HTTP headers for all transactions.
+	NoHead            string          `json:"noHead" default:"false"`                // Don't use HEAD requests.
+	NoSlash           string          `json:"noSlash" default:"false"`               // Set this if the site doesn't end directories with /.
+	Url               string          `json:"url"`                                   // URL of HTTP host to connect to.
 }
 
 // @Summary Add http source for a dataset
@@ -468,16 +486,17 @@ type HttpRequest struct {
 func handleHttp() {}
 
 type InternetarchiveRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`                             // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`                      // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`                         // Automatically rescan the source directory when this interval has passed from last successful scan
-	AccessKeyId       string `json:"accessKeyId"`                                                // IAS3 Access Key.
-	DisableChecksum   string `json:"disableChecksum" default:"true"`                             // Don't ask the server to test against MD5 checksum calculated by rclone.
-	Encoding          string `json:"encoding" default:"Slash,LtGt,CrLf,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
-	Endpoint          string `json:"endpoint" default:"https://s3.us.archive.org"`               // IAS3 Endpoint.
-	FrontEndpoint     string `json:"frontEndpoint" default:"https://archive.org"`                // Host of InternetArchive Frontend.
-	SecretAccessKey   string `json:"secretAccessKey"`                                            // IAS3 Secret Key (password).
-	WaitArchive       string `json:"waitArchive" default:"0s"`                                   // Timeout for waiting the server's processing tasks (specifically archive and book_op) to finish.
+	SourcePath        string          `validate:"required" json:"sourcePath"`                             // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`                      // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`                         // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`                          // Starting state for scanning
+	AccessKeyId       string          `json:"accessKeyId"`                                                // IAS3 Access Key.
+	DisableChecksum   string          `json:"disableChecksum" default:"true"`                             // Don't ask the server to test against MD5 checksum calculated by rclone.
+	Encoding          string          `json:"encoding" default:"Slash,LtGt,CrLf,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
+	Endpoint          string          `json:"endpoint" default:"https://s3.us.archive.org"`               // IAS3 Endpoint.
+	FrontEndpoint     string          `json:"frontEndpoint" default:"https://archive.org"`                // Host of InternetArchive Frontend.
+	SecretAccessKey   string          `json:"secretAccessKey"`                                            // IAS3 Secret Key (password).
+	WaitArchive       string          `json:"waitArchive" default:"0s"`                                   // Timeout for waiting the server's processing tasks (specifically archive and book_op) to finish.
 }
 
 // @Summary Add internetarchive source for a dataset
@@ -493,15 +512,16 @@ type InternetarchiveRequest struct {
 func handleInternetarchive() {}
 
 type JottacloudRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`                                                                 // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`                                                          // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`                                                             // Automatically rescan the source directory when this interval has passed from last successful scan
-	Encoding          string `json:"encoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
-	HardDelete        string `json:"hardDelete" default:"false"`                                                                     // Delete files permanently rather than putting them into the trash.
-	Md5MemoryLimit    string `json:"md5MemoryLimit" default:"10Mi"`                                                                  // Files bigger than this will be cached on disk to calculate the MD5 if required.
-	NoVersions        string `json:"noVersions" default:"false"`                                                                     // Avoid server side versioning by deleting files and recreating files instead of overwriting them.
-	TrashedOnly       string `json:"trashedOnly" default:"false"`                                                                    // Only show files that are in the trash.
-	UploadResumeLimit string `json:"uploadResumeLimit" default:"10Mi"`                                                               // Files bigger than this can be resumed if the upload fail's.
+	SourcePath        string          `validate:"required" json:"sourcePath"`                                                                 // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`                                                          // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`                                                             // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`                                                              // Starting state for scanning
+	Encoding          string          `json:"encoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
+	HardDelete        string          `json:"hardDelete" default:"false"`                                                                     // Delete files permanently rather than putting them into the trash.
+	Md5MemoryLimit    string          `json:"md5MemoryLimit" default:"10Mi"`                                                                  // Files bigger than this will be cached on disk to calculate the MD5 if required.
+	NoVersions        string          `json:"noVersions" default:"false"`                                                                     // Avoid server side versioning by deleting files and recreating files instead of overwriting them.
+	TrashedOnly       string          `json:"trashedOnly" default:"false"`                                                                    // Only show files that are in the trash.
+	UploadResumeLimit string          `json:"uploadResumeLimit" default:"10Mi"`                                                               // Files bigger than this can be resumed if the upload fail's.
 }
 
 // @Summary Add jottacloud source for a dataset
@@ -517,16 +537,17 @@ type JottacloudRequest struct {
 func handleJottacloud() {}
 
 type KoofrRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`                             // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`                      // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`                         // Automatically rescan the source directory when this interval has passed from last successful scan
-	Encoding          string `json:"encoding" default:"Slash,BackSlash,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
-	Endpoint          string `json:"endpoint"`                                                   // The Koofr API endpoint to use.
-	Mountid           string `json:"mountid"`                                                    // Mount ID of the mount to use.
-	Password          string `json:"password"`                                                   // Your password for rclone (generate one at https://app.koofr.net/app/admin/preferences/password).
-	Provider          string `json:"provider"`                                                   // Choose your storage provider.
-	Setmtime          string `json:"setmtime" default:"true"`                                    // Does the backend support setting modification time.
-	User              string `json:"user"`                                                       // Your user name.
+	SourcePath        string          `validate:"required" json:"sourcePath"`                             // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`                      // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`                         // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`                          // Starting state for scanning
+	Encoding          string          `json:"encoding" default:"Slash,BackSlash,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
+	Endpoint          string          `json:"endpoint"`                                                   // The Koofr API endpoint to use.
+	Mountid           string          `json:"mountid"`                                                    // Mount ID of the mount to use.
+	Password          string          `json:"password"`                                                   // Your password for rclone (generate one at https://app.koofr.net/app/admin/preferences/password).
+	Provider          string          `json:"provider"`                                                   // Choose your storage provider.
+	Setmtime          string          `json:"setmtime" default:"true"`                                    // Does the backend support setting modification time.
+	User              string          `json:"user"`                                                       // Your user name.
 }
 
 // @Summary Add koofr source for a dataset
@@ -542,23 +563,24 @@ type KoofrRequest struct {
 func handleKoofr() {}
 
 type LocalRequest struct {
-	SourcePath           string `validate:"required" json:"sourcePath"`        // The path of the source to scan items
-	DeleteAfterExport    bool   `validate:"required" json:"deleteAfterExport"` // Delete the source after exporting to CAR files
-	RescanInterval       string `validate:"required" json:"rescanInterval"`    // Automatically rescan the source directory when this interval has passed from last successful scan
-	CaseInsensitive      string `json:"caseInsensitive" default:"false"`       // Force the filesystem to report itself as case insensitive.
-	CaseSensitive        string `json:"caseSensitive" default:"false"`         // Force the filesystem to report itself as case sensitive.
-	CopyLinks            string `json:"copyLinks" default:"false"`             // Follow symlinks and copy the pointed to item.
-	Encoding             string `json:"encoding" default:"Slash,Dot"`          // The encoding for the backend.
-	Links                string `json:"links" default:"false"`                 // Translate symlinks to/from regular files with a '.rclonelink' extension.
-	NoCheckUpdated       string `json:"noCheckUpdated" default:"false"`        // Don't check to see if the files change during upload.
-	NoPreallocate        string `json:"noPreallocate" default:"false"`         // Disable preallocation of disk space for transferred files.
-	NoSetModtime         string `json:"noSetModtime" default:"false"`          // Disable setting modtime.
-	NoSparse             string `json:"noSparse" default:"false"`              // Disable sparse files for multi-thread downloads.
-	Nounc                string `json:"nounc" default:"false"`                 // Disable UNC (long path names) conversion on Windows.
-	OneFileSystem        string `json:"oneFileSystem" default:"false"`         // Don't cross filesystem boundaries (unix/macOS only).
-	SkipLinks            string `json:"skipLinks" default:"false"`             // Don't warn about skipped symlinks.
-	UnicodeNormalization string `json:"unicodeNormalization" default:"false"`  // Apply unicode NFC normalization to paths and filenames.
-	ZeroSizeLinks        string `json:"zeroSizeLinks" default:"false"`         // Assume the Stat size of links is zero (and read them instead) (deprecated).
+	SourcePath           string          `validate:"required" json:"sourcePath"`        // The path of the source to scan items
+	DeleteAfterExport    bool            `validate:"required" json:"deleteAfterExport"` // Delete the source after exporting to CAR files
+	RescanInterval       string          `validate:"required" json:"rescanInterval"`    // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState        model.WorkState `validate:"required" json:"scanningState"`     // Starting state for scanning
+	CaseInsensitive      string          `json:"caseInsensitive" default:"false"`       // Force the filesystem to report itself as case insensitive.
+	CaseSensitive        string          `json:"caseSensitive" default:"false"`         // Force the filesystem to report itself as case sensitive.
+	CopyLinks            string          `json:"copyLinks" default:"false"`             // Follow symlinks and copy the pointed to item.
+	Encoding             string          `json:"encoding" default:"Slash,Dot"`          // The encoding for the backend.
+	Links                string          `json:"links" default:"false"`                 // Translate symlinks to/from regular files with a '.rclonelink' extension.
+	NoCheckUpdated       string          `json:"noCheckUpdated" default:"false"`        // Don't check to see if the files change during upload.
+	NoPreallocate        string          `json:"noPreallocate" default:"false"`         // Disable preallocation of disk space for transferred files.
+	NoSetModtime         string          `json:"noSetModtime" default:"false"`          // Disable setting modtime.
+	NoSparse             string          `json:"noSparse" default:"false"`              // Disable sparse files for multi-thread downloads.
+	Nounc                string          `json:"nounc" default:"false"`                 // Disable UNC (long path names) conversion on Windows.
+	OneFileSystem        string          `json:"oneFileSystem" default:"false"`         // Don't cross filesystem boundaries (unix/macOS only).
+	SkipLinks            string          `json:"skipLinks" default:"false"`             // Don't warn about skipped symlinks.
+	UnicodeNormalization string          `json:"unicodeNormalization" default:"false"`  // Apply unicode NFC normalization to paths and filenames.
+	ZeroSizeLinks        string          `json:"zeroSizeLinks" default:"false"`         // Assume the Stat size of links is zero (and read them instead) (deprecated).
 }
 
 // @Summary Add local source for a dataset
@@ -574,19 +596,20 @@ type LocalRequest struct {
 func handleLocal() {}
 
 type MailruRequest struct {
-	SourcePath          string `validate:"required" json:"sourcePath"`                                                                           // The path of the source to scan items
-	DeleteAfterExport   bool   `validate:"required" json:"deleteAfterExport"`                                                                    // Delete the source after exporting to CAR files
-	RescanInterval      string `validate:"required" json:"rescanInterval"`                                                                       // Automatically rescan the source directory when this interval has passed from last successful scan
-	CheckHash           string `json:"checkHash" default:"true"`                                                                                 // What should copy do if file checksum is mismatched or invalid.
-	Encoding            string `json:"encoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
-	Pass                string `json:"pass"`                                                                                                     // Password.
-	Quirks              string `json:"quirks"`                                                                                                   // Comma separated list of internal maintenance flags.
-	SpeedupEnable       string `json:"speedupEnable" default:"true"`                                                                             // Skip full upload if there is another file with same data hash.
-	SpeedupFilePatterns string `json:"speedupFilePatterns" default:"*.mkv,*.avi,*.mp4,*.mp3,*.zip,*.gz,*.rar,*.pdf"`                             // Comma separated list of file name patterns eligible for speedup (put by hash).
-	SpeedupMaxDisk      string `json:"speedupMaxDisk" default:"3Gi"`                                                                             // This option allows you to disable speedup (put by hash) for large files.
-	SpeedupMaxMemory    string `json:"speedupMaxMemory" default:"32Mi"`                                                                          // Files larger than the size given below will always be hashed on disk.
-	User                string `json:"user"`                                                                                                     // User name (usually email).
-	UserAgent           string `json:"userAgent"`                                                                                                // HTTP user agent used internally by client.
+	SourcePath          string          `validate:"required" json:"sourcePath"`                                                                           // The path of the source to scan items
+	DeleteAfterExport   bool            `validate:"required" json:"deleteAfterExport"`                                                                    // Delete the source after exporting to CAR files
+	RescanInterval      string          `validate:"required" json:"rescanInterval"`                                                                       // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState       model.WorkState `validate:"required" json:"scanningState"`                                                                        // Starting state for scanning
+	CheckHash           string          `json:"checkHash" default:"true"`                                                                                 // What should copy do if file checksum is mismatched or invalid.
+	Encoding            string          `json:"encoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
+	Pass                string          `json:"pass"`                                                                                                     // Password.
+	Quirks              string          `json:"quirks"`                                                                                                   // Comma separated list of internal maintenance flags.
+	SpeedupEnable       string          `json:"speedupEnable" default:"true"`                                                                             // Skip full upload if there is another file with same data hash.
+	SpeedupFilePatterns string          `json:"speedupFilePatterns" default:"*.mkv,*.avi,*.mp4,*.mp3,*.zip,*.gz,*.rar,*.pdf"`                             // Comma separated list of file name patterns eligible for speedup (put by hash).
+	SpeedupMaxDisk      string          `json:"speedupMaxDisk" default:"3Gi"`                                                                             // This option allows you to disable speedup (put by hash) for large files.
+	SpeedupMaxMemory    string          `json:"speedupMaxMemory" default:"32Mi"`                                                                          // Files larger than the size given below will always be hashed on disk.
+	User                string          `json:"user"`                                                                                                     // User name (usually email).
+	UserAgent           string          `json:"userAgent"`                                                                                                // HTTP user agent used internally by client.
 }
 
 // @Summary Add mailru source for a dataset
@@ -602,15 +625,16 @@ type MailruRequest struct {
 func handleMailru() {}
 
 type MegaRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`           // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`    // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`       // Automatically rescan the source directory when this interval has passed from last successful scan
-	Debug             string `json:"debug" default:"false"`                    // Output more debug from Mega.
-	Encoding          string `json:"encoding" default:"Slash,InvalidUtf8,Dot"` // The encoding for the backend.
-	HardDelete        string `json:"hardDelete" default:"false"`               // Delete files permanently rather than putting them into the trash.
-	Pass              string `json:"pass"`                                     // Password.
-	UseHttps          string `json:"useHttps" default:"false"`                 // Use HTTPS for transfers.
-	User              string `json:"user"`                                     // User name.
+	SourcePath        string          `validate:"required" json:"sourcePath"`           // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`    // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`       // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`        // Starting state for scanning
+	Debug             string          `json:"debug" default:"false"`                    // Output more debug from Mega.
+	Encoding          string          `json:"encoding" default:"Slash,InvalidUtf8,Dot"` // The encoding for the backend.
+	HardDelete        string          `json:"hardDelete" default:"false"`               // Delete files permanently rather than putting them into the trash.
+	Pass              string          `json:"pass"`                                     // Password.
+	UseHttps          string          `json:"useHttps" default:"false"`                 // Use HTTPS for transfers.
+	User              string          `json:"user"`                                     // User name.
 }
 
 // @Summary Add mega source for a dataset
@@ -626,13 +650,14 @@ type MegaRequest struct {
 func handleMega() {}
 
 type NetstorageRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`        // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"` // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`    // Automatically rescan the source directory when this interval has passed from last successful scan
-	Account           string `json:"account"`                               // Set the NetStorage account name
-	Host              string `json:"host"`                                  // Domain+path of NetStorage host to connect to.
-	Protocol          string `json:"protocol" default:"https"`              // Select between HTTP or HTTPS protocol.
-	Secret            string `json:"secret"`                                // Set the NetStorage account secret/G2O key for authentication.
+	SourcePath        string          `validate:"required" json:"sourcePath"`        // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"` // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`    // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`     // Starting state for scanning
+	Account           string          `json:"account"`                               // Set the NetStorage account name
+	Host              string          `json:"host"`                                  // Domain+path of NetStorage host to connect to.
+	Protocol          string          `json:"protocol" default:"https"`              // Select between HTTP or HTTPS protocol.
+	Secret            string          `json:"secret"`                                // Set the NetStorage account secret/G2O key for authentication.
 }
 
 // @Summary Add netstorage source for a dataset
@@ -648,30 +673,31 @@ type NetstorageRequest struct {
 func handleNetstorage() {}
 
 type OnedriveRequest struct {
-	SourcePath              string `validate:"required" json:"sourcePath"`                                                                                                                      // The path of the source to scan items
-	DeleteAfterExport       bool   `validate:"required" json:"deleteAfterExport"`                                                                                                               // Delete the source after exporting to CAR files
-	RescanInterval          string `validate:"required" json:"rescanInterval"`                                                                                                                  // Automatically rescan the source directory when this interval has passed from last successful scan
-	AccessScopes            string `json:"accessScopes" default:"Files.Read Files.ReadWrite Files.Read.All Files.ReadWrite.All Sites.Read.All offline_access"`                                  // Set scopes to be requested by rclone.
-	AuthUrl                 string `json:"authUrl"`                                                                                                                                             // Auth server URL.
-	ChunkSize               string `json:"chunkSize" default:"10Mi"`                                                                                                                            // Chunk size to upload files with - must be multiple of 320k (327,680 bytes).
-	ClientId                string `json:"clientId"`                                                                                                                                            // OAuth Client Id.
-	ClientSecret            string `json:"clientSecret"`                                                                                                                                        // OAuth Client Secret.
-	DisableSitePermission   string `json:"disableSitePermission" default:"false"`                                                                                                               // Disable the request for Sites.Read.All permission.
-	DriveId                 string `json:"driveId"`                                                                                                                                             // The ID of the drive to use.
-	DriveType               string `json:"driveType"`                                                                                                                                           // The type of the drive (personal | business | documentLibrary).
-	Encoding                string `json:"encoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,Del,Ctl,LeftSpace,LeftTilde,RightSpace,RightPeriod,InvalidUtf8,Dot"` // The encoding for the backend.
-	ExposeOnenoteFiles      string `json:"exposeOnenoteFiles" default:"false"`                                                                                                                  // Set to make OneNote files show up in directory listings.
-	HashType                string `json:"hashType" default:"auto"`                                                                                                                             // Specify the hash in use for the backend.
-	LinkPassword            string `json:"linkPassword"`                                                                                                                                        // Set the password for links created by the link command.
-	LinkScope               string `json:"linkScope" default:"anonymous"`                                                                                                                       // Set the scope of the links created by the link command.
-	LinkType                string `json:"linkType" default:"view"`                                                                                                                             // Set the type of the links created by the link command.
-	ListChunk               string `json:"listChunk" default:"1000"`                                                                                                                            // Size of listing chunk.
-	NoVersions              string `json:"noVersions" default:"false"`                                                                                                                          // Remove all versions on modifying operations.
-	Region                  string `json:"region" default:"global"`                                                                                                                             // Choose national cloud region for OneDrive.
-	RootFolderId            string `json:"rootFolderId"`                                                                                                                                        // ID of the root folder.
-	ServerSideAcrossConfigs string `json:"serverSideAcrossConfigs" default:"false"`                                                                                                             // Allow server-side operations (e.g. copy) to work across different onedrive configs.
-	Token                   string `json:"token"`                                                                                                                                               // OAuth Access Token as a JSON blob.
-	TokenUrl                string `json:"tokenUrl"`                                                                                                                                            // Token server url.
+	SourcePath              string          `validate:"required" json:"sourcePath"`                                                                                                                      // The path of the source to scan items
+	DeleteAfterExport       bool            `validate:"required" json:"deleteAfterExport"`                                                                                                               // Delete the source after exporting to CAR files
+	RescanInterval          string          `validate:"required" json:"rescanInterval"`                                                                                                                  // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState           model.WorkState `validate:"required" json:"scanningState"`                                                                                                                   // Starting state for scanning
+	AccessScopes            string          `json:"accessScopes" default:"Files.Read Files.ReadWrite Files.Read.All Files.ReadWrite.All Sites.Read.All offline_access"`                                  // Set scopes to be requested by rclone.
+	AuthUrl                 string          `json:"authUrl"`                                                                                                                                             // Auth server URL.
+	ChunkSize               string          `json:"chunkSize" default:"10Mi"`                                                                                                                            // Chunk size to upload files with - must be multiple of 320k (327,680 bytes).
+	ClientId                string          `json:"clientId"`                                                                                                                                            // OAuth Client Id.
+	ClientSecret            string          `json:"clientSecret"`                                                                                                                                        // OAuth Client Secret.
+	DisableSitePermission   string          `json:"disableSitePermission" default:"false"`                                                                                                               // Disable the request for Sites.Read.All permission.
+	DriveId                 string          `json:"driveId"`                                                                                                                                             // The ID of the drive to use.
+	DriveType               string          `json:"driveType"`                                                                                                                                           // The type of the drive (personal | business | documentLibrary).
+	Encoding                string          `json:"encoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,Del,Ctl,LeftSpace,LeftTilde,RightSpace,RightPeriod,InvalidUtf8,Dot"` // The encoding for the backend.
+	ExposeOnenoteFiles      string          `json:"exposeOnenoteFiles" default:"false"`                                                                                                                  // Set to make OneNote files show up in directory listings.
+	HashType                string          `json:"hashType" default:"auto"`                                                                                                                             // Specify the hash in use for the backend.
+	LinkPassword            string          `json:"linkPassword"`                                                                                                                                        // Set the password for links created by the link command.
+	LinkScope               string          `json:"linkScope" default:"anonymous"`                                                                                                                       // Set the scope of the links created by the link command.
+	LinkType                string          `json:"linkType" default:"view"`                                                                                                                             // Set the type of the links created by the link command.
+	ListChunk               string          `json:"listChunk" default:"1000"`                                                                                                                            // Size of listing chunk.
+	NoVersions              string          `json:"noVersions" default:"false"`                                                                                                                          // Remove all versions on modifying operations.
+	Region                  string          `json:"region" default:"global"`                                                                                                                             // Choose national cloud region for OneDrive.
+	RootFolderId            string          `json:"rootFolderId"`                                                                                                                                        // ID of the root folder.
+	ServerSideAcrossConfigs string          `json:"serverSideAcrossConfigs" default:"false"`                                                                                                             // Allow server-side operations (e.g. copy) to work across different onedrive configs.
+	Token                   string          `json:"token"`                                                                                                                                               // OAuth Access Token as a JSON blob.
+	TokenUrl                string          `json:"tokenUrl"`                                                                                                                                            // Token server url.
 }
 
 // @Summary Add onedrive source for a dataset
@@ -687,13 +713,14 @@ type OnedriveRequest struct {
 func handleOnedrive() {}
 
 type OpendriveRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`                                                                                                                   // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`                                                                                                            // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`                                                                                                               // Automatically rescan the source directory when this interval has passed from last successful scan
-	ChunkSize         string `json:"chunkSize" default:"10Mi"`                                                                                                                         // Files will be uploaded in chunks this size.
-	Encoding          string `json:"encoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,LeftSpace,LeftCrLfHtVt,RightSpace,RightCrLfHtVt,InvalidUtf8,Dot"` // The encoding for the backend.
-	Password          string `json:"password"`                                                                                                                                         // Password.
-	Username          string `json:"username"`                                                                                                                                         // Username.
+	SourcePath        string          `validate:"required" json:"sourcePath"`                                                                                                                   // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`                                                                                                            // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`                                                                                                               // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`                                                                                                                // Starting state for scanning
+	ChunkSize         string          `json:"chunkSize" default:"10Mi"`                                                                                                                         // Files will be uploaded in chunks this size.
+	Encoding          string          `json:"encoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,LeftSpace,LeftCrLfHtVt,RightSpace,RightCrLfHtVt,InvalidUtf8,Dot"` // The encoding for the backend.
+	Password          string          `json:"password"`                                                                                                                                         // Password.
+	Username          string          `json:"username"`                                                                                                                                         // Username.
 }
 
 // @Summary Add opendrive source for a dataset
@@ -709,31 +736,32 @@ type OpendriveRequest struct {
 func handleOpendrive() {}
 
 type OosRequest struct {
-	SourcePath           string `validate:"required" json:"sourcePath"`           // The path of the source to scan items
-	DeleteAfterExport    bool   `validate:"required" json:"deleteAfterExport"`    // Delete the source after exporting to CAR files
-	RescanInterval       string `validate:"required" json:"rescanInterval"`       // Automatically rescan the source directory when this interval has passed from last successful scan
-	ChunkSize            string `json:"chunkSize" default:"5Mi"`                  // Chunk size to use for uploading.
-	Compartment          string `json:"compartment"`                              // Object storage compartment OCID
-	ConfigFile           string `json:"configFile" default:"~/.oci/config"`       // Path to OCI config file
-	ConfigProfile        string `json:"configProfile" default:"Default"`          // Profile name inside the oci config file
-	CopyCutoff           string `json:"copyCutoff" default:"4.656Gi"`             // Cutoff for switching to multipart copy.
-	CopyTimeout          string `json:"copyTimeout" default:"1m0s"`               // Timeout for copy.
-	DisableChecksum      string `json:"disableChecksum" default:"false"`          // Don't store MD5 checksum with object metadata.
-	Encoding             string `json:"encoding" default:"Slash,InvalidUtf8,Dot"` // The encoding for the backend.
-	Endpoint             string `json:"endpoint"`                                 // Endpoint for Object storage API.
-	LeavePartsOnError    string `json:"leavePartsOnError" default:"false"`        // If true avoid calling abort upload on a failure, leaving all successfully uploaded parts on S3 for manual recovery.
-	Namespace            string `json:"namespace"`                                // Object storage namespace
-	NoCheckBucket        string `json:"noCheckBucket" default:"false"`            // If set, don't attempt to check the bucket exists or create it.
-	Provider             string `json:"provider" default:"env_auth"`              // Choose your Auth Provider
-	Region               string `json:"region"`                                   // Object storage Region
-	SseCustomerAlgorithm string `json:"sseCustomerAlgorithm"`                     // If using SSE-C, the optional header that specifies "AES256" as the encryption algorithm.
-	SseCustomerKey       string `json:"sseCustomerKey"`                           // To use SSE-C, the optional header that specifies the base64-encoded 256-bit encryption key to use to
-	SseCustomerKeyFile   string `json:"sseCustomerKeyFile"`                       // To use SSE-C, a file containing the base64-encoded string of the AES-256 encryption key associated
-	SseCustomerKeySha256 string `json:"sseCustomerKeySha256"`                     // If using SSE-C, The optional header that specifies the base64-encoded SHA256 hash of the encryption
-	SseKmsKeyId          string `json:"sseKmsKeyId"`                              // if using using your own master key in vault, this header specifies the
-	StorageTier          string `json:"storageTier" default:"Standard"`           // The storage class to use when storing new objects in storage. https://docs.oracle.com/en-us/iaas/Content/Object/Concepts/understandingstoragetiers.htm
-	UploadConcurrency    string `json:"uploadConcurrency" default:"10"`           // Concurrency for multipart uploads.
-	UploadCutoff         string `json:"uploadCutoff" default:"200Mi"`             // Cutoff for switching to chunked upload.
+	SourcePath           string          `validate:"required" json:"sourcePath"`           // The path of the source to scan items
+	DeleteAfterExport    bool            `validate:"required" json:"deleteAfterExport"`    // Delete the source after exporting to CAR files
+	RescanInterval       string          `validate:"required" json:"rescanInterval"`       // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState        model.WorkState `validate:"required" json:"scanningState"`        // Starting state for scanning
+	ChunkSize            string          `json:"chunkSize" default:"5Mi"`                  // Chunk size to use for uploading.
+	Compartment          string          `json:"compartment"`                              // Object storage compartment OCID
+	ConfigFile           string          `json:"configFile" default:"~/.oci/config"`       // Path to OCI config file
+	ConfigProfile        string          `json:"configProfile" default:"Default"`          // Profile name inside the oci config file
+	CopyCutoff           string          `json:"copyCutoff" default:"4.656Gi"`             // Cutoff for switching to multipart copy.
+	CopyTimeout          string          `json:"copyTimeout" default:"1m0s"`               // Timeout for copy.
+	DisableChecksum      string          `json:"disableChecksum" default:"false"`          // Don't store MD5 checksum with object metadata.
+	Encoding             string          `json:"encoding" default:"Slash,InvalidUtf8,Dot"` // The encoding for the backend.
+	Endpoint             string          `json:"endpoint"`                                 // Endpoint for Object storage API.
+	LeavePartsOnError    string          `json:"leavePartsOnError" default:"false"`        // If true avoid calling abort upload on a failure, leaving all successfully uploaded parts on S3 for manual recovery.
+	Namespace            string          `json:"namespace"`                                // Object storage namespace
+	NoCheckBucket        string          `json:"noCheckBucket" default:"false"`            // If set, don't attempt to check the bucket exists or create it.
+	Provider             string          `json:"provider" default:"env_auth"`              // Choose your Auth Provider
+	Region               string          `json:"region"`                                   // Object storage Region
+	SseCustomerAlgorithm string          `json:"sseCustomerAlgorithm"`                     // If using SSE-C, the optional header that specifies "AES256" as the encryption algorithm.
+	SseCustomerKey       string          `json:"sseCustomerKey"`                           // To use SSE-C, the optional header that specifies the base64-encoded 256-bit encryption key to use to
+	SseCustomerKeyFile   string          `json:"sseCustomerKeyFile"`                       // To use SSE-C, a file containing the base64-encoded string of the AES-256 encryption key associated
+	SseCustomerKeySha256 string          `json:"sseCustomerKeySha256"`                     // If using SSE-C, The optional header that specifies the base64-encoded SHA256 hash of the encryption
+	SseKmsKeyId          string          `json:"sseKmsKeyId"`                              // if using using your own master key in vault, this header specifies the
+	StorageTier          string          `json:"storageTier" default:"Standard"`           // The storage class to use when storing new objects in storage. https://docs.oracle.com/en-us/iaas/Content/Object/Concepts/understandingstoragetiers.htm
+	UploadConcurrency    string          `json:"uploadConcurrency" default:"10"`           // Concurrency for multipart uploads.
+	UploadCutoff         string          `json:"uploadCutoff" default:"200Mi"`             // Cutoff for switching to chunked upload.
 }
 
 // @Summary Add oos source for a dataset
@@ -749,19 +777,20 @@ type OosRequest struct {
 func handleOos() {}
 
 type PcloudRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`                             // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`                      // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`                         // Automatically rescan the source directory when this interval has passed from last successful scan
-	AuthUrl           string `json:"authUrl"`                                                    // Auth server URL.
-	ClientId          string `json:"clientId"`                                                   // OAuth Client Id.
-	ClientSecret      string `json:"clientSecret"`                                               // OAuth Client Secret.
-	Encoding          string `json:"encoding" default:"Slash,BackSlash,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
-	Hostname          string `json:"hostname" default:"api.pcloud.com"`                          // Hostname to connect to.
-	Password          string `json:"password"`                                                   // Your pcloud password.
-	RootFolderId      string `json:"rootFolderId" default:"d0"`                                  // Fill in for rclone to use a non root folder as its starting point.
-	Token             string `json:"token"`                                                      // OAuth Access Token as a JSON blob.
-	TokenUrl          string `json:"tokenUrl"`                                                   // Token server url.
-	Username          string `json:"username"`                                                   // Your pcloud username.
+	SourcePath        string          `validate:"required" json:"sourcePath"`                             // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`                      // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`                         // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`                          // Starting state for scanning
+	AuthUrl           string          `json:"authUrl"`                                                    // Auth server URL.
+	ClientId          string          `json:"clientId"`                                                   // OAuth Client Id.
+	ClientSecret      string          `json:"clientSecret"`                                               // OAuth Client Secret.
+	Encoding          string          `json:"encoding" default:"Slash,BackSlash,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
+	Hostname          string          `json:"hostname" default:"api.pcloud.com"`                          // Hostname to connect to.
+	Password          string          `json:"password"`                                                   // Your pcloud password.
+	RootFolderId      string          `json:"rootFolderId" default:"d0"`                                  // Fill in for rclone to use a non root folder as its starting point.
+	Token             string          `json:"token"`                                                      // OAuth Access Token as a JSON blob.
+	TokenUrl          string          `json:"tokenUrl"`                                                   // Token server url.
+	Username          string          `json:"username"`                                                   // Your pcloud username.
 }
 
 // @Summary Add pcloud source for a dataset
@@ -777,11 +806,12 @@ type PcloudRequest struct {
 func handlePcloud() {}
 
 type PremiumizemeRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`                                         // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`                                  // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`                                     // Automatically rescan the source directory when this interval has passed from last successful scan
-	ApiKey            string `json:"apiKey"`                                                                 // API Key.
-	Encoding          string `json:"encoding" default:"Slash,DoubleQuote,BackSlash,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
+	SourcePath        string          `validate:"required" json:"sourcePath"`                                         // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`                                  // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`                                     // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`                                      // Starting state for scanning
+	ApiKey            string          `json:"apiKey"`                                                                 // API Key.
+	Encoding          string          `json:"encoding" default:"Slash,DoubleQuote,BackSlash,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
 }
 
 // @Summary Add premiumizeme source for a dataset
@@ -797,10 +827,11 @@ type PremiumizemeRequest struct {
 func handlePremiumizeme() {}
 
 type PutioRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`                             // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`                      // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`                         // Automatically rescan the source directory when this interval has passed from last successful scan
-	Encoding          string `json:"encoding" default:"Slash,BackSlash,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
+	SourcePath        string          `validate:"required" json:"sourcePath"`                             // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`                      // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`                         // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`                          // Starting state for scanning
+	Encoding          string          `json:"encoding" default:"Slash,BackSlash,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
 }
 
 // @Summary Add putio source for a dataset
@@ -816,19 +847,20 @@ type PutioRequest struct {
 func handlePutio() {}
 
 type QingstorRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`           // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`    // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`       // Automatically rescan the source directory when this interval has passed from last successful scan
-	AccessKeyId       string `json:"accessKeyId"`                              // QingStor Access Key ID.
-	ChunkSize         string `json:"chunkSize" default:"4Mi"`                  // Chunk size to use for uploading.
-	ConnectionRetries string `json:"connectionRetries" default:"3"`            // Number of connection retries.
-	Encoding          string `json:"encoding" default:"Slash,Ctl,InvalidUtf8"` // The encoding for the backend.
-	Endpoint          string `json:"endpoint"`                                 // Enter an endpoint URL to connection QingStor API.
-	EnvAuth           string `json:"envAuth" default:"false"`                  // Get QingStor credentials from runtime.
-	SecretAccessKey   string `json:"secretAccessKey"`                          // QingStor Secret Access Key (password).
-	UploadConcurrency string `json:"uploadConcurrency" default:"1"`            // Concurrency for multipart uploads.
-	UploadCutoff      string `json:"uploadCutoff" default:"200Mi"`             // Cutoff for switching to chunked upload.
-	Zone              string `json:"zone"`                                     // Zone to connect to.
+	SourcePath        string          `validate:"required" json:"sourcePath"`           // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`    // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`       // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`        // Starting state for scanning
+	AccessKeyId       string          `json:"accessKeyId"`                              // QingStor Access Key ID.
+	ChunkSize         string          `json:"chunkSize" default:"4Mi"`                  // Chunk size to use for uploading.
+	ConnectionRetries string          `json:"connectionRetries" default:"3"`            // Number of connection retries.
+	Encoding          string          `json:"encoding" default:"Slash,Ctl,InvalidUtf8"` // The encoding for the backend.
+	Endpoint          string          `json:"endpoint"`                                 // Enter an endpoint URL to connection QingStor API.
+	EnvAuth           string          `json:"envAuth" default:"false"`                  // Get QingStor credentials from runtime.
+	SecretAccessKey   string          `json:"secretAccessKey"`                          // QingStor Secret Access Key (password).
+	UploadConcurrency string          `json:"uploadConcurrency" default:"1"`            // Concurrency for multipart uploads.
+	UploadCutoff      string          `json:"uploadCutoff" default:"200Mi"`             // Cutoff for switching to chunked upload.
+	Zone              string          `json:"zone"`                                     // Zone to connect to.
 }
 
 // @Summary Add qingstor source for a dataset
@@ -844,58 +876,59 @@ type QingstorRequest struct {
 func handleQingstor() {}
 
 type S3Request struct {
-	SourcePath            string `validate:"required" json:"sourcePath"`           // The path of the source to scan items
-	DeleteAfterExport     bool   `validate:"required" json:"deleteAfterExport"`    // Delete the source after exporting to CAR files
-	RescanInterval        string `validate:"required" json:"rescanInterval"`       // Automatically rescan the source directory when this interval has passed from last successful scan
-	AccessKeyId           string `json:"accessKeyId"`                              // AWS Access Key ID.
-	Acl                   string `json:"acl"`                                      // Canned ACL used when creating buckets and storing or copying objects.
-	BucketAcl             string `json:"bucketAcl"`                                // Canned ACL used when creating buckets.
-	ChunkSize             string `json:"chunkSize" default:"5Mi"`                  // Chunk size to use for uploading.
-	CopyCutoff            string `json:"copyCutoff" default:"4.656Gi"`             // Cutoff for switching to multipart copy.
-	Decompress            string `json:"decompress" default:"false"`               // If set this will decompress gzip encoded objects.
-	DisableChecksum       string `json:"disableChecksum" default:"false"`          // Don't store MD5 checksum with object metadata.
-	DisableHttp2          string `json:"disableHttp2" default:"false"`             // Disable usage of http2 for S3 backends.
-	DownloadUrl           string `json:"downloadUrl"`                              // Custom endpoint for downloads.
-	Encoding              string `json:"encoding" default:"Slash,InvalidUtf8,Dot"` // The encoding for the backend.
-	Endpoint              string `json:"endpoint"`                                 // Endpoint for S3 API.
-	EnvAuth               string `json:"envAuth" default:"false"`                  // Get AWS credentials from runtime (environment variables or EC2/ECS meta data if no env vars).
-	ForcePathStyle        string `json:"forcePathStyle" default:"true"`            // If true use path style access if false use virtual hosted style.
-	LeavePartsOnError     string `json:"leavePartsOnError" default:"false"`        // If true avoid calling abort upload on a failure, leaving all successfully uploaded parts on S3 for manual recovery.
-	ListChunk             string `json:"listChunk" default:"1000"`                 // Size of listing chunk (response list for each ListObject S3 request).
-	ListUrlEncode         string `json:"listUrlEncode" default:"unset"`            // Whether to url encode listings: true/false/unset
-	ListVersion           string `json:"listVersion" default:"0"`                  // Version of ListObjects to use: 1,2 or 0 for auto.
-	LocationConstraint    string `json:"locationConstraint"`                       // Location constraint - must be set to match the Region.
-	MaxUploadParts        string `json:"maxUploadParts" default:"10000"`           // Maximum number of parts in a multipart upload.
-	MemoryPoolFlushTime   string `json:"memoryPoolFlushTime" default:"1m0s"`       // How often internal memory buffer pools will be flushed.
-	MemoryPoolUseMmap     string `json:"memoryPoolUseMmap" default:"false"`        // Whether to use mmap buffers in internal memory pool.
-	MightGzip             string `json:"mightGzip" default:"unset"`                // Set this if the backend might gzip objects.
-	NoCheckBucket         string `json:"noCheckBucket" default:"false"`            // If set, don't attempt to check the bucket exists or create it.
-	NoHead                string `json:"noHead" default:"false"`                   // If set, don't HEAD uploaded objects to check integrity.
-	NoHeadObject          string `json:"noHeadObject" default:"false"`             // If set, do not do HEAD before GET when getting objects.
-	NoSystemMetadata      string `json:"noSystemMetadata" default:"false"`         // Suppress setting and reading of system metadata
-	Profile               string `json:"profile"`                                  // Profile to use in the shared credentials file.
-	Provider              string `json:"provider"`                                 // Choose your S3 provider.
-	Region                string `json:"region"`                                   // Region to connect to.
-	RequesterPays         string `json:"requesterPays" default:"false"`            // Enables requester pays option when interacting with S3 bucket.
-	SecretAccessKey       string `json:"secretAccessKey"`                          // AWS Secret Access Key (password).
-	ServerSideEncryption  string `json:"serverSideEncryption"`                     // The server-side encryption algorithm used when storing this object in S3.
-	SessionToken          string `json:"sessionToken"`                             // An AWS session token.
-	SharedCredentialsFile string `json:"sharedCredentialsFile"`                    // Path to the shared credentials file.
-	SseCustomerAlgorithm  string `json:"sseCustomerAlgorithm"`                     // If using SSE-C, the server-side encryption algorithm used when storing this object in S3.
-	SseCustomerKey        string `json:"sseCustomerKey"`                           // To use SSE-C you may provide the secret encryption key used to encrypt/decrypt your data.
-	SseCustomerKeyBase64  string `json:"sseCustomerKeyBase64"`                     // If using SSE-C you must provide the secret encryption key encoded in base64 format to encrypt/decrypt your data.
-	SseCustomerKeyMd5     string `json:"sseCustomerKeyMd5"`                        // If using SSE-C you may provide the secret encryption key MD5 checksum (optional).
-	SseKmsKeyId           string `json:"sseKmsKeyId"`                              // If using KMS ID you must provide the ARN of Key.
-	StorageClass          string `json:"storageClass"`                             // The storage class to use when storing new objects in S3.
-	StsEndpoint           string `json:"stsEndpoint"`                              // Endpoint for STS.
-	UploadConcurrency     string `json:"uploadConcurrency" default:"4"`            // Concurrency for multipart uploads.
-	UploadCutoff          string `json:"uploadCutoff" default:"200Mi"`             // Cutoff for switching to chunked upload.
-	UseAccelerateEndpoint string `json:"useAccelerateEndpoint" default:"false"`    // If true use the AWS S3 accelerated endpoint.
-	UseMultipartEtag      string `json:"useMultipartEtag" default:"unset"`         // Whether to use ETag in multipart uploads for verification
-	UsePresignedRequest   string `json:"usePresignedRequest" default:"false"`      // Whether to use a presigned request or PutObject for single part uploads
-	V2Auth                string `json:"v2Auth" default:"false"`                   // If true use v2 authentication.
-	VersionAt             string `json:"versionAt" default:"off"`                  // Show file versions as they were at the specified time.
-	Versions              string `json:"versions" default:"false"`                 // Include old versions in directory listings.
+	SourcePath            string          `validate:"required" json:"sourcePath"`           // The path of the source to scan items
+	DeleteAfterExport     bool            `validate:"required" json:"deleteAfterExport"`    // Delete the source after exporting to CAR files
+	RescanInterval        string          `validate:"required" json:"rescanInterval"`       // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState         model.WorkState `validate:"required" json:"scanningState"`        // Starting state for scanning
+	AccessKeyId           string          `json:"accessKeyId"`                              // AWS Access Key ID.
+	Acl                   string          `json:"acl"`                                      // Canned ACL used when creating buckets and storing or copying objects.
+	BucketAcl             string          `json:"bucketAcl"`                                // Canned ACL used when creating buckets.
+	ChunkSize             string          `json:"chunkSize" default:"5Mi"`                  // Chunk size to use for uploading.
+	CopyCutoff            string          `json:"copyCutoff" default:"4.656Gi"`             // Cutoff for switching to multipart copy.
+	Decompress            string          `json:"decompress" default:"false"`               // If set this will decompress gzip encoded objects.
+	DisableChecksum       string          `json:"disableChecksum" default:"false"`          // Don't store MD5 checksum with object metadata.
+	DisableHttp2          string          `json:"disableHttp2" default:"false"`             // Disable usage of http2 for S3 backends.
+	DownloadUrl           string          `json:"downloadUrl"`                              // Custom endpoint for downloads.
+	Encoding              string          `json:"encoding" default:"Slash,InvalidUtf8,Dot"` // The encoding for the backend.
+	Endpoint              string          `json:"endpoint"`                                 // Endpoint for S3 API.
+	EnvAuth               string          `json:"envAuth" default:"false"`                  // Get AWS credentials from runtime (environment variables or EC2/ECS meta data if no env vars).
+	ForcePathStyle        string          `json:"forcePathStyle" default:"true"`            // If true use path style access if false use virtual hosted style.
+	LeavePartsOnError     string          `json:"leavePartsOnError" default:"false"`        // If true avoid calling abort upload on a failure, leaving all successfully uploaded parts on S3 for manual recovery.
+	ListChunk             string          `json:"listChunk" default:"1000"`                 // Size of listing chunk (response list for each ListObject S3 request).
+	ListUrlEncode         string          `json:"listUrlEncode" default:"unset"`            // Whether to url encode listings: true/false/unset
+	ListVersion           string          `json:"listVersion" default:"0"`                  // Version of ListObjects to use: 1,2 or 0 for auto.
+	LocationConstraint    string          `json:"locationConstraint"`                       // Location constraint - must be set to match the Region.
+	MaxUploadParts        string          `json:"maxUploadParts" default:"10000"`           // Maximum number of parts in a multipart upload.
+	MemoryPoolFlushTime   string          `json:"memoryPoolFlushTime" default:"1m0s"`       // How often internal memory buffer pools will be flushed.
+	MemoryPoolUseMmap     string          `json:"memoryPoolUseMmap" default:"false"`        // Whether to use mmap buffers in internal memory pool.
+	MightGzip             string          `json:"mightGzip" default:"unset"`                // Set this if the backend might gzip objects.
+	NoCheckBucket         string          `json:"noCheckBucket" default:"false"`            // If set, don't attempt to check the bucket exists or create it.
+	NoHead                string          `json:"noHead" default:"false"`                   // If set, don't HEAD uploaded objects to check integrity.
+	NoHeadObject          string          `json:"noHeadObject" default:"false"`             // If set, do not do HEAD before GET when getting objects.
+	NoSystemMetadata      string          `json:"noSystemMetadata" default:"false"`         // Suppress setting and reading of system metadata
+	Profile               string          `json:"profile"`                                  // Profile to use in the shared credentials file.
+	Provider              string          `json:"provider"`                                 // Choose your S3 provider.
+	Region                string          `json:"region"`                                   // Region to connect to.
+	RequesterPays         string          `json:"requesterPays" default:"false"`            // Enables requester pays option when interacting with S3 bucket.
+	SecretAccessKey       string          `json:"secretAccessKey"`                          // AWS Secret Access Key (password).
+	ServerSideEncryption  string          `json:"serverSideEncryption"`                     // The server-side encryption algorithm used when storing this object in S3.
+	SessionToken          string          `json:"sessionToken"`                             // An AWS session token.
+	SharedCredentialsFile string          `json:"sharedCredentialsFile"`                    // Path to the shared credentials file.
+	SseCustomerAlgorithm  string          `json:"sseCustomerAlgorithm"`                     // If using SSE-C, the server-side encryption algorithm used when storing this object in S3.
+	SseCustomerKey        string          `json:"sseCustomerKey"`                           // To use SSE-C you may provide the secret encryption key used to encrypt/decrypt your data.
+	SseCustomerKeyBase64  string          `json:"sseCustomerKeyBase64"`                     // If using SSE-C you must provide the secret encryption key encoded in base64 format to encrypt/decrypt your data.
+	SseCustomerKeyMd5     string          `json:"sseCustomerKeyMd5"`                        // If using SSE-C you may provide the secret encryption key MD5 checksum (optional).
+	SseKmsKeyId           string          `json:"sseKmsKeyId"`                              // If using KMS ID you must provide the ARN of Key.
+	StorageClass          string          `json:"storageClass"`                             // The storage class to use when storing new objects in S3.
+	StsEndpoint           string          `json:"stsEndpoint"`                              // Endpoint for STS.
+	UploadConcurrency     string          `json:"uploadConcurrency" default:"4"`            // Concurrency for multipart uploads.
+	UploadCutoff          string          `json:"uploadCutoff" default:"200Mi"`             // Cutoff for switching to chunked upload.
+	UseAccelerateEndpoint string          `json:"useAccelerateEndpoint" default:"false"`    // If true use the AWS S3 accelerated endpoint.
+	UseMultipartEtag      string          `json:"useMultipartEtag" default:"unset"`         // Whether to use ETag in multipart uploads for verification
+	UsePresignedRequest   string          `json:"usePresignedRequest" default:"false"`      // Whether to use a presigned request or PutObject for single part uploads
+	V2Auth                string          `json:"v2Auth" default:"false"`                   // If true use v2 authentication.
+	VersionAt             string          `json:"versionAt" default:"off"`                  // Show file versions as they were at the specified time.
+	Versions              string          `json:"versions" default:"false"`                 // Include old versions in directory listings.
 }
 
 // @Summary Add s3 source for a dataset
@@ -911,18 +944,19 @@ type S3Request struct {
 func handleS3() {}
 
 type SeafileRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`                                 // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`                          // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`                             // Automatically rescan the source directory when this interval has passed from last successful scan
-	TwoFA             string `json:"2fa" default:"false"`                                            // Two-factor authentication ('true' if the account has 2FA enabled).
-	AuthToken         string `json:"authToken"`                                                      // Authentication token.
-	CreateLibrary     string `json:"createLibrary" default:"false"`                                  // Should rclone create a library if it doesn't exist.
-	Encoding          string `json:"encoding" default:"Slash,DoubleQuote,BackSlash,Ctl,InvalidUtf8"` // The encoding for the backend.
-	Library           string `json:"library"`                                                        // Name of the library.
-	LibraryKey        string `json:"libraryKey"`                                                     // Library password (for encrypted libraries only).
-	Pass              string `json:"pass"`                                                           // Password.
-	Url               string `json:"url"`                                                            // URL of seafile host to connect to.
-	User              string `json:"user"`                                                           // User name (usually email address).
+	SourcePath        string          `validate:"required" json:"sourcePath"`                                 // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`                          // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`                             // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`                              // Starting state for scanning
+	TwoFA             string          `json:"2fa" default:"false"`                                            // Two-factor authentication ('true' if the account has 2FA enabled).
+	AuthToken         string          `json:"authToken"`                                                      // Authentication token.
+	CreateLibrary     string          `json:"createLibrary" default:"false"`                                  // Should rclone create a library if it doesn't exist.
+	Encoding          string          `json:"encoding" default:"Slash,DoubleQuote,BackSlash,Ctl,InvalidUtf8"` // The encoding for the backend.
+	Library           string          `json:"library"`                                                        // Name of the library.
+	LibraryKey        string          `json:"libraryKey"`                                                     // Library password (for encrypted libraries only).
+	Pass              string          `json:"pass"`                                                           // Password.
+	Url               string          `json:"url"`                                                            // URL of seafile host to connect to.
+	User              string          `json:"user"`                                                           // User name (usually email address).
 }
 
 // @Summary Add seafile source for a dataset
@@ -938,40 +972,41 @@ type SeafileRequest struct {
 func handleSeafile() {}
 
 type SftpRequest struct {
-	SourcePath              string `validate:"required" json:"sourcePath"`          // The path of the source to scan items
-	DeleteAfterExport       bool   `validate:"required" json:"deleteAfterExport"`   // Delete the source after exporting to CAR files
-	RescanInterval          string `validate:"required" json:"rescanInterval"`      // Automatically rescan the source directory when this interval has passed from last successful scan
-	AskPassword             string `json:"askPassword" default:"false"`             // Allow asking for SFTP password when needed.
-	ChunkSize               string `json:"chunkSize" default:"32Ki"`                // Upload and download chunk size.
-	Ciphers                 string `json:"ciphers"`                                 // Space separated list of ciphers to be used for session encryption, ordered by preference.
-	Concurrency             string `json:"concurrency" default:"64"`                // The maximum number of outstanding requests for one file
-	DisableConcurrentReads  string `json:"disableConcurrentReads" default:"false"`  // If set don't use concurrent reads.
-	DisableConcurrentWrites string `json:"disableConcurrentWrites" default:"false"` // If set don't use concurrent writes.
-	DisableHashcheck        string `json:"disableHashcheck" default:"false"`        // Disable the execution of SSH commands to determine if remote file hashing is available.
-	Host                    string `json:"host"`                                    // SSH host to connect to.
-	IdleTimeout             string `json:"idleTimeout" default:"1m0s"`              // Max time before closing idle connections.
-	KeyExchange             string `json:"keyExchange"`                             // Space separated list of key exchange algorithms, ordered by preference.
-	KeyFile                 string `json:"keyFile"`                                 // Path to PEM-encoded private key file.
-	KeyFilePass             string `json:"keyFilePass"`                             // The passphrase to decrypt the PEM-encoded private key file.
-	KeyPem                  string `json:"keyPem"`                                  // Raw PEM-encoded private key.
-	KeyUseAgent             string `json:"keyUseAgent" default:"false"`             // When set forces the usage of the ssh-agent.
-	KnownHostsFile          string `json:"knownHostsFile"`                          // Optional path to known_hosts file.
-	Macs                    string `json:"macs"`                                    // Space separated list of MACs (message authentication code) algorithms, ordered by preference.
-	Md5sumCommand           string `json:"md5sumCommand"`                           // The command used to read md5 hashes.
-	Pass                    string `json:"pass"`                                    // SSH password, leave blank to use ssh-agent.
-	PathOverride            string `json:"pathOverride"`                            // Override path used by SSH shell commands.
-	Port                    string `json:"port" default:"22"`                       // SSH port number.
-	PubkeyFile              string `json:"pubkeyFile"`                              // Optional path to public key file.
-	ServerCommand           string `json:"serverCommand"`                           // Specifies the path or command to run a sftp server on the remote host.
-	SetEnv                  string `json:"setEnv"`                                  // Environment variables to pass to sftp and commands
-	SetModtime              string `json:"setModtime" default:"true"`               // Set the modified time on the remote if set.
-	Sha1sumCommand          string `json:"sha1sumCommand"`                          // The command used to read sha1 hashes.
-	ShellType               string `json:"shellType"`                               // The type of SSH shell on remote server, if any.
-	SkipLinks               string `json:"skipLinks" default:"false"`               // Set to skip any symlinks and any other non regular files.
-	Subsystem               string `json:"subsystem" default:"sftp"`                // Specifies the SSH2 subsystem on the remote host.
-	UseFstat                string `json:"useFstat" default:"false"`                // If set use fstat instead of stat.
-	UseInsecureCipher       string `json:"useInsecureCipher" default:"false"`       // Enable the use of insecure ciphers and key exchange methods.
-	User                    string `json:"user" default:"$USER"`                    // SSH username.
+	SourcePath              string          `validate:"required" json:"sourcePath"`          // The path of the source to scan items
+	DeleteAfterExport       bool            `validate:"required" json:"deleteAfterExport"`   // Delete the source after exporting to CAR files
+	RescanInterval          string          `validate:"required" json:"rescanInterval"`      // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState           model.WorkState `validate:"required" json:"scanningState"`       // Starting state for scanning
+	AskPassword             string          `json:"askPassword" default:"false"`             // Allow asking for SFTP password when needed.
+	ChunkSize               string          `json:"chunkSize" default:"32Ki"`                // Upload and download chunk size.
+	Ciphers                 string          `json:"ciphers"`                                 // Space separated list of ciphers to be used for session encryption, ordered by preference.
+	Concurrency             string          `json:"concurrency" default:"64"`                // The maximum number of outstanding requests for one file
+	DisableConcurrentReads  string          `json:"disableConcurrentReads" default:"false"`  // If set don't use concurrent reads.
+	DisableConcurrentWrites string          `json:"disableConcurrentWrites" default:"false"` // If set don't use concurrent writes.
+	DisableHashcheck        string          `json:"disableHashcheck" default:"false"`        // Disable the execution of SSH commands to determine if remote file hashing is available.
+	Host                    string          `json:"host"`                                    // SSH host to connect to.
+	IdleTimeout             string          `json:"idleTimeout" default:"1m0s"`              // Max time before closing idle connections.
+	KeyExchange             string          `json:"keyExchange"`                             // Space separated list of key exchange algorithms, ordered by preference.
+	KeyFile                 string          `json:"keyFile"`                                 // Path to PEM-encoded private key file.
+	KeyFilePass             string          `json:"keyFilePass"`                             // The passphrase to decrypt the PEM-encoded private key file.
+	KeyPem                  string          `json:"keyPem"`                                  // Raw PEM-encoded private key.
+	KeyUseAgent             string          `json:"keyUseAgent" default:"false"`             // When set forces the usage of the ssh-agent.
+	KnownHostsFile          string          `json:"knownHostsFile"`                          // Optional path to known_hosts file.
+	Macs                    string          `json:"macs"`                                    // Space separated list of MACs (message authentication code) algorithms, ordered by preference.
+	Md5sumCommand           string          `json:"md5sumCommand"`                           // The command used to read md5 hashes.
+	Pass                    string          `json:"pass"`                                    // SSH password, leave blank to use ssh-agent.
+	PathOverride            string          `json:"pathOverride"`                            // Override path used by SSH shell commands.
+	Port                    string          `json:"port" default:"22"`                       // SSH port number.
+	PubkeyFile              string          `json:"pubkeyFile"`                              // Optional path to public key file.
+	ServerCommand           string          `json:"serverCommand"`                           // Specifies the path or command to run a sftp server on the remote host.
+	SetEnv                  string          `json:"setEnv"`                                  // Environment variables to pass to sftp and commands
+	SetModtime              string          `json:"setModtime" default:"true"`               // Set the modified time on the remote if set.
+	Sha1sumCommand          string          `json:"sha1sumCommand"`                          // The command used to read sha1 hashes.
+	ShellType               string          `json:"shellType"`                               // The type of SSH shell on remote server, if any.
+	SkipLinks               string          `json:"skipLinks" default:"false"`               // Set to skip any symlinks and any other non regular files.
+	Subsystem               string          `json:"subsystem" default:"sftp"`                // Specifies the SSH2 subsystem on the remote host.
+	UseFstat                string          `json:"useFstat" default:"false"`                // If set use fstat instead of stat.
+	UseInsecureCipher       string          `json:"useInsecureCipher" default:"false"`       // Enable the use of insecure ciphers and key exchange methods.
+	User                    string          `json:"user" default:"$USER"`                    // SSH username.
 }
 
 // @Summary Add sftp source for a dataset
@@ -987,14 +1022,15 @@ type SftpRequest struct {
 func handleSftp() {}
 
 type SharefileRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`                                                                                                                   // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`                                                                                                            // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`                                                                                                               // Automatically rescan the source directory when this interval has passed from last successful scan
-	ChunkSize         string `json:"chunkSize" default:"64Mi"`                                                                                                                         // Upload chunk size.
-	Encoding          string `json:"encoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,Ctl,LeftSpace,LeftPeriod,RightSpace,RightPeriod,InvalidUtf8,Dot"` // The encoding for the backend.
-	Endpoint          string `json:"endpoint"`                                                                                                                                         // Endpoint for API calls.
-	RootFolderId      string `json:"rootFolderId"`                                                                                                                                     // ID of the root folder.
-	UploadCutoff      string `json:"uploadCutoff" default:"128Mi"`                                                                                                                     // Cutoff for switching to multipart upload.
+	SourcePath        string          `validate:"required" json:"sourcePath"`                                                                                                                   // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`                                                                                                            // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`                                                                                                               // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`                                                                                                                // Starting state for scanning
+	ChunkSize         string          `json:"chunkSize" default:"64Mi"`                                                                                                                         // Upload chunk size.
+	Encoding          string          `json:"encoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,Ctl,LeftSpace,LeftPeriod,RightSpace,RightPeriod,InvalidUtf8,Dot"` // The encoding for the backend.
+	Endpoint          string          `json:"endpoint"`                                                                                                                                         // Endpoint for API calls.
+	RootFolderId      string          `json:"rootFolderId"`                                                                                                                                     // ID of the root folder.
+	UploadCutoff      string          `json:"uploadCutoff" default:"128Mi"`                                                                                                                     // Cutoff for switching to multipart upload.
 }
 
 // @Summary Add sharefile source for a dataset
@@ -1010,13 +1046,14 @@ type SharefileRequest struct {
 func handleSharefile() {}
 
 type SiaRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`                                         // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`                                  // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`                                     // Automatically rescan the source directory when this interval has passed from last successful scan
-	ApiPassword       string `json:"apiPassword"`                                                            // Sia Daemon API Password.
-	ApiUrl            string `json:"apiUrl" default:"http://127.0.0.1:9980"`                                 // Sia daemon API URL, like http://sia.daemon.host:9980.
-	Encoding          string `json:"encoding" default:"Slash,Question,Hash,Percent,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
-	UserAgent         string `json:"userAgent" default:"Sia-Agent"`                                          // Siad User Agent
+	SourcePath        string          `validate:"required" json:"sourcePath"`                                         // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`                                  // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`                                     // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`                                      // Starting state for scanning
+	ApiPassword       string          `json:"apiPassword"`                                                            // Sia Daemon API Password.
+	ApiUrl            string          `json:"apiUrl" default:"http://127.0.0.1:9980"`                                 // Sia daemon API URL, like http://sia.daemon.host:9980.
+	Encoding          string          `json:"encoding" default:"Slash,Question,Hash,Percent,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
+	UserAgent         string          `json:"userAgent" default:"Sia-Agent"`                                          // Siad User Agent
 }
 
 // @Summary Add sia source for a dataset
@@ -1032,19 +1069,20 @@ type SiaRequest struct {
 func handleSia() {}
 
 type SmbRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`                                                                                              // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`                                                                                       // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`                                                                                          // Automatically rescan the source directory when this interval has passed from last successful scan
-	CaseInsensitive   string `json:"caseInsensitive" default:"true"`                                                                                              // Whether the server is configured to be case-insensitive.
-	Domain            string `json:"domain" default:"WORKGROUP"`                                                                                                  // Domain name for NTLM authentication.
-	Encoding          string `json:"encoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,Ctl,RightSpace,RightPeriod,InvalidUtf8,Dot"` // The encoding for the backend.
-	HideSpecialShare  string `json:"hideSpecialShare" default:"true"`                                                                                             // Hide special shares (e.g. print$) which users aren't supposed to access.
-	Host              string `json:"host"`                                                                                                                        // SMB server hostname to connect to.
-	IdleTimeout       string `json:"idleTimeout" default:"1m0s"`                                                                                                  // Max time before closing idle connections.
-	Pass              string `json:"pass"`                                                                                                                        // SMB password.
-	Port              string `json:"port" default:"445"`                                                                                                          // SMB port number.
-	Spn               string `json:"spn"`                                                                                                                         // Service principal name.
-	User              string `json:"user" default:"$USER"`                                                                                                        // SMB username.
+	SourcePath        string          `validate:"required" json:"sourcePath"`                                                                                              // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`                                                                                       // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`                                                                                          // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`                                                                                           // Starting state for scanning
+	CaseInsensitive   string          `json:"caseInsensitive" default:"true"`                                                                                              // Whether the server is configured to be case-insensitive.
+	Domain            string          `json:"domain" default:"WORKGROUP"`                                                                                                  // Domain name for NTLM authentication.
+	Encoding          string          `json:"encoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,Ctl,RightSpace,RightPeriod,InvalidUtf8,Dot"` // The encoding for the backend.
+	HideSpecialShare  string          `json:"hideSpecialShare" default:"true"`                                                                                             // Hide special shares (e.g. print$) which users aren't supposed to access.
+	Host              string          `json:"host"`                                                                                                                        // SMB server hostname to connect to.
+	IdleTimeout       string          `json:"idleTimeout" default:"1m0s"`                                                                                                  // Max time before closing idle connections.
+	Pass              string          `json:"pass"`                                                                                                                        // SMB password.
+	Port              string          `json:"port" default:"445"`                                                                                                          // SMB port number.
+	Spn               string          `json:"spn"`                                                                                                                         // Service principal name.
+	User              string          `json:"user" default:"$USER"`                                                                                                        // SMB username.
 }
 
 // @Summary Add smb source for a dataset
@@ -1060,14 +1098,15 @@ type SmbRequest struct {
 func handleSmb() {}
 
 type StorjRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`          // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`   // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`      // Automatically rescan the source directory when this interval has passed from last successful scan
-	AccessGrant       string `json:"accessGrant"`                             // Access grant.
-	ApiKey            string `json:"apiKey"`                                  // API key.
-	Passphrase        string `json:"passphrase"`                              // Encryption passphrase.
-	Provider          string `json:"provider" default:"existing"`             // Choose an authentication method.
-	SatelliteAddress  string `json:"satelliteAddress" default:"us1.storj.io"` // Satellite address.
+	SourcePath        string          `validate:"required" json:"sourcePath"`          // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`   // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`      // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`       // Starting state for scanning
+	AccessGrant       string          `json:"accessGrant"`                             // Access grant.
+	ApiKey            string          `json:"apiKey"`                                  // API key.
+	Passphrase        string          `json:"passphrase"`                              // Encryption passphrase.
+	Provider          string          `json:"provider" default:"existing"`             // Choose an authentication method.
+	SatelliteAddress  string          `json:"satelliteAddress" default:"us1.storj.io"` // Satellite address.
 }
 
 // @Summary Add storj source for a dataset
@@ -1083,20 +1122,21 @@ type StorjRequest struct {
 func handleStorj() {}
 
 type SugarsyncRequest struct {
-	SourcePath          string `validate:"required" json:"sourcePath"`               // The path of the source to scan items
-	DeleteAfterExport   bool   `validate:"required" json:"deleteAfterExport"`        // Delete the source after exporting to CAR files
-	RescanInterval      string `validate:"required" json:"rescanInterval"`           // Automatically rescan the source directory when this interval has passed from last successful scan
-	AccessKeyId         string `json:"accessKeyId"`                                  // Sugarsync Access Key ID.
-	AppId               string `json:"appId"`                                        // Sugarsync App ID.
-	Authorization       string `json:"authorization"`                                // Sugarsync authorization.
-	AuthorizationExpiry string `json:"authorizationExpiry"`                          // Sugarsync authorization expiry.
-	DeletedId           string `json:"deletedId"`                                    // Sugarsync deleted folder id.
-	Encoding            string `json:"encoding" default:"Slash,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
-	HardDelete          string `json:"hardDelete" default:"false"`                   // Permanently delete files if true
-	PrivateAccessKey    string `json:"privateAccessKey"`                             // Sugarsync Private Access Key.
-	RefreshToken        string `json:"refreshToken"`                                 // Sugarsync refresh token.
-	RootId              string `json:"rootId"`                                       // Sugarsync root id.
-	User                string `json:"user"`                                         // Sugarsync user.
+	SourcePath          string          `validate:"required" json:"sourcePath"`               // The path of the source to scan items
+	DeleteAfterExport   bool            `validate:"required" json:"deleteAfterExport"`        // Delete the source after exporting to CAR files
+	RescanInterval      string          `validate:"required" json:"rescanInterval"`           // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState       model.WorkState `validate:"required" json:"scanningState"`            // Starting state for scanning
+	AccessKeyId         string          `json:"accessKeyId"`                                  // Sugarsync Access Key ID.
+	AppId               string          `json:"appId"`                                        // Sugarsync App ID.
+	Authorization       string          `json:"authorization"`                                // Sugarsync authorization.
+	AuthorizationExpiry string          `json:"authorizationExpiry"`                          // Sugarsync authorization expiry.
+	DeletedId           string          `json:"deletedId"`                                    // Sugarsync deleted folder id.
+	Encoding            string          `json:"encoding" default:"Slash,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
+	HardDelete          string          `json:"hardDelete" default:"false"`                   // Permanently delete files if true
+	PrivateAccessKey    string          `json:"privateAccessKey"`                             // Sugarsync Private Access Key.
+	RefreshToken        string          `json:"refreshToken"`                                 // Sugarsync refresh token.
+	RootId              string          `json:"rootId"`                                       // Sugarsync root id.
+	User                string          `json:"user"`                                         // Sugarsync user.
 }
 
 // @Summary Add sugarsync source for a dataset
@@ -1112,32 +1152,33 @@ type SugarsyncRequest struct {
 func handleSugarsync() {}
 
 type SwiftRequest struct {
-	SourcePath                  string `validate:"required" json:"sourcePath"`        // The path of the source to scan items
-	DeleteAfterExport           bool   `validate:"required" json:"deleteAfterExport"` // Delete the source after exporting to CAR files
-	RescanInterval              string `validate:"required" json:"rescanInterval"`    // Automatically rescan the source directory when this interval has passed from last successful scan
-	ApplicationCredentialId     string `json:"applicationCredentialId"`               // Application Credential ID (OS_APPLICATION_CREDENTIAL_ID).
-	ApplicationCredentialName   string `json:"applicationCredentialName"`             // Application Credential Name (OS_APPLICATION_CREDENTIAL_NAME).
-	ApplicationCredentialSecret string `json:"applicationCredentialSecret"`           // Application Credential Secret (OS_APPLICATION_CREDENTIAL_SECRET).
-	Auth                        string `json:"auth"`                                  // Authentication URL for server (OS_AUTH_URL).
-	AuthToken                   string `json:"authToken"`                             // Auth Token from alternate authentication - optional (OS_AUTH_TOKEN).
-	AuthVersion                 string `json:"authVersion" default:"0"`               // AuthVersion - optional - set to (1,2,3) if your auth URL has no version (ST_AUTH_VERSION).
-	ChunkSize                   string `json:"chunkSize" default:"5Gi"`               // Above this size files will be chunked into a _segments container.
-	Domain                      string `json:"domain"`                                // User domain - optional (v3 auth) (OS_USER_DOMAIN_NAME)
-	Encoding                    string `json:"encoding" default:"Slash,InvalidUtf8"`  // The encoding for the backend.
-	EndpointType                string `json:"endpointType" default:"public"`         // Endpoint type to choose from the service catalogue (OS_ENDPOINT_TYPE).
-	EnvAuth                     string `json:"envAuth" default:"false"`               // Get swift credentials from environment variables in standard OpenStack form.
-	Key                         string `json:"key"`                                   // API key or password (OS_PASSWORD).
-	LeavePartsOnError           string `json:"leavePartsOnError" default:"false"`     // If true avoid calling abort upload on a failure.
-	NoChunk                     string `json:"noChunk" default:"false"`               // Don't chunk files during streaming upload.
-	NoLargeObjects              string `json:"noLargeObjects" default:"false"`        // Disable support for static and dynamic large objects
-	Region                      string `json:"region"`                                // Region name - optional (OS_REGION_NAME).
-	StoragePolicy               string `json:"storagePolicy"`                         // The storage policy to use when creating a new container.
-	StorageUrl                  string `json:"storageUrl"`                            // Storage URL - optional (OS_STORAGE_URL).
-	Tenant                      string `json:"tenant"`                                // Tenant name - optional for v1 auth, this or tenant_id required otherwise (OS_TENANT_NAME or OS_PROJECT_NAME).
-	TenantDomain                string `json:"tenantDomain"`                          // Tenant domain - optional (v3 auth) (OS_PROJECT_DOMAIN_NAME).
-	TenantId                    string `json:"tenantId"`                              // Tenant ID - optional for v1 auth, this or tenant required otherwise (OS_TENANT_ID).
-	User                        string `json:"user"`                                  // User name to log in (OS_USERNAME).
-	UserId                      string `json:"userId"`                                // User ID to log in - optional - most swift systems use user and leave this blank (v3 auth) (OS_USER_ID).
+	SourcePath                  string          `validate:"required" json:"sourcePath"`        // The path of the source to scan items
+	DeleteAfterExport           bool            `validate:"required" json:"deleteAfterExport"` // Delete the source after exporting to CAR files
+	RescanInterval              string          `validate:"required" json:"rescanInterval"`    // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState               model.WorkState `validate:"required" json:"scanningState"`     // Starting state for scanning
+	ApplicationCredentialId     string          `json:"applicationCredentialId"`               // Application Credential ID (OS_APPLICATION_CREDENTIAL_ID).
+	ApplicationCredentialName   string          `json:"applicationCredentialName"`             // Application Credential Name (OS_APPLICATION_CREDENTIAL_NAME).
+	ApplicationCredentialSecret string          `json:"applicationCredentialSecret"`           // Application Credential Secret (OS_APPLICATION_CREDENTIAL_SECRET).
+	Auth                        string          `json:"auth"`                                  // Authentication URL for server (OS_AUTH_URL).
+	AuthToken                   string          `json:"authToken"`                             // Auth Token from alternate authentication - optional (OS_AUTH_TOKEN).
+	AuthVersion                 string          `json:"authVersion" default:"0"`               // AuthVersion - optional - set to (1,2,3) if your auth URL has no version (ST_AUTH_VERSION).
+	ChunkSize                   string          `json:"chunkSize" default:"5Gi"`               // Above this size files will be chunked into a _segments container.
+	Domain                      string          `json:"domain"`                                // User domain - optional (v3 auth) (OS_USER_DOMAIN_NAME)
+	Encoding                    string          `json:"encoding" default:"Slash,InvalidUtf8"`  // The encoding for the backend.
+	EndpointType                string          `json:"endpointType" default:"public"`         // Endpoint type to choose from the service catalogue (OS_ENDPOINT_TYPE).
+	EnvAuth                     string          `json:"envAuth" default:"false"`               // Get swift credentials from environment variables in standard OpenStack form.
+	Key                         string          `json:"key"`                                   // API key or password (OS_PASSWORD).
+	LeavePartsOnError           string          `json:"leavePartsOnError" default:"false"`     // If true avoid calling abort upload on a failure.
+	NoChunk                     string          `json:"noChunk" default:"false"`               // Don't chunk files during streaming upload.
+	NoLargeObjects              string          `json:"noLargeObjects" default:"false"`        // Disable support for static and dynamic large objects
+	Region                      string          `json:"region"`                                // Region name - optional (OS_REGION_NAME).
+	StoragePolicy               string          `json:"storagePolicy"`                         // The storage policy to use when creating a new container.
+	StorageUrl                  string          `json:"storageUrl"`                            // Storage URL - optional (OS_STORAGE_URL).
+	Tenant                      string          `json:"tenant"`                                // Tenant name - optional for v1 auth, this or tenant_id required otherwise (OS_TENANT_NAME or OS_PROJECT_NAME).
+	TenantDomain                string          `json:"tenantDomain"`                          // Tenant domain - optional (v3 auth) (OS_PROJECT_DOMAIN_NAME).
+	TenantId                    string          `json:"tenantId"`                              // Tenant ID - optional for v1 auth, this or tenant required otherwise (OS_TENANT_ID).
+	User                        string          `json:"user"`                                  // User name to log in (OS_USERNAME).
+	UserId                      string          `json:"userId"`                                // User ID to log in - optional - most swift systems use user and leave this blank (v3 auth) (OS_USER_ID).
 }
 
 // @Summary Add swift source for a dataset
@@ -1153,11 +1194,12 @@ type SwiftRequest struct {
 func handleSwift() {}
 
 type UptoboxRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`                                                        // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`                                                 // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`                                                    // Automatically rescan the source directory when this interval has passed from last successful scan
-	AccessToken       string `json:"accessToken"`                                                                           // Your access token.
-	Encoding          string `json:"encoding" default:"Slash,LtGt,DoubleQuote,BackQuote,Del,Ctl,LeftSpace,InvalidUtf8,Dot"` // The encoding for the backend.
+	SourcePath        string          `validate:"required" json:"sourcePath"`                                                        // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`                                                 // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`                                                    // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`                                                     // Starting state for scanning
+	AccessToken       string          `json:"accessToken"`                                                                           // Your access token.
+	Encoding          string          `json:"encoding" default:"Slash,LtGt,DoubleQuote,BackQuote,Del,Ctl,LeftSpace,InvalidUtf8,Dot"` // The encoding for the backend.
 }
 
 // @Summary Add uptobox source for a dataset
@@ -1173,17 +1215,18 @@ type UptoboxRequest struct {
 func handleUptobox() {}
 
 type WebdavRequest struct {
-	SourcePath         string `validate:"required" json:"sourcePath"`        // The path of the source to scan items
-	DeleteAfterExport  bool   `validate:"required" json:"deleteAfterExport"` // Delete the source after exporting to CAR files
-	RescanInterval     string `validate:"required" json:"rescanInterval"`    // Automatically rescan the source directory when this interval has passed from last successful scan
-	BearerToken        string `json:"bearerToken"`                           // Bearer token instead of user/pass (e.g. a Macaroon).
-	BearerTokenCommand string `json:"bearerTokenCommand"`                    // Command to run to get a bearer token.
-	Encoding           string `json:"encoding"`                              // The encoding for the backend.
-	Headers            string `json:"headers"`                               // Set HTTP headers for all transactions.
-	Pass               string `json:"pass"`                                  // Password.
-	Url                string `json:"url"`                                   // URL of http host to connect to.
-	User               string `json:"user"`                                  // User name.
-	Vendor             string `json:"vendor"`                                // Name of the WebDAV site/service/software you are using.
+	SourcePath         string          `validate:"required" json:"sourcePath"`        // The path of the source to scan items
+	DeleteAfterExport  bool            `validate:"required" json:"deleteAfterExport"` // Delete the source after exporting to CAR files
+	RescanInterval     string          `validate:"required" json:"rescanInterval"`    // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState      model.WorkState `validate:"required" json:"scanningState"`     // Starting state for scanning
+	BearerToken        string          `json:"bearerToken"`                           // Bearer token instead of user/pass (e.g. a Macaroon).
+	BearerTokenCommand string          `json:"bearerTokenCommand"`                    // Command to run to get a bearer token.
+	Encoding           string          `json:"encoding"`                              // The encoding for the backend.
+	Headers            string          `json:"headers"`                               // Set HTTP headers for all transactions.
+	Pass               string          `json:"pass"`                                  // Password.
+	Url                string          `json:"url"`                                   // URL of http host to connect to.
+	User               string          `json:"user"`                                  // User name.
+	Vendor             string          `json:"vendor"`                                // Name of the WebDAV site/service/software you are using.
 }
 
 // @Summary Add webdav source for a dataset
@@ -1199,16 +1242,17 @@ type WebdavRequest struct {
 func handleWebdav() {}
 
 type YandexRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`                   // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`            // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`               // Automatically rescan the source directory when this interval has passed from last successful scan
-	AuthUrl           string `json:"authUrl"`                                          // Auth server URL.
-	ClientId          string `json:"clientId"`                                         // OAuth Client Id.
-	ClientSecret      string `json:"clientSecret"`                                     // OAuth Client Secret.
-	Encoding          string `json:"encoding" default:"Slash,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
-	HardDelete        string `json:"hardDelete" default:"false"`                       // Delete files permanently rather than putting them into the trash.
-	Token             string `json:"token"`                                            // OAuth Access Token as a JSON blob.
-	TokenUrl          string `json:"tokenUrl"`                                         // Token server url.
+	SourcePath        string          `validate:"required" json:"sourcePath"`                   // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`            // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`               // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`                // Starting state for scanning
+	AuthUrl           string          `json:"authUrl"`                                          // Auth server URL.
+	ClientId          string          `json:"clientId"`                                         // OAuth Client Id.
+	ClientSecret      string          `json:"clientSecret"`                                     // OAuth Client Secret.
+	Encoding          string          `json:"encoding" default:"Slash,Del,Ctl,InvalidUtf8,Dot"` // The encoding for the backend.
+	HardDelete        string          `json:"hardDelete" default:"false"`                       // Delete files permanently rather than putting them into the trash.
+	Token             string          `json:"token"`                                            // OAuth Access Token as a JSON blob.
+	TokenUrl          string          `json:"tokenUrl"`                                         // Token server url.
 }
 
 // @Summary Add yandex source for a dataset
@@ -1224,16 +1268,17 @@ type YandexRequest struct {
 func handleYandex() {}
 
 type ZohoRequest struct {
-	SourcePath        string `validate:"required" json:"sourcePath"`         // The path of the source to scan items
-	DeleteAfterExport bool   `validate:"required" json:"deleteAfterExport"`  // Delete the source after exporting to CAR files
-	RescanInterval    string `validate:"required" json:"rescanInterval"`     // Automatically rescan the source directory when this interval has passed from last successful scan
-	AuthUrl           string `json:"authUrl"`                                // Auth server URL.
-	ClientId          string `json:"clientId"`                               // OAuth Client Id.
-	ClientSecret      string `json:"clientSecret"`                           // OAuth Client Secret.
-	Encoding          string `json:"encoding" default:"Del,Ctl,InvalidUtf8"` // The encoding for the backend.
-	Region            string `json:"region"`                                 // Zoho region to connect to.
-	Token             string `json:"token"`                                  // OAuth Access Token as a JSON blob.
-	TokenUrl          string `json:"tokenUrl"`                               // Token server url.
+	SourcePath        string          `validate:"required" json:"sourcePath"`         // The path of the source to scan items
+	DeleteAfterExport bool            `validate:"required" json:"deleteAfterExport"`  // Delete the source after exporting to CAR files
+	RescanInterval    string          `validate:"required" json:"rescanInterval"`     // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState     model.WorkState `validate:"required" json:"scanningState"`      // Starting state for scanning
+	AuthUrl           string          `json:"authUrl"`                                // Auth server URL.
+	ClientId          string          `json:"clientId"`                               // OAuth Client Id.
+	ClientSecret      string          `json:"clientSecret"`                           // OAuth Client Secret.
+	Encoding          string          `json:"encoding" default:"Del,Ctl,InvalidUtf8"` // The encoding for the backend.
+	Region            string          `json:"region"`                                 // Zoho region to connect to.
+	Token             string          `json:"token"`                                  // OAuth Access Token as a JSON blob.
+	TokenUrl          string          `json:"tokenUrl"`                               // Token server url.
 }
 
 // @Summary Add zoho source for a dataset
@@ -1249,514 +1294,515 @@ type ZohoRequest struct {
 func handleZoho() {}
 
 type AllConfig struct {
-	SourcePath                          string `validate:"required" json:"sourcePath"`                                                                                                                              // The path of the source to scan items
-	DeleteAfterExport                   bool   `validate:"optional" json:"deleteAfterExport"`                                                                                                                       // Delete the source after exporting to CAR files
-	RescanInterval                      string `validate:"optional" json:"rescanInterval"`                                                                                                                          // Automatically rescan the source directory when this interval has passed from last successful scan
-	AcdAuthUrl                          string `json:"acdAuthUrl"`                                                                                                                                                  // Auth server URL.
-	AcdCheckpoint                       string `json:"acdCheckpoint"`                                                                                                                                               // Checkpoint for internal polling (debug).
-	AcdClientId                         string `json:"acdClientId"`                                                                                                                                                 // OAuth Client Id.
-	AcdClientSecret                     string `json:"acdClientSecret"`                                                                                                                                             // OAuth Client Secret.
-	AcdEncoding                         string `json:"acdEncoding" default:"Slash,InvalidUtf8,Dot"`                                                                                                                 // The encoding for the backend.
-	AcdTemplinkThreshold                string `json:"acdTemplinkThreshold" default:"9Gi"`                                                                                                                          // Files >= this size will be downloaded via their tempLink.
-	AcdToken                            string `json:"acdToken"`                                                                                                                                                    // OAuth Access Token as a JSON blob.
-	AcdTokenUrl                         string `json:"acdTokenUrl"`                                                                                                                                                 // Token server url.
-	AcdUploadWaitPerGb                  string `json:"acdUploadWaitPerGb" default:"3m0s"`                                                                                                                           // Additional time per GiB to wait after a failed complete upload to see if it appears.
-	AzureblobAccessTier                 string `json:"azureblobAccessTier"`                                                                                                                                         // Access tier of blob: hot, cool or archive.
-	AzureblobAccount                    string `json:"azureblobAccount"`                                                                                                                                            // Azure Storage Account Name.
-	AzureblobArchiveTierDelete          string `json:"azureblobArchiveTierDelete" default:"false"`                                                                                                                  // Delete archive tier blobs before overwriting.
-	AzureblobChunkSize                  string `json:"azureblobChunkSize" default:"4Mi"`                                                                                                                            // Upload chunk size.
-	AzureblobClientCertificatePassword  string `json:"azureblobClientCertificatePassword"`                                                                                                                          // Password for the certificate file (optional).
-	AzureblobClientCertificatePath      string `json:"azureblobClientCertificatePath"`                                                                                                                              // Path to a PEM or PKCS12 certificate file including the private key.
-	AzureblobClientId                   string `json:"azureblobClientId"`                                                                                                                                           // The ID of the client in use.
-	AzureblobClientSecret               string `json:"azureblobClientSecret"`                                                                                                                                       // One of the service principal's client secrets
-	AzureblobClientSendCertificateChain string `json:"azureblobClientSendCertificateChain" default:"false"`                                                                                                         // Send the certificate chain when using certificate auth.
-	AzureblobDisableChecksum            string `json:"azureblobDisableChecksum" default:"false"`                                                                                                                    // Don't store MD5 checksum with object metadata.
-	AzureblobEncoding                   string `json:"azureblobEncoding" default:"Slash,BackSlash,Del,Ctl,RightPeriod,InvalidUtf8"`                                                                                 // The encoding for the backend.
-	AzureblobEndpoint                   string `json:"azureblobEndpoint"`                                                                                                                                           // Endpoint for the service.
-	AzureblobEnvAuth                    string `json:"azureblobEnvAuth" default:"false"`                                                                                                                            // Read credentials from runtime (environment variables, CLI or MSI).
-	AzureblobKey                        string `json:"azureblobKey"`                                                                                                                                                // Storage Account Shared Key.
-	AzureblobListChunk                  string `json:"azureblobListChunk" default:"5000"`                                                                                                                           // Size of blob list.
-	AzureblobMemoryPoolFlushTime        string `json:"azureblobMemoryPoolFlushTime" default:"1m0s"`                                                                                                                 // How often internal memory buffer pools will be flushed.
-	AzureblobMemoryPoolUseMmap          string `json:"azureblobMemoryPoolUseMmap" default:"false"`                                                                                                                  // Whether to use mmap buffers in internal memory pool.
-	AzureblobMsiClientId                string `json:"azureblobMsiClientId"`                                                                                                                                        // Object ID of the user-assigned MSI to use, if any.
-	AzureblobMsiMiResId                 string `json:"azureblobMsiMiResId"`                                                                                                                                         // Azure resource ID of the user-assigned MSI to use, if any.
-	AzureblobMsiObjectId                string `json:"azureblobMsiObjectId"`                                                                                                                                        // Object ID of the user-assigned MSI to use, if any.
-	AzureblobNoCheckContainer           string `json:"azureblobNoCheckContainer" default:"false"`                                                                                                                   // If set, don't attempt to check the container exists or create it.
-	AzureblobNoHeadObject               string `json:"azureblobNoHeadObject" default:"false"`                                                                                                                       // If set, do not do HEAD before GET when getting objects.
-	AzureblobPassword                   string `json:"azureblobPassword"`                                                                                                                                           // The user's password
-	AzureblobPublicAccess               string `json:"azureblobPublicAccess"`                                                                                                                                       // Public access level of a container: blob or container.
-	AzureblobSasUrl                     string `json:"azureblobSasUrl"`                                                                                                                                             // SAS URL for container level access only.
-	AzureblobServicePrincipalFile       string `json:"azureblobServicePrincipalFile"`                                                                                                                               // Path to file containing credentials for use with a service principal.
-	AzureblobTenant                     string `json:"azureblobTenant"`                                                                                                                                             // ID of the service principal's tenant. Also called its directory ID.
-	AzureblobUploadConcurrency          string `json:"azureblobUploadConcurrency" default:"16"`                                                                                                                     // Concurrency for multipart uploads.
-	AzureblobUploadCutoff               string `json:"azureblobUploadCutoff"`                                                                                                                                       // Cutoff for switching to chunked upload (<= 256 MiB) (deprecated).
-	AzureblobUseEmulator                string `json:"azureblobUseEmulator" default:"false"`                                                                                                                        // Uses local storage emulator if provided as 'true'.
-	AzureblobUseMsi                     string `json:"azureblobUseMsi" default:"false"`                                                                                                                             // Use a managed service identity to authenticate (only works in Azure).
-	AzureblobUsername                   string `json:"azureblobUsername"`                                                                                                                                           // User name (usually an email address)
-	B2Account                           string `json:"b2Account"`                                                                                                                                                   // Account ID or Application Key ID.
-	B2ChunkSize                         string `json:"b2ChunkSize" default:"96Mi"`                                                                                                                                  // Upload chunk size.
-	B2CopyCutoff                        string `json:"b2CopyCutoff" default:"4Gi"`                                                                                                                                  // Cutoff for switching to multipart copy.
-	B2DisableChecksum                   string `json:"b2DisableChecksum" default:"false"`                                                                                                                           // Disable checksums for large (> upload cutoff) files.
-	B2DownloadAuthDuration              string `json:"b2DownloadAuthDuration" default:"1w"`                                                                                                                         // Time before the authorization token will expire in s or suffix ms|s|m|h|d.
-	B2DownloadUrl                       string `json:"b2DownloadUrl"`                                                                                                                                               // Custom endpoint for downloads.
-	B2Encoding                          string `json:"b2Encoding" default:"Slash,BackSlash,Del,Ctl,InvalidUtf8,Dot"`                                                                                                // The encoding for the backend.
-	B2Endpoint                          string `json:"b2Endpoint"`                                                                                                                                                  // Endpoint for the service.
-	B2HardDelete                        string `json:"b2HardDelete" default:"false"`                                                                                                                                // Permanently delete files on remote removal, otherwise hide files.
-	B2Key                               string `json:"b2Key"`                                                                                                                                                       // Application Key.
-	B2MemoryPoolFlushTime               string `json:"b2MemoryPoolFlushTime" default:"1m0s"`                                                                                                                        // How often internal memory buffer pools will be flushed.
-	B2MemoryPoolUseMmap                 string `json:"b2MemoryPoolUseMmap" default:"false"`                                                                                                                         // Whether to use mmap buffers in internal memory pool.
-	B2TestMode                          string `json:"b2TestMode"`                                                                                                                                                  // A flag string for X-Bz-Test-Mode header for debugging.
-	B2UploadCutoff                      string `json:"b2UploadCutoff" default:"200Mi"`                                                                                                                              // Cutoff for switching to chunked upload.
-	B2VersionAt                         string `json:"b2VersionAt" default:"off"`                                                                                                                                   // Show file versions as they were at the specified time.
-	B2Versions                          string `json:"b2Versions" default:"false"`                                                                                                                                  // Include old versions in directory listings.
-	BoxAccessToken                      string `json:"boxAccessToken"`                                                                                                                                              // Box App Primary Access Token
-	BoxAuthUrl                          string `json:"boxAuthUrl"`                                                                                                                                                  // Auth server URL.
-	BoxBoxConfigFile                    string `json:"boxBoxConfigFile"`                                                                                                                                            // Box App config.json location
-	BoxBoxSubType                       string `json:"boxBoxSubType" default:"user"`                                                                                                                                //
-	BoxClientId                         string `json:"boxClientId"`                                                                                                                                                 // OAuth Client Id.
-	BoxClientSecret                     string `json:"boxClientSecret"`                                                                                                                                             // OAuth Client Secret.
-	BoxCommitRetries                    string `json:"boxCommitRetries" default:"100"`                                                                                                                              // Max number of times to try committing a multipart file.
-	BoxEncoding                         string `json:"boxEncoding" default:"Slash,BackSlash,Del,Ctl,RightSpace,InvalidUtf8,Dot"`                                                                                    // The encoding for the backend.
-	BoxListChunk                        string `json:"boxListChunk" default:"1000"`                                                                                                                                 // Size of listing chunk 1-1000.
-	BoxOwnedBy                          string `json:"boxOwnedBy"`                                                                                                                                                  // Only show items owned by the login (email address) passed in.
-	BoxRootFolderId                     string `json:"boxRootFolderId" default:"0"`                                                                                                                                 // Fill in for rclone to use a non root folder as its starting point.
-	BoxToken                            string `json:"boxToken"`                                                                                                                                                    // OAuth Access Token as a JSON blob.
-	BoxTokenUrl                         string `json:"boxTokenUrl"`                                                                                                                                                 // Token server url.
-	BoxUploadCutoff                     string `json:"boxUploadCutoff" default:"50Mi"`                                                                                                                              // Cutoff for switching to multipart upload (>= 50 MiB).
-	DriveAcknowledgeAbuse               string `json:"driveAcknowledgeAbuse" default:"false"`                                                                                                                       // Set to allow files which return cannotDownloadAbusiveFile to be downloaded.
-	DriveAllowImportNameChange          string `json:"driveAllowImportNameChange" default:"false"`                                                                                                                  // Allow the filetype to change when uploading Google docs.
-	DriveAlternateExport                string `json:"driveAlternateExport" default:"false"`                                                                                                                        // Deprecated: No longer needed.
-	DriveAuthOwnerOnly                  string `json:"driveAuthOwnerOnly" default:"false"`                                                                                                                          // Only consider files owned by the authenticated user.
-	DriveAuthUrl                        string `json:"driveAuthUrl"`                                                                                                                                                // Auth server URL.
-	DriveChunkSize                      string `json:"driveChunkSize" default:"8Mi"`                                                                                                                                // Upload chunk size.
-	DriveClientId                       string `json:"driveClientId"`                                                                                                                                               // Google Application Client Id
-	DriveClientSecret                   string `json:"driveClientSecret"`                                                                                                                                           // OAuth Client Secret.
-	DriveCopyShortcutContent            string `json:"driveCopyShortcutContent" default:"false"`                                                                                                                    // Server side copy contents of shortcuts instead of the shortcut.
-	DriveDisableHttp2                   string `json:"driveDisableHttp2" default:"true"`                                                                                                                            // Disable drive using http2.
-	DriveEncoding                       string `json:"driveEncoding" default:"InvalidUtf8"`                                                                                                                         // The encoding for the backend.
-	DriveExportFormats                  string `json:"driveExportFormats" default:"docx,xlsx,pptx,svg"`                                                                                                             // Comma separated list of preferred formats for downloading Google docs.
-	DriveFormats                        string `json:"driveFormats"`                                                                                                                                                // Deprecated: See export_formats.
-	DriveImpersonate                    string `json:"driveImpersonate"`                                                                                                                                            // Impersonate this user when using a service account.
-	DriveImportFormats                  string `json:"driveImportFormats"`                                                                                                                                          // Comma separated list of preferred formats for uploading Google docs.
-	DriveKeepRevisionForever            string `json:"driveKeepRevisionForever" default:"false"`                                                                                                                    // Keep new head revision of each file forever.
-	DriveListChunk                      string `json:"driveListChunk" default:"1000"`                                                                                                                               // Size of listing chunk 100-1000, 0 to disable.
-	DrivePacerBurst                     string `json:"drivePacerBurst" default:"100"`                                                                                                                               // Number of API calls to allow without sleeping.
-	DrivePacerMinSleep                  string `json:"drivePacerMinSleep" default:"100ms"`                                                                                                                          // Minimum time to sleep between API calls.
-	DriveResourceKey                    string `json:"driveResourceKey"`                                                                                                                                            // Resource key for accessing a link-shared file.
-	DriveRootFolderId                   string `json:"driveRootFolderId"`                                                                                                                                           // ID of the root folder.
-	DriveScope                          string `json:"driveScope"`                                                                                                                                                  // Scope that rclone should use when requesting access from drive.
-	DriveServerSideAcrossConfigs        string `json:"driveServerSideAcrossConfigs" default:"false"`                                                                                                                // Allow server-side operations (e.g. copy) to work across different drive configs.
-	DriveServiceAccountCredentials      string `json:"driveServiceAccountCredentials"`                                                                                                                              // Service Account Credentials JSON blob.
-	DriveServiceAccountFile             string `json:"driveServiceAccountFile"`                                                                                                                                     // Service Account Credentials JSON file path.
-	DriveSharedWithMe                   string `json:"driveSharedWithMe" default:"false"`                                                                                                                           // Only show files that are shared with me.
-	DriveSizeAsQuota                    string `json:"driveSizeAsQuota" default:"false"`                                                                                                                            // Show sizes as storage quota usage, not actual size.
-	DriveSkipChecksumGphotos            string `json:"driveSkipChecksumGphotos" default:"false"`                                                                                                                    // Skip MD5 checksum on Google photos and videos only.
-	DriveSkipDanglingShortcuts          string `json:"driveSkipDanglingShortcuts" default:"false"`                                                                                                                  // If set skip dangling shortcut files.
-	DriveSkipGdocs                      string `json:"driveSkipGdocs" default:"false"`                                                                                                                              // Skip google documents in all listings.
-	DriveSkipShortcuts                  string `json:"driveSkipShortcuts" default:"false"`                                                                                                                          // If set skip shortcut files.
-	DriveStarredOnly                    string `json:"driveStarredOnly" default:"false"`                                                                                                                            // Only show files that are starred.
-	DriveStopOnDownloadLimit            string `json:"driveStopOnDownloadLimit" default:"false"`                                                                                                                    // Make download limit errors be fatal.
-	DriveStopOnUploadLimit              string `json:"driveStopOnUploadLimit" default:"false"`                                                                                                                      // Make upload limit errors be fatal.
-	DriveTeamDrive                      string `json:"driveTeamDrive"`                                                                                                                                              // ID of the Shared Drive (Team Drive).
-	DriveToken                          string `json:"driveToken"`                                                                                                                                                  // OAuth Access Token as a JSON blob.
-	DriveTokenUrl                       string `json:"driveTokenUrl"`                                                                                                                                               // Token server url.
-	DriveTrashedOnly                    string `json:"driveTrashedOnly" default:"false"`                                                                                                                            // Only show files that are in the trash.
-	DriveUploadCutoff                   string `json:"driveUploadCutoff" default:"8Mi"`                                                                                                                             // Cutoff for switching to chunked upload.
-	DriveUseCreatedDate                 string `json:"driveUseCreatedDate" default:"false"`                                                                                                                         // Use file created date instead of modified date.
-	DriveUseSharedDate                  string `json:"driveUseSharedDate" default:"false"`                                                                                                                          // Use date file was shared instead of modified date.
-	DriveUseTrash                       string `json:"driveUseTrash" default:"true"`                                                                                                                                // Send files to the trash instead of deleting permanently.
-	DriveV2DownloadMinSize              string `json:"driveV2DownloadMinSize" default:"off"`                                                                                                                        // If Object's are greater, use drive v2 API to download.
-	DropboxAuthUrl                      string `json:"dropboxAuthUrl"`                                                                                                                                              // Auth server URL.
-	DropboxBatchCommitTimeout           string `json:"dropboxBatchCommitTimeout" default:"10m0s"`                                                                                                                   // Max time to wait for a batch to finish committing
-	DropboxBatchMode                    string `json:"dropboxBatchMode" default:"sync"`                                                                                                                             // Upload file batching sync|async|off.
-	DropboxBatchSize                    string `json:"dropboxBatchSize" default:"0"`                                                                                                                                // Max number of files in upload batch.
-	DropboxBatchTimeout                 string `json:"dropboxBatchTimeout" default:"0s"`                                                                                                                            // Max time to allow an idle upload batch before uploading.
-	DropboxChunkSize                    string `json:"dropboxChunkSize" default:"48Mi"`                                                                                                                             // Upload chunk size (< 150Mi).
-	DropboxClientId                     string `json:"dropboxClientId"`                                                                                                                                             // OAuth Client Id.
-	DropboxClientSecret                 string `json:"dropboxClientSecret"`                                                                                                                                         // OAuth Client Secret.
-	DropboxEncoding                     string `json:"dropboxEncoding" default:"Slash,BackSlash,Del,RightSpace,InvalidUtf8,Dot"`                                                                                    // The encoding for the backend.
-	DropboxImpersonate                  string `json:"dropboxImpersonate"`                                                                                                                                          // Impersonate this user when using a business account.
-	DropboxSharedFiles                  string `json:"dropboxSharedFiles" default:"false"`                                                                                                                          // Instructs rclone to work on individual shared files.
-	DropboxSharedFolders                string `json:"dropboxSharedFolders" default:"false"`                                                                                                                        // Instructs rclone to work on shared folders.
-	DropboxToken                        string `json:"dropboxToken"`                                                                                                                                                // OAuth Access Token as a JSON blob.
-	DropboxTokenUrl                     string `json:"dropboxTokenUrl"`                                                                                                                                             // Token server url.
-	FichierApiKey                       string `json:"fichierApiKey"`                                                                                                                                               // Your API Key, get it from https://1fichier.com/console/params.pl.
-	FichierEncoding                     string `json:"fichierEncoding" default:"Slash,LtGt,DoubleQuote,SingleQuote,BackQuote,Dollar,BackSlash,Del,Ctl,LeftSpace,RightSpace,InvalidUtf8,Dot"`                        // The encoding for the backend.
-	FichierFilePassword                 string `json:"fichierFilePassword"`                                                                                                                                         // If you want to download a shared file that is password protected, add this parameter.
-	FichierFolderPassword               string `json:"fichierFolderPassword"`                                                                                                                                       // If you want to list the files in a shared folder that is password protected, add this parameter.
-	FichierSharedFolder                 string `json:"fichierSharedFolder"`                                                                                                                                         // If you want to download a shared folder, add this parameter.
-	FilefabricEncoding                  string `json:"filefabricEncoding" default:"Slash,Del,Ctl,InvalidUtf8,Dot"`                                                                                                  // The encoding for the backend.
-	FilefabricPermanentToken            string `json:"filefabricPermanentToken"`                                                                                                                                    // Permanent Authentication Token.
-	FilefabricRootFolderId              string `json:"filefabricRootFolderId"`                                                                                                                                      // ID of the root folder.
-	FilefabricToken                     string `json:"filefabricToken"`                                                                                                                                             // Session Token.
-	FilefabricTokenExpiry               string `json:"filefabricTokenExpiry"`                                                                                                                                       // Token expiry time.
-	FilefabricUrl                       string `json:"filefabricUrl"`                                                                                                                                               // URL of the Enterprise File Fabric to connect to.
-	FilefabricVersion                   string `json:"filefabricVersion"`                                                                                                                                           // Version read from the file fabric.
-	FtpAskPassword                      string `json:"ftpAskPassword" default:"false"`                                                                                                                              // Allow asking for FTP password when needed.
-	FtpCloseTimeout                     string `json:"ftpCloseTimeout" default:"1m0s"`                                                                                                                              // Maximum time to wait for a response to close.
-	FtpConcurrency                      string `json:"ftpConcurrency" default:"0"`                                                                                                                                  // Maximum number of FTP simultaneous connections, 0 for unlimited.
-	FtpDisableEpsv                      string `json:"ftpDisableEpsv" default:"false"`                                                                                                                              // Disable using EPSV even if server advertises support.
-	FtpDisableMlsd                      string `json:"ftpDisableMlsd" default:"false"`                                                                                                                              // Disable using MLSD even if server advertises support.
-	FtpDisableTls13                     string `json:"ftpDisableTls13" default:"false"`                                                                                                                             // Disable TLS 1.3 (workaround for FTP servers with buggy TLS)
-	FtpDisableUtf8                      string `json:"ftpDisableUtf8" default:"false"`                                                                                                                              // Disable using UTF-8 even if server advertises support.
-	FtpEncoding                         string `json:"ftpEncoding" default:"Slash,Del,Ctl,RightSpace,Dot"`                                                                                                          // The encoding for the backend.
-	FtpExplicitTls                      string `json:"ftpExplicitTls" default:"false"`                                                                                                                              // Use Explicit FTPS (FTP over TLS).
-	FtpForceListHidden                  string `json:"ftpForceListHidden" default:"false"`                                                                                                                          // Use LIST -a to force listing of hidden files and folders. This will disable the use of MLSD.
-	FtpHost                             string `json:"ftpHost"`                                                                                                                                                     // FTP host to connect to.
-	FtpIdleTimeout                      string `json:"ftpIdleTimeout" default:"1m0s"`                                                                                                                               // Max time before closing idle connections.
-	FtpNoCheckCertificate               string `json:"ftpNoCheckCertificate" default:"false"`                                                                                                                       // Do not verify the TLS certificate of the server.
-	FtpPass                             string `json:"ftpPass"`                                                                                                                                                     // FTP password.
-	FtpPort                             string `json:"ftpPort" default:"21"`                                                                                                                                        // FTP port number.
-	FtpShutTimeout                      string `json:"ftpShutTimeout" default:"1m0s"`                                                                                                                               // Maximum time to wait for data connection closing status.
-	FtpTls                              string `json:"ftpTls" default:"false"`                                                                                                                                      // Use Implicit FTPS (FTP over TLS).
-	FtpTlsCacheSize                     string `json:"ftpTlsCacheSize" default:"32"`                                                                                                                                // Size of TLS session cache for all control and data connections.
-	FtpUser                             string `json:"ftpUser" default:"$USER"`                                                                                                                                     // FTP username.
-	FtpWritingMdtm                      string `json:"ftpWritingMdtm" default:"false"`                                                                                                                              // Use MDTM to set modification time (VsFtpd quirk)
-	GcsAnonymous                        string `json:"gcsAnonymous" default:"false"`                                                                                                                                // Access public buckets and objects without credentials.
-	GcsAuthUrl                          string `json:"gcsAuthUrl"`                                                                                                                                                  // Auth server URL.
-	GcsBucketAcl                        string `json:"gcsBucketAcl"`                                                                                                                                                // Access Control List for new buckets.
-	GcsBucketPolicyOnly                 string `json:"gcsBucketPolicyOnly" default:"false"`                                                                                                                         // Access checks should use bucket-level IAM policies.
-	GcsClientId                         string `json:"gcsClientId"`                                                                                                                                                 // OAuth Client Id.
-	GcsClientSecret                     string `json:"gcsClientSecret"`                                                                                                                                             // OAuth Client Secret.
-	GcsDecompress                       string `json:"gcsDecompress" default:"false"`                                                                                                                               // If set this will decompress gzip encoded objects.
-	GcsEncoding                         string `json:"gcsEncoding" default:"Slash,CrLf,InvalidUtf8,Dot"`                                                                                                            // The encoding for the backend.
-	GcsEndpoint                         string `json:"gcsEndpoint"`                                                                                                                                                 // Endpoint for the service.
-	GcsEnvAuth                          string `json:"gcsEnvAuth" default:"false"`                                                                                                                                  // Get GCP IAM credentials from runtime (environment variables or instance meta data if no env vars).
-	GcsLocation                         string `json:"gcsLocation"`                                                                                                                                                 // Location for the newly created buckets.
-	GcsNoCheckBucket                    string `json:"gcsNoCheckBucket" default:"false"`                                                                                                                            // If set, don't attempt to check the bucket exists or create it.
-	GcsObjectAcl                        string `json:"gcsObjectAcl"`                                                                                                                                                // Access Control List for new objects.
-	GcsProjectNumber                    string `json:"gcsProjectNumber"`                                                                                                                                            // Project number.
-	GcsServiceAccountCredentials        string `json:"gcsServiceAccountCredentials"`                                                                                                                                // Service Account Credentials JSON blob.
-	GcsServiceAccountFile               string `json:"gcsServiceAccountFile"`                                                                                                                                       // Service Account Credentials JSON file path.
-	GcsStorageClass                     string `json:"gcsStorageClass"`                                                                                                                                             // The storage class to use when storing objects in Google Cloud Storage.
-	GcsToken                            string `json:"gcsToken"`                                                                                                                                                    // OAuth Access Token as a JSON blob.
-	GcsTokenUrl                         string `json:"gcsTokenUrl"`                                                                                                                                                 // Token server url.
-	GphotosAuthUrl                      string `json:"gphotosAuthUrl"`                                                                                                                                              // Auth server URL.
-	GphotosClientId                     string `json:"gphotosClientId"`                                                                                                                                             // OAuth Client Id.
-	GphotosClientSecret                 string `json:"gphotosClientSecret"`                                                                                                                                         // OAuth Client Secret.
-	GphotosEncoding                     string `json:"gphotosEncoding" default:"Slash,CrLf,InvalidUtf8,Dot"`                                                                                                        // The encoding for the backend.
-	GphotosIncludeArchived              string `json:"gphotosIncludeArchived" default:"false"`                                                                                                                      // Also view and download archived media.
-	GphotosReadOnly                     string `json:"gphotosReadOnly" default:"false"`                                                                                                                             // Set to make the Google Photos backend read only.
-	GphotosReadSize                     string `json:"gphotosReadSize" default:"false"`                                                                                                                             // Set to read the size of media items.
-	GphotosStartYear                    string `json:"gphotosStartYear" default:"2000"`                                                                                                                             // Year limits the photos to be downloaded to those which are uploaded after the given year.
-	GphotosToken                        string `json:"gphotosToken"`                                                                                                                                                // OAuth Access Token as a JSON blob.
-	GphotosTokenUrl                     string `json:"gphotosTokenUrl"`                                                                                                                                             // Token server url.
-	HdfsDataTransferProtection          string `json:"hdfsDataTransferProtection"`                                                                                                                                  // Kerberos data transfer protection: authentication|integrity|privacy.
-	HdfsEncoding                        string `json:"hdfsEncoding" default:"Slash,Colon,Del,Ctl,InvalidUtf8,Dot"`                                                                                                  // The encoding for the backend.
-	HdfsNamenode                        string `json:"hdfsNamenode"`                                                                                                                                                // Hadoop name node and port.
-	HdfsServicePrincipalName            string `json:"hdfsServicePrincipalName"`                                                                                                                                    // Kerberos service principal name for the namenode.
-	HdfsUsername                        string `json:"hdfsUsername"`                                                                                                                                                // Hadoop user name.
-	HidriveAuthUrl                      string `json:"hidriveAuthUrl"`                                                                                                                                              // Auth server URL.
-	HidriveChunkSize                    string `json:"hidriveChunkSize" default:"48Mi"`                                                                                                                             // Chunksize for chunked uploads.
-	HidriveClientId                     string `json:"hidriveClientId"`                                                                                                                                             // OAuth Client Id.
-	HidriveClientSecret                 string `json:"hidriveClientSecret"`                                                                                                                                         // OAuth Client Secret.
-	HidriveDisableFetchingMemberCount   string `json:"hidriveDisableFetchingMemberCount" default:"false"`                                                                                                           // Do not fetch number of objects in directories unless it is absolutely necessary.
-	HidriveEncoding                     string `json:"hidriveEncoding" default:"Slash,Dot"`                                                                                                                         // The encoding for the backend.
-	HidriveEndpoint                     string `json:"hidriveEndpoint" default:"https://api.hidrive.strato.com/2.1"`                                                                                                // Endpoint for the service.
-	HidriveRootPrefix                   string `json:"hidriveRootPrefix" default:"/"`                                                                                                                               // The root/parent folder for all paths.
-	HidriveScopeAccess                  string `json:"hidriveScopeAccess" default:"rw"`                                                                                                                             // Access permissions that rclone should use when requesting access from HiDrive.
-	HidriveScopeRole                    string `json:"hidriveScopeRole" default:"user"`                                                                                                                             // User-level that rclone should use when requesting access from HiDrive.
-	HidriveToken                        string `json:"hidriveToken"`                                                                                                                                                // OAuth Access Token as a JSON blob.
-	HidriveTokenUrl                     string `json:"hidriveTokenUrl"`                                                                                                                                             // Token server url.
-	HidriveUploadConcurrency            string `json:"hidriveUploadConcurrency" default:"4"`                                                                                                                        // Concurrency for chunked uploads.
-	HidriveUploadCutoff                 string `json:"hidriveUploadCutoff" default:"96Mi"`                                                                                                                          // Cutoff/Threshold for chunked uploads.
-	HttpHeaders                         string `json:"httpHeaders"`                                                                                                                                                 // Set HTTP headers for all transactions.
-	HttpNoHead                          string `json:"httpNoHead" default:"false"`                                                                                                                                  // Don't use HEAD requests.
-	HttpNoSlash                         string `json:"httpNoSlash" default:"false"`                                                                                                                                 // Set this if the site doesn't end directories with /.
-	HttpUrl                             string `json:"httpUrl"`                                                                                                                                                     // URL of HTTP host to connect to.
-	InternetarchiveAccessKeyId          string `json:"internetarchiveAccessKeyId"`                                                                                                                                  // IAS3 Access Key.
-	InternetarchiveDisableChecksum      string `json:"internetarchiveDisableChecksum" default:"true"`                                                                                                               // Don't ask the server to test against MD5 checksum calculated by rclone.
-	InternetarchiveEncoding             string `json:"internetarchiveEncoding" default:"Slash,LtGt,CrLf,Del,Ctl,InvalidUtf8,Dot"`                                                                                   // The encoding for the backend.
-	InternetarchiveEndpoint             string `json:"internetarchiveEndpoint" default:"https://s3.us.archive.org"`                                                                                                 // IAS3 Endpoint.
-	InternetarchiveFrontEndpoint        string `json:"internetarchiveFrontEndpoint" default:"https://archive.org"`                                                                                                  // Host of InternetArchive Frontend.
-	InternetarchiveSecretAccessKey      string `json:"internetarchiveSecretAccessKey"`                                                                                                                              // IAS3 Secret Key (password).
-	InternetarchiveWaitArchive          string `json:"internetarchiveWaitArchive" default:"0s"`                                                                                                                     // Timeout for waiting the server's processing tasks (specifically archive and book_op) to finish.
-	JottacloudEncoding                  string `json:"jottacloudEncoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,Del,Ctl,InvalidUtf8,Dot"`                                                    // The encoding for the backend.
-	JottacloudHardDelete                string `json:"jottacloudHardDelete" default:"false"`                                                                                                                        // Delete files permanently rather than putting them into the trash.
-	JottacloudMd5MemoryLimit            string `json:"jottacloudMd5MemoryLimit" default:"10Mi"`                                                                                                                     // Files bigger than this will be cached on disk to calculate the MD5 if required.
-	JottacloudNoVersions                string `json:"jottacloudNoVersions" default:"false"`                                                                                                                        // Avoid server side versioning by deleting files and recreating files instead of overwriting them.
-	JottacloudTrashedOnly               string `json:"jottacloudTrashedOnly" default:"false"`                                                                                                                       // Only show files that are in the trash.
-	JottacloudUploadResumeLimit         string `json:"jottacloudUploadResumeLimit" default:"10Mi"`                                                                                                                  // Files bigger than this can be resumed if the upload fail's.
-	KoofrEncoding                       string `json:"koofrEncoding" default:"Slash,BackSlash,Del,Ctl,InvalidUtf8,Dot"`                                                                                             // The encoding for the backend.
-	KoofrEndpoint                       string `json:"koofrEndpoint"`                                                                                                                                               // The Koofr API endpoint to use.
-	KoofrMountid                        string `json:"koofrMountid"`                                                                                                                                                // Mount ID of the mount to use.
-	KoofrPassword                       string `json:"koofrPassword"`                                                                                                                                               // Your password for rclone (generate one at https://app.koofr.net/app/admin/preferences/password).
-	KoofrProvider                       string `json:"koofrProvider"`                                                                                                                                               // Choose your storage provider.
-	KoofrSetmtime                       string `json:"koofrSetmtime" default:"true"`                                                                                                                                // Does the backend support setting modification time.
-	KoofrUser                           string `json:"koofrUser"`                                                                                                                                                   // Your user name.
-	LocalCaseInsensitive                string `json:"localCaseInsensitive" default:"false"`                                                                                                                        // Force the filesystem to report itself as case insensitive.
-	LocalCaseSensitive                  string `json:"localCaseSensitive" default:"false"`                                                                                                                          // Force the filesystem to report itself as case sensitive.
-	LocalCopyLinks                      string `json:"localCopyLinks" default:"false"`                                                                                                                              // Follow symlinks and copy the pointed to item.
-	LocalEncoding                       string `json:"localEncoding" default:"Slash,Dot"`                                                                                                                           // The encoding for the backend.
-	LocalLinks                          string `json:"localLinks" default:"false"`                                                                                                                                  // Translate symlinks to/from regular files with a '.rclonelink' extension.
-	LocalNoCheckUpdated                 string `json:"localNoCheckUpdated" default:"false"`                                                                                                                         // Don't check to see if the files change during upload.
-	LocalNoPreallocate                  string `json:"localNoPreallocate" default:"false"`                                                                                                                          // Disable preallocation of disk space for transferred files.
-	LocalNoSetModtime                   string `json:"localNoSetModtime" default:"false"`                                                                                                                           // Disable setting modtime.
-	LocalNoSparse                       string `json:"localNoSparse" default:"false"`                                                                                                                               // Disable sparse files for multi-thread downloads.
-	LocalNounc                          string `json:"localNounc" default:"false"`                                                                                                                                  // Disable UNC (long path names) conversion on Windows.
-	LocalOneFileSystem                  string `json:"localOneFileSystem" default:"false"`                                                                                                                          // Don't cross filesystem boundaries (unix/macOS only).
-	LocalSkipLinks                      string `json:"localSkipLinks" default:"false"`                                                                                                                              // Don't warn about skipped symlinks.
-	LocalUnicodeNormalization           string `json:"localUnicodeNormalization" default:"false"`                                                                                                                   // Apply unicode NFC normalization to paths and filenames.
-	LocalZeroSizeLinks                  string `json:"localZeroSizeLinks" default:"false"`                                                                                                                          // Assume the Stat size of links is zero (and read them instead) (deprecated).
-	MailruCheckHash                     string `json:"mailruCheckHash" default:"true"`                                                                                                                              // What should copy do if file checksum is mismatched or invalid.
-	MailruEncoding                      string `json:"mailruEncoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,Del,Ctl,InvalidUtf8,Dot"`                                              // The encoding for the backend.
-	MailruPass                          string `json:"mailruPass"`                                                                                                                                                  // Password.
-	MailruQuirks                        string `json:"mailruQuirks"`                                                                                                                                                // Comma separated list of internal maintenance flags.
-	MailruSpeedupEnable                 string `json:"mailruSpeedupEnable" default:"true"`                                                                                                                          // Skip full upload if there is another file with same data hash.
-	MailruSpeedupFilePatterns           string `json:"mailruSpeedupFilePatterns" default:"*.mkv,*.avi,*.mp4,*.mp3,*.zip,*.gz,*.rar,*.pdf"`                                                                          // Comma separated list of file name patterns eligible for speedup (put by hash).
-	MailruSpeedupMaxDisk                string `json:"mailruSpeedupMaxDisk" default:"3Gi"`                                                                                                                          // This option allows you to disable speedup (put by hash) for large files.
-	MailruSpeedupMaxMemory              string `json:"mailruSpeedupMaxMemory" default:"32Mi"`                                                                                                                       // Files larger than the size given below will always be hashed on disk.
-	MailruUser                          string `json:"mailruUser"`                                                                                                                                                  // User name (usually email).
-	MailruUserAgent                     string `json:"mailruUserAgent"`                                                                                                                                             // HTTP user agent used internally by client.
-	MegaDebug                           string `json:"megaDebug" default:"false"`                                                                                                                                   // Output more debug from Mega.
-	MegaEncoding                        string `json:"megaEncoding" default:"Slash,InvalidUtf8,Dot"`                                                                                                                // The encoding for the backend.
-	MegaHardDelete                      string `json:"megaHardDelete" default:"false"`                                                                                                                              // Delete files permanently rather than putting them into the trash.
-	MegaPass                            string `json:"megaPass"`                                                                                                                                                    // Password.
-	MegaUseHttps                        string `json:"megaUseHttps" default:"false"`                                                                                                                                // Use HTTPS for transfers.
-	MegaUser                            string `json:"megaUser"`                                                                                                                                                    // User name.
-	NetstorageAccount                   string `json:"netstorageAccount"`                                                                                                                                           // Set the NetStorage account name
-	NetstorageHost                      string `json:"netstorageHost"`                                                                                                                                              // Domain+path of NetStorage host to connect to.
-	NetstorageProtocol                  string `json:"netstorageProtocol" default:"https"`                                                                                                                          // Select between HTTP or HTTPS protocol.
-	NetstorageSecret                    string `json:"netstorageSecret"`                                                                                                                                            // Set the NetStorage account secret/G2O key for authentication.
-	OnedriveAccessScopes                string `json:"onedriveAccessScopes" default:"Files.Read Files.ReadWrite Files.Read.All Files.ReadWrite.All Sites.Read.All offline_access"`                                  // Set scopes to be requested by rclone.
-	OnedriveAuthUrl                     string `json:"onedriveAuthUrl"`                                                                                                                                             // Auth server URL.
-	OnedriveChunkSize                   string `json:"onedriveChunkSize" default:"10Mi"`                                                                                                                            // Chunk size to upload files with - must be multiple of 320k (327,680 bytes).
-	OnedriveClientId                    string `json:"onedriveClientId"`                                                                                                                                            // OAuth Client Id.
-	OnedriveClientSecret                string `json:"onedriveClientSecret"`                                                                                                                                        // OAuth Client Secret.
-	OnedriveDisableSitePermission       string `json:"onedriveDisableSitePermission" default:"false"`                                                                                                               // Disable the request for Sites.Read.All permission.
-	OnedriveDriveId                     string `json:"onedriveDriveId"`                                                                                                                                             // The ID of the drive to use.
-	OnedriveDriveType                   string `json:"onedriveDriveType"`                                                                                                                                           // The type of the drive (personal | business | documentLibrary).
-	OnedriveEncoding                    string `json:"onedriveEncoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,Del,Ctl,LeftSpace,LeftTilde,RightSpace,RightPeriod,InvalidUtf8,Dot"` // The encoding for the backend.
-	OnedriveExposeOnenoteFiles          string `json:"onedriveExposeOnenoteFiles" default:"false"`                                                                                                                  // Set to make OneNote files show up in directory listings.
-	OnedriveHashType                    string `json:"onedriveHashType" default:"auto"`                                                                                                                             // Specify the hash in use for the backend.
-	OnedriveLinkPassword                string `json:"onedriveLinkPassword"`                                                                                                                                        // Set the password for links created by the link command.
-	OnedriveLinkScope                   string `json:"onedriveLinkScope" default:"anonymous"`                                                                                                                       // Set the scope of the links created by the link command.
-	OnedriveLinkType                    string `json:"onedriveLinkType" default:"view"`                                                                                                                             // Set the type of the links created by the link command.
-	OnedriveListChunk                   string `json:"onedriveListChunk" default:"1000"`                                                                                                                            // Size of listing chunk.
-	OnedriveNoVersions                  string `json:"onedriveNoVersions" default:"false"`                                                                                                                          // Remove all versions on modifying operations.
-	OnedriveRegion                      string `json:"onedriveRegion" default:"global"`                                                                                                                             // Choose national cloud region for OneDrive.
-	OnedriveRootFolderId                string `json:"onedriveRootFolderId"`                                                                                                                                        // ID of the root folder.
-	OnedriveServerSideAcrossConfigs     string `json:"onedriveServerSideAcrossConfigs" default:"false"`                                                                                                             // Allow server-side operations (e.g. copy) to work across different onedrive configs.
-	OnedriveToken                       string `json:"onedriveToken"`                                                                                                                                               // OAuth Access Token as a JSON blob.
-	OnedriveTokenUrl                    string `json:"onedriveTokenUrl"`                                                                                                                                            // Token server url.
-	OpendriveChunkSize                  string `json:"opendriveChunkSize" default:"10Mi"`                                                                                                                           // Files will be uploaded in chunks this size.
-	OpendriveEncoding                   string `json:"opendriveEncoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,LeftSpace,LeftCrLfHtVt,RightSpace,RightCrLfHtVt,InvalidUtf8,Dot"`   // The encoding for the backend.
-	OpendrivePassword                   string `json:"opendrivePassword"`                                                                                                                                           // Password.
-	OpendriveUsername                   string `json:"opendriveUsername"`                                                                                                                                           // Username.
-	OosChunkSize                        string `json:"oosChunkSize" default:"5Mi"`                                                                                                                                  // Chunk size to use for uploading.
-	OosCompartment                      string `json:"oosCompartment"`                                                                                                                                              // Object storage compartment OCID
-	OosConfigFile                       string `json:"oosConfigFile" default:"~/.oci/config"`                                                                                                                       // Path to OCI config file
-	OosConfigProfile                    string `json:"oosConfigProfile" default:"Default"`                                                                                                                          // Profile name inside the oci config file
-	OosCopyCutoff                       string `json:"oosCopyCutoff" default:"4.656Gi"`                                                                                                                             // Cutoff for switching to multipart copy.
-	OosCopyTimeout                      string `json:"oosCopyTimeout" default:"1m0s"`                                                                                                                               // Timeout for copy.
-	OosDisableChecksum                  string `json:"oosDisableChecksum" default:"false"`                                                                                                                          // Don't store MD5 checksum with object metadata.
-	OosEncoding                         string `json:"oosEncoding" default:"Slash,InvalidUtf8,Dot"`                                                                                                                 // The encoding for the backend.
-	OosEndpoint                         string `json:"oosEndpoint"`                                                                                                                                                 // Endpoint for Object storage API.
-	OosLeavePartsOnError                string `json:"oosLeavePartsOnError" default:"false"`                                                                                                                        // If true avoid calling abort upload on a failure, leaving all successfully uploaded parts on S3 for manual recovery.
-	OosNamespace                        string `json:"oosNamespace"`                                                                                                                                                // Object storage namespace
-	OosNoCheckBucket                    string `json:"oosNoCheckBucket" default:"false"`                                                                                                                            // If set, don't attempt to check the bucket exists or create it.
-	OosProvider                         string `json:"oosProvider" default:"env_auth"`                                                                                                                              // Choose your Auth Provider
-	OosRegion                           string `json:"oosRegion"`                                                                                                                                                   // Object storage Region
-	OosSseCustomerAlgorithm             string `json:"oosSseCustomerAlgorithm"`                                                                                                                                     // If using SSE-C, the optional header that specifies "AES256" as the encryption algorithm.
-	OosSseCustomerKey                   string `json:"oosSseCustomerKey"`                                                                                                                                           // To use SSE-C, the optional header that specifies the base64-encoded 256-bit encryption key to use to
-	OosSseCustomerKeyFile               string `json:"oosSseCustomerKeyFile"`                                                                                                                                       // To use SSE-C, a file containing the base64-encoded string of the AES-256 encryption key associated
-	OosSseCustomerKeySha256             string `json:"oosSseCustomerKeySha256"`                                                                                                                                     // If using SSE-C, The optional header that specifies the base64-encoded SHA256 hash of the encryption
-	OosSseKmsKeyId                      string `json:"oosSseKmsKeyId"`                                                                                                                                              // if using using your own master key in vault, this header specifies the
-	OosStorageTier                      string `json:"oosStorageTier" default:"Standard"`                                                                                                                           // The storage class to use when storing new objects in storage. https://docs.oracle.com/en-us/iaas/Content/Object/Concepts/understandingstoragetiers.htm
-	OosUploadConcurrency                string `json:"oosUploadConcurrency" default:"10"`                                                                                                                           // Concurrency for multipart uploads.
-	OosUploadCutoff                     string `json:"oosUploadCutoff" default:"200Mi"`                                                                                                                             // Cutoff for switching to chunked upload.
-	PcloudAuthUrl                       string `json:"pcloudAuthUrl"`                                                                                                                                               // Auth server URL.
-	PcloudClientId                      string `json:"pcloudClientId"`                                                                                                                                              // OAuth Client Id.
-	PcloudClientSecret                  string `json:"pcloudClientSecret"`                                                                                                                                          // OAuth Client Secret.
-	PcloudEncoding                      string `json:"pcloudEncoding" default:"Slash,BackSlash,Del,Ctl,InvalidUtf8,Dot"`                                                                                            // The encoding for the backend.
-	PcloudHostname                      string `json:"pcloudHostname" default:"api.pcloud.com"`                                                                                                                     // Hostname to connect to.
-	PcloudPassword                      string `json:"pcloudPassword"`                                                                                                                                              // Your pcloud password.
-	PcloudRootFolderId                  string `json:"pcloudRootFolderId" default:"d0"`                                                                                                                             // Fill in for rclone to use a non root folder as its starting point.
-	PcloudToken                         string `json:"pcloudToken"`                                                                                                                                                 // OAuth Access Token as a JSON blob.
-	PcloudTokenUrl                      string `json:"pcloudTokenUrl"`                                                                                                                                              // Token server url.
-	PcloudUsername                      string `json:"pcloudUsername"`                                                                                                                                              // Your pcloud username.
-	PremiumizemeApiKey                  string `json:"premiumizemeApiKey"`                                                                                                                                          // API Key.
-	PremiumizemeEncoding                string `json:"premiumizemeEncoding" default:"Slash,DoubleQuote,BackSlash,Del,Ctl,InvalidUtf8,Dot"`                                                                          // The encoding for the backend.
-	PutioEncoding                       string `json:"putioEncoding" default:"Slash,BackSlash,Del,Ctl,InvalidUtf8,Dot"`                                                                                             // The encoding for the backend.
-	QingstorAccessKeyId                 string `json:"qingstorAccessKeyId"`                                                                                                                                         // QingStor Access Key ID.
-	QingstorChunkSize                   string `json:"qingstorChunkSize" default:"4Mi"`                                                                                                                             // Chunk size to use for uploading.
-	QingstorConnectionRetries           string `json:"qingstorConnectionRetries" default:"3"`                                                                                                                       // Number of connection retries.
-	QingstorEncoding                    string `json:"qingstorEncoding" default:"Slash,Ctl,InvalidUtf8"`                                                                                                            // The encoding for the backend.
-	QingstorEndpoint                    string `json:"qingstorEndpoint"`                                                                                                                                            // Enter an endpoint URL to connection QingStor API.
-	QingstorEnvAuth                     string `json:"qingstorEnvAuth" default:"false"`                                                                                                                             // Get QingStor credentials from runtime.
-	QingstorSecretAccessKey             string `json:"qingstorSecretAccessKey"`                                                                                                                                     // QingStor Secret Access Key (password).
-	QingstorUploadConcurrency           string `json:"qingstorUploadConcurrency" default:"1"`                                                                                                                       // Concurrency for multipart uploads.
-	QingstorUploadCutoff                string `json:"qingstorUploadCutoff" default:"200Mi"`                                                                                                                        // Cutoff for switching to chunked upload.
-	QingstorZone                        string `json:"qingstorZone"`                                                                                                                                                // Zone to connect to.
-	S3AccessKeyId                       string `json:"s3AccessKeyId"`                                                                                                                                               // AWS Access Key ID.
-	S3Acl                               string `json:"s3Acl"`                                                                                                                                                       // Canned ACL used when creating buckets and storing or copying objects.
-	S3BucketAcl                         string `json:"s3BucketAcl"`                                                                                                                                                 // Canned ACL used when creating buckets.
-	S3ChunkSize                         string `json:"s3ChunkSize" default:"5Mi"`                                                                                                                                   // Chunk size to use for uploading.
-	S3CopyCutoff                        string `json:"s3CopyCutoff" default:"4.656Gi"`                                                                                                                              // Cutoff for switching to multipart copy.
-	S3Decompress                        string `json:"s3Decompress" default:"false"`                                                                                                                                // If set this will decompress gzip encoded objects.
-	S3DisableChecksum                   string `json:"s3DisableChecksum" default:"false"`                                                                                                                           // Don't store MD5 checksum with object metadata.
-	S3DisableHttp2                      string `json:"s3DisableHttp2" default:"false"`                                                                                                                              // Disable usage of http2 for S3 backends.
-	S3DownloadUrl                       string `json:"s3DownloadUrl"`                                                                                                                                               // Custom endpoint for downloads.
-	S3Encoding                          string `json:"s3Encoding" default:"Slash,InvalidUtf8,Dot"`                                                                                                                  // The encoding for the backend.
-	S3Endpoint                          string `json:"s3Endpoint"`                                                                                                                                                  // Endpoint for S3 API.
-	S3EnvAuth                           string `json:"s3EnvAuth" default:"false"`                                                                                                                                   // Get AWS credentials from runtime (environment variables or EC2/ECS meta data if no env vars).
-	S3ForcePathStyle                    string `json:"s3ForcePathStyle" default:"true"`                                                                                                                             // If true use path style access if false use virtual hosted style.
-	S3LeavePartsOnError                 string `json:"s3LeavePartsOnError" default:"false"`                                                                                                                         // If true avoid calling abort upload on a failure, leaving all successfully uploaded parts on S3 for manual recovery.
-	S3ListChunk                         string `json:"s3ListChunk" default:"1000"`                                                                                                                                  // Size of listing chunk (response list for each ListObject S3 request).
-	S3ListUrlEncode                     string `json:"s3ListUrlEncode" default:"unset"`                                                                                                                             // Whether to url encode listings: true/false/unset
-	S3ListVersion                       string `json:"s3ListVersion" default:"0"`                                                                                                                                   // Version of ListObjects to use: 1,2 or 0 for auto.
-	S3LocationConstraint                string `json:"s3LocationConstraint"`                                                                                                                                        // Location constraint - must be set to match the Region.
-	S3MaxUploadParts                    string `json:"s3MaxUploadParts" default:"10000"`                                                                                                                            // Maximum number of parts in a multipart upload.
-	S3MemoryPoolFlushTime               string `json:"s3MemoryPoolFlushTime" default:"1m0s"`                                                                                                                        // How often internal memory buffer pools will be flushed.
-	S3MemoryPoolUseMmap                 string `json:"s3MemoryPoolUseMmap" default:"false"`                                                                                                                         // Whether to use mmap buffers in internal memory pool.
-	S3MightGzip                         string `json:"s3MightGzip" default:"unset"`                                                                                                                                 // Set this if the backend might gzip objects.
-	S3NoCheckBucket                     string `json:"s3NoCheckBucket" default:"false"`                                                                                                                             // If set, don't attempt to check the bucket exists or create it.
-	S3NoHead                            string `json:"s3NoHead" default:"false"`                                                                                                                                    // If set, don't HEAD uploaded objects to check integrity.
-	S3NoHeadObject                      string `json:"s3NoHeadObject" default:"false"`                                                                                                                              // If set, do not do HEAD before GET when getting objects.
-	S3NoSystemMetadata                  string `json:"s3NoSystemMetadata" default:"false"`                                                                                                                          // Suppress setting and reading of system metadata
-	S3Profile                           string `json:"s3Profile"`                                                                                                                                                   // Profile to use in the shared credentials file.
-	S3Provider                          string `json:"s3Provider"`                                                                                                                                                  // Choose your S3 provider.
-	S3Region                            string `json:"s3Region"`                                                                                                                                                    // Region to connect to.
-	S3RequesterPays                     string `json:"s3RequesterPays" default:"false"`                                                                                                                             // Enables requester pays option when interacting with S3 bucket.
-	S3SecretAccessKey                   string `json:"s3SecretAccessKey"`                                                                                                                                           // AWS Secret Access Key (password).
-	S3ServerSideEncryption              string `json:"s3ServerSideEncryption"`                                                                                                                                      // The server-side encryption algorithm used when storing this object in S3.
-	S3SessionToken                      string `json:"s3SessionToken"`                                                                                                                                              // An AWS session token.
-	S3SharedCredentialsFile             string `json:"s3SharedCredentialsFile"`                                                                                                                                     // Path to the shared credentials file.
-	S3SseCustomerAlgorithm              string `json:"s3SseCustomerAlgorithm"`                                                                                                                                      // If using SSE-C, the server-side encryption algorithm used when storing this object in S3.
-	S3SseCustomerKey                    string `json:"s3SseCustomerKey"`                                                                                                                                            // To use SSE-C you may provide the secret encryption key used to encrypt/decrypt your data.
-	S3SseCustomerKeyBase64              string `json:"s3SseCustomerKeyBase64"`                                                                                                                                      // If using SSE-C you must provide the secret encryption key encoded in base64 format to encrypt/decrypt your data.
-	S3SseCustomerKeyMd5                 string `json:"s3SseCustomerKeyMd5"`                                                                                                                                         // If using SSE-C you may provide the secret encryption key MD5 checksum (optional).
-	S3SseKmsKeyId                       string `json:"s3SseKmsKeyId"`                                                                                                                                               // If using KMS ID you must provide the ARN of Key.
-	S3StorageClass                      string `json:"s3StorageClass"`                                                                                                                                              // The storage class to use when storing new objects in S3.
-	S3StsEndpoint                       string `json:"s3StsEndpoint"`                                                                                                                                               // Endpoint for STS.
-	S3UploadConcurrency                 string `json:"s3UploadConcurrency" default:"4"`                                                                                                                             // Concurrency for multipart uploads.
-	S3UploadCutoff                      string `json:"s3UploadCutoff" default:"200Mi"`                                                                                                                              // Cutoff for switching to chunked upload.
-	S3UseAccelerateEndpoint             string `json:"s3UseAccelerateEndpoint" default:"false"`                                                                                                                     // If true use the AWS S3 accelerated endpoint.
-	S3UseMultipartEtag                  string `json:"s3UseMultipartEtag" default:"unset"`                                                                                                                          // Whether to use ETag in multipart uploads for verification
-	S3UsePresignedRequest               string `json:"s3UsePresignedRequest" default:"false"`                                                                                                                       // Whether to use a presigned request or PutObject for single part uploads
-	S3V2Auth                            string `json:"s3V2Auth" default:"false"`                                                                                                                                    // If true use v2 authentication.
-	S3VersionAt                         string `json:"s3VersionAt" default:"off"`                                                                                                                                   // Show file versions as they were at the specified time.
-	S3Versions                          string `json:"s3Versions" default:"false"`                                                                                                                                  // Include old versions in directory listings.
-	Seafile2fa                          string `json:"seafile2fa" default:"false"`                                                                                                                                  // Two-factor authentication ('true' if the account has 2FA enabled).
-	SeafileAuthToken                    string `json:"seafileAuthToken"`                                                                                                                                            // Authentication token.
-	SeafileCreateLibrary                string `json:"seafileCreateLibrary" default:"false"`                                                                                                                        // Should rclone create a library if it doesn't exist.
-	SeafileEncoding                     string `json:"seafileEncoding" default:"Slash,DoubleQuote,BackSlash,Ctl,InvalidUtf8"`                                                                                       // The encoding for the backend.
-	SeafileLibrary                      string `json:"seafileLibrary"`                                                                                                                                              // Name of the library.
-	SeafileLibraryKey                   string `json:"seafileLibraryKey"`                                                                                                                                           // Library password (for encrypted libraries only).
-	SeafilePass                         string `json:"seafilePass"`                                                                                                                                                 // Password.
-	SeafileUrl                          string `json:"seafileUrl"`                                                                                                                                                  // URL of seafile host to connect to.
-	SeafileUser                         string `json:"seafileUser"`                                                                                                                                                 // User name (usually email address).
-	SftpAskPassword                     string `json:"sftpAskPassword" default:"false"`                                                                                                                             // Allow asking for SFTP password when needed.
-	SftpChunkSize                       string `json:"sftpChunkSize" default:"32Ki"`                                                                                                                                // Upload and download chunk size.
-	SftpCiphers                         string `json:"sftpCiphers"`                                                                                                                                                 // Space separated list of ciphers to be used for session encryption, ordered by preference.
-	SftpConcurrency                     string `json:"sftpConcurrency" default:"64"`                                                                                                                                // The maximum number of outstanding requests for one file
-	SftpDisableConcurrentReads          string `json:"sftpDisableConcurrentReads" default:"false"`                                                                                                                  // If set don't use concurrent reads.
-	SftpDisableConcurrentWrites         string `json:"sftpDisableConcurrentWrites" default:"false"`                                                                                                                 // If set don't use concurrent writes.
-	SftpDisableHashcheck                string `json:"sftpDisableHashcheck" default:"false"`                                                                                                                        // Disable the execution of SSH commands to determine if remote file hashing is available.
-	SftpHost                            string `json:"sftpHost"`                                                                                                                                                    // SSH host to connect to.
-	SftpIdleTimeout                     string `json:"sftpIdleTimeout" default:"1m0s"`                                                                                                                              // Max time before closing idle connections.
-	SftpKeyExchange                     string `json:"sftpKeyExchange"`                                                                                                                                             // Space separated list of key exchange algorithms, ordered by preference.
-	SftpKeyFile                         string `json:"sftpKeyFile"`                                                                                                                                                 // Path to PEM-encoded private key file.
-	SftpKeyFilePass                     string `json:"sftpKeyFilePass"`                                                                                                                                             // The passphrase to decrypt the PEM-encoded private key file.
-	SftpKeyPem                          string `json:"sftpKeyPem"`                                                                                                                                                  // Raw PEM-encoded private key.
-	SftpKeyUseAgent                     string `json:"sftpKeyUseAgent" default:"false"`                                                                                                                             // When set forces the usage of the ssh-agent.
-	SftpKnownHostsFile                  string `json:"sftpKnownHostsFile"`                                                                                                                                          // Optional path to known_hosts file.
-	SftpMacs                            string `json:"sftpMacs"`                                                                                                                                                    // Space separated list of MACs (message authentication code) algorithms, ordered by preference.
-	SftpMd5sumCommand                   string `json:"sftpMd5sumCommand"`                                                                                                                                           // The command used to read md5 hashes.
-	SftpPass                            string `json:"sftpPass"`                                                                                                                                                    // SSH password, leave blank to use ssh-agent.
-	SftpPathOverride                    string `json:"sftpPathOverride"`                                                                                                                                            // Override path used by SSH shell commands.
-	SftpPort                            string `json:"sftpPort" default:"22"`                                                                                                                                       // SSH port number.
-	SftpPubkeyFile                      string `json:"sftpPubkeyFile"`                                                                                                                                              // Optional path to public key file.
-	SftpServerCommand                   string `json:"sftpServerCommand"`                                                                                                                                           // Specifies the path or command to run a sftp server on the remote host.
-	SftpSetEnv                          string `json:"sftpSetEnv"`                                                                                                                                                  // Environment variables to pass to sftp and commands
-	SftpSetModtime                      string `json:"sftpSetModtime" default:"true"`                                                                                                                               // Set the modified time on the remote if set.
-	SftpSha1sumCommand                  string `json:"sftpSha1sumCommand"`                                                                                                                                          // The command used to read sha1 hashes.
-	SftpShellType                       string `json:"sftpShellType"`                                                                                                                                               // The type of SSH shell on remote server, if any.
-	SftpSkipLinks                       string `json:"sftpSkipLinks" default:"false"`                                                                                                                               // Set to skip any symlinks and any other non regular files.
-	SftpSubsystem                       string `json:"sftpSubsystem" default:"sftp"`                                                                                                                                // Specifies the SSH2 subsystem on the remote host.
-	SftpUseFstat                        string `json:"sftpUseFstat" default:"false"`                                                                                                                                // If set use fstat instead of stat.
-	SftpUseInsecureCipher               string `json:"sftpUseInsecureCipher" default:"false"`                                                                                                                       // Enable the use of insecure ciphers and key exchange methods.
-	SftpUser                            string `json:"sftpUser" default:"$USER"`                                                                                                                                    // SSH username.
-	SharefileChunkSize                  string `json:"sharefileChunkSize" default:"64Mi"`                                                                                                                           // Upload chunk size.
-	SharefileEncoding                   string `json:"sharefileEncoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,Ctl,LeftSpace,LeftPeriod,RightSpace,RightPeriod,InvalidUtf8,Dot"`   // The encoding for the backend.
-	SharefileEndpoint                   string `json:"sharefileEndpoint"`                                                                                                                                           // Endpoint for API calls.
-	SharefileRootFolderId               string `json:"sharefileRootFolderId"`                                                                                                                                       // ID of the root folder.
-	SharefileUploadCutoff               string `json:"sharefileUploadCutoff" default:"128Mi"`                                                                                                                       // Cutoff for switching to multipart upload.
-	SiaApiPassword                      string `json:"siaApiPassword"`                                                                                                                                              // Sia Daemon API Password.
-	SiaApiUrl                           string `json:"siaApiUrl" default:"http://127.0.0.1:9980"`                                                                                                                   // Sia daemon API URL, like http://sia.daemon.host:9980.
-	SiaEncoding                         string `json:"siaEncoding" default:"Slash,Question,Hash,Percent,Del,Ctl,InvalidUtf8,Dot"`                                                                                   // The encoding for the backend.
-	SiaUserAgent                        string `json:"siaUserAgent" default:"Sia-Agent"`                                                                                                                            // Siad User Agent
-	SmbCaseInsensitive                  string `json:"smbCaseInsensitive" default:"true"`                                                                                                                           // Whether the server is configured to be case-insensitive.
-	SmbDomain                           string `json:"smbDomain" default:"WORKGROUP"`                                                                                                                               // Domain name for NTLM authentication.
-	SmbEncoding                         string `json:"smbEncoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,Ctl,RightSpace,RightPeriod,InvalidUtf8,Dot"`                              // The encoding for the backend.
-	SmbHideSpecialShare                 string `json:"smbHideSpecialShare" default:"true"`                                                                                                                          // Hide special shares (e.g. print$) which users aren't supposed to access.
-	SmbHost                             string `json:"smbHost"`                                                                                                                                                     // SMB server hostname to connect to.
-	SmbIdleTimeout                      string `json:"smbIdleTimeout" default:"1m0s"`                                                                                                                               // Max time before closing idle connections.
-	SmbPass                             string `json:"smbPass"`                                                                                                                                                     // SMB password.
-	SmbPort                             string `json:"smbPort" default:"445"`                                                                                                                                       // SMB port number.
-	SmbSpn                              string `json:"smbSpn"`                                                                                                                                                      // Service principal name.
-	SmbUser                             string `json:"smbUser" default:"$USER"`                                                                                                                                     // SMB username.
-	StorjAccessGrant                    string `json:"storjAccessGrant"`                                                                                                                                            // Access grant.
-	StorjApiKey                         string `json:"storjApiKey"`                                                                                                                                                 // API key.
-	StorjPassphrase                     string `json:"storjPassphrase"`                                                                                                                                             // Encryption passphrase.
-	StorjProvider                       string `json:"storjProvider" default:"existing"`                                                                                                                            // Choose an authentication method.
-	StorjSatelliteAddress               string `json:"storjSatelliteAddress" default:"us1.storj.io"`                                                                                                                // Satellite address.
-	SugarsyncAccessKeyId                string `json:"sugarsyncAccessKeyId"`                                                                                                                                        // Sugarsync Access Key ID.
-	SugarsyncAppId                      string `json:"sugarsyncAppId"`                                                                                                                                              // Sugarsync App ID.
-	SugarsyncAuthorization              string `json:"sugarsyncAuthorization"`                                                                                                                                      // Sugarsync authorization.
-	SugarsyncAuthorizationExpiry        string `json:"sugarsyncAuthorizationExpiry"`                                                                                                                                // Sugarsync authorization expiry.
-	SugarsyncDeletedId                  string `json:"sugarsyncDeletedId"`                                                                                                                                          // Sugarsync deleted folder id.
-	SugarsyncEncoding                   string `json:"sugarsyncEncoding" default:"Slash,Ctl,InvalidUtf8,Dot"`                                                                                                       // The encoding for the backend.
-	SugarsyncHardDelete                 string `json:"sugarsyncHardDelete" default:"false"`                                                                                                                         // Permanently delete files if true
-	SugarsyncPrivateAccessKey           string `json:"sugarsyncPrivateAccessKey"`                                                                                                                                   // Sugarsync Private Access Key.
-	SugarsyncRefreshToken               string `json:"sugarsyncRefreshToken"`                                                                                                                                       // Sugarsync refresh token.
-	SugarsyncRootId                     string `json:"sugarsyncRootId"`                                                                                                                                             // Sugarsync root id.
-	SugarsyncUser                       string `json:"sugarsyncUser"`                                                                                                                                               // Sugarsync user.
-	SwiftApplicationCredentialId        string `json:"swiftApplicationCredentialId"`                                                                                                                                // Application Credential ID (OS_APPLICATION_CREDENTIAL_ID).
-	SwiftApplicationCredentialName      string `json:"swiftApplicationCredentialName"`                                                                                                                              // Application Credential Name (OS_APPLICATION_CREDENTIAL_NAME).
-	SwiftApplicationCredentialSecret    string `json:"swiftApplicationCredentialSecret"`                                                                                                                            // Application Credential Secret (OS_APPLICATION_CREDENTIAL_SECRET).
-	SwiftAuth                           string `json:"swiftAuth"`                                                                                                                                                   // Authentication URL for server (OS_AUTH_URL).
-	SwiftAuthToken                      string `json:"swiftAuthToken"`                                                                                                                                              // Auth Token from alternate authentication - optional (OS_AUTH_TOKEN).
-	SwiftAuthVersion                    string `json:"swiftAuthVersion" default:"0"`                                                                                                                                // AuthVersion - optional - set to (1,2,3) if your auth URL has no version (ST_AUTH_VERSION).
-	SwiftChunkSize                      string `json:"swiftChunkSize" default:"5Gi"`                                                                                                                                // Above this size files will be chunked into a _segments container.
-	SwiftDomain                         string `json:"swiftDomain"`                                                                                                                                                 // User domain - optional (v3 auth) (OS_USER_DOMAIN_NAME)
-	SwiftEncoding                       string `json:"swiftEncoding" default:"Slash,InvalidUtf8"`                                                                                                                   // The encoding for the backend.
-	SwiftEndpointType                   string `json:"swiftEndpointType" default:"public"`                                                                                                                          // Endpoint type to choose from the service catalogue (OS_ENDPOINT_TYPE).
-	SwiftEnvAuth                        string `json:"swiftEnvAuth" default:"false"`                                                                                                                                // Get swift credentials from environment variables in standard OpenStack form.
-	SwiftKey                            string `json:"swiftKey"`                                                                                                                                                    // API key or password (OS_PASSWORD).
-	SwiftLeavePartsOnError              string `json:"swiftLeavePartsOnError" default:"false"`                                                                                                                      // If true avoid calling abort upload on a failure.
-	SwiftNoChunk                        string `json:"swiftNoChunk" default:"false"`                                                                                                                                // Don't chunk files during streaming upload.
-	SwiftNoLargeObjects                 string `json:"swiftNoLargeObjects" default:"false"`                                                                                                                         // Disable support for static and dynamic large objects
-	SwiftRegion                         string `json:"swiftRegion"`                                                                                                                                                 // Region name - optional (OS_REGION_NAME).
-	SwiftStoragePolicy                  string `json:"swiftStoragePolicy"`                                                                                                                                          // The storage policy to use when creating a new container.
-	SwiftStorageUrl                     string `json:"swiftStorageUrl"`                                                                                                                                             // Storage URL - optional (OS_STORAGE_URL).
-	SwiftTenant                         string `json:"swiftTenant"`                                                                                                                                                 // Tenant name - optional for v1 auth, this or tenant_id required otherwise (OS_TENANT_NAME or OS_PROJECT_NAME).
-	SwiftTenantDomain                   string `json:"swiftTenantDomain"`                                                                                                                                           // Tenant domain - optional (v3 auth) (OS_PROJECT_DOMAIN_NAME).
-	SwiftTenantId                       string `json:"swiftTenantId"`                                                                                                                                               // Tenant ID - optional for v1 auth, this or tenant required otherwise (OS_TENANT_ID).
-	SwiftUser                           string `json:"swiftUser"`                                                                                                                                                   // User name to log in (OS_USERNAME).
-	SwiftUserId                         string `json:"swiftUserId"`                                                                                                                                                 // User ID to log in - optional - most swift systems use user and leave this blank (v3 auth) (OS_USER_ID).
-	UptoboxAccessToken                  string `json:"uptoboxAccessToken"`                                                                                                                                          // Your access token.
-	UptoboxEncoding                     string `json:"uptoboxEncoding" default:"Slash,LtGt,DoubleQuote,BackQuote,Del,Ctl,LeftSpace,InvalidUtf8,Dot"`                                                                // The encoding for the backend.
-	WebdavBearerToken                   string `json:"webdavBearerToken"`                                                                                                                                           // Bearer token instead of user/pass (e.g. a Macaroon).
-	WebdavBearerTokenCommand            string `json:"webdavBearerTokenCommand"`                                                                                                                                    // Command to run to get a bearer token.
-	WebdavEncoding                      string `json:"webdavEncoding"`                                                                                                                                              // The encoding for the backend.
-	WebdavHeaders                       string `json:"webdavHeaders"`                                                                                                                                               // Set HTTP headers for all transactions.
-	WebdavPass                          string `json:"webdavPass"`                                                                                                                                                  // Password.
-	WebdavUrl                           string `json:"webdavUrl"`                                                                                                                                                   // URL of http host to connect to.
-	WebdavUser                          string `json:"webdavUser"`                                                                                                                                                  // User name.
-	WebdavVendor                        string `json:"webdavVendor"`                                                                                                                                                // Name of the WebDAV site/service/software you are using.
-	YandexAuthUrl                       string `json:"yandexAuthUrl"`                                                                                                                                               // Auth server URL.
-	YandexClientId                      string `json:"yandexClientId"`                                                                                                                                              // OAuth Client Id.
-	YandexClientSecret                  string `json:"yandexClientSecret"`                                                                                                                                          // OAuth Client Secret.
-	YandexEncoding                      string `json:"yandexEncoding" default:"Slash,Del,Ctl,InvalidUtf8,Dot"`                                                                                                      // The encoding for the backend.
-	YandexHardDelete                    string `json:"yandexHardDelete" default:"false"`                                                                                                                            // Delete files permanently rather than putting them into the trash.
-	YandexToken                         string `json:"yandexToken"`                                                                                                                                                 // OAuth Access Token as a JSON blob.
-	YandexTokenUrl                      string `json:"yandexTokenUrl"`                                                                                                                                              // Token server url.
-	ZohoAuthUrl                         string `json:"zohoAuthUrl"`                                                                                                                                                 // Auth server URL.
-	ZohoClientId                        string `json:"zohoClientId"`                                                                                                                                                // OAuth Client Id.
-	ZohoClientSecret                    string `json:"zohoClientSecret"`                                                                                                                                            // OAuth Client Secret.
-	ZohoEncoding                        string `json:"zohoEncoding" default:"Del,Ctl,InvalidUtf8"`                                                                                                                  // The encoding for the backend.
-	ZohoRegion                          string `json:"zohoRegion"`                                                                                                                                                  // Zoho region to connect to.
-	ZohoToken                           string `json:"zohoToken"`                                                                                                                                                   // OAuth Access Token as a JSON blob.
-	ZohoTokenUrl                        string `json:"zohoTokenUrl"`                                                                                                                                                // Token server url.
+	SourcePath                          string          `validate:"required" json:"sourcePath"`                                                                                                                              // The path of the source to scan items
+	DeleteAfterExport                   bool            `validate:"optional" json:"deleteAfterExport"`                                                                                                                       // Delete the source after exporting to CAR files
+	RescanInterval                      string          `validate:"optional" json:"rescanInterval"`                                                                                                                          // Automatically rescan the source directory when this interval has passed from last successful scan
+	ScanningState                       model.WorkState `validate:"optional" json:"scanningState"`                                                                                                                           // Starting state for scanning
+	AcdAuthUrl                          string          `json:"acdAuthUrl"`                                                                                                                                                  // Auth server URL.
+	AcdCheckpoint                       string          `json:"acdCheckpoint"`                                                                                                                                               // Checkpoint for internal polling (debug).
+	AcdClientId                         string          `json:"acdClientId"`                                                                                                                                                 // OAuth Client Id.
+	AcdClientSecret                     string          `json:"acdClientSecret"`                                                                                                                                             // OAuth Client Secret.
+	AcdEncoding                         string          `json:"acdEncoding" default:"Slash,InvalidUtf8,Dot"`                                                                                                                 // The encoding for the backend.
+	AcdTemplinkThreshold                string          `json:"acdTemplinkThreshold" default:"9Gi"`                                                                                                                          // Files >= this size will be downloaded via their tempLink.
+	AcdToken                            string          `json:"acdToken"`                                                                                                                                                    // OAuth Access Token as a JSON blob.
+	AcdTokenUrl                         string          `json:"acdTokenUrl"`                                                                                                                                                 // Token server url.
+	AcdUploadWaitPerGb                  string          `json:"acdUploadWaitPerGb" default:"3m0s"`                                                                                                                           // Additional time per GiB to wait after a failed complete upload to see if it appears.
+	AzureblobAccessTier                 string          `json:"azureblobAccessTier"`                                                                                                                                         // Access tier of blob: hot, cool or archive.
+	AzureblobAccount                    string          `json:"azureblobAccount"`                                                                                                                                            // Azure Storage Account Name.
+	AzureblobArchiveTierDelete          string          `json:"azureblobArchiveTierDelete" default:"false"`                                                                                                                  // Delete archive tier blobs before overwriting.
+	AzureblobChunkSize                  string          `json:"azureblobChunkSize" default:"4Mi"`                                                                                                                            // Upload chunk size.
+	AzureblobClientCertificatePassword  string          `json:"azureblobClientCertificatePassword"`                                                                                                                          // Password for the certificate file (optional).
+	AzureblobClientCertificatePath      string          `json:"azureblobClientCertificatePath"`                                                                                                                              // Path to a PEM or PKCS12 certificate file including the private key.
+	AzureblobClientId                   string          `json:"azureblobClientId"`                                                                                                                                           // The ID of the client in use.
+	AzureblobClientSecret               string          `json:"azureblobClientSecret"`                                                                                                                                       // One of the service principal's client secrets
+	AzureblobClientSendCertificateChain string          `json:"azureblobClientSendCertificateChain" default:"false"`                                                                                                         // Send the certificate chain when using certificate auth.
+	AzureblobDisableChecksum            string          `json:"azureblobDisableChecksum" default:"false"`                                                                                                                    // Don't store MD5 checksum with object metadata.
+	AzureblobEncoding                   string          `json:"azureblobEncoding" default:"Slash,BackSlash,Del,Ctl,RightPeriod,InvalidUtf8"`                                                                                 // The encoding for the backend.
+	AzureblobEndpoint                   string          `json:"azureblobEndpoint"`                                                                                                                                           // Endpoint for the service.
+	AzureblobEnvAuth                    string          `json:"azureblobEnvAuth" default:"false"`                                                                                                                            // Read credentials from runtime (environment variables, CLI or MSI).
+	AzureblobKey                        string          `json:"azureblobKey"`                                                                                                                                                // Storage Account Shared Key.
+	AzureblobListChunk                  string          `json:"azureblobListChunk" default:"5000"`                                                                                                                           // Size of blob list.
+	AzureblobMemoryPoolFlushTime        string          `json:"azureblobMemoryPoolFlushTime" default:"1m0s"`                                                                                                                 // How often internal memory buffer pools will be flushed.
+	AzureblobMemoryPoolUseMmap          string          `json:"azureblobMemoryPoolUseMmap" default:"false"`                                                                                                                  // Whether to use mmap buffers in internal memory pool.
+	AzureblobMsiClientId                string          `json:"azureblobMsiClientId"`                                                                                                                                        // Object ID of the user-assigned MSI to use, if any.
+	AzureblobMsiMiResId                 string          `json:"azureblobMsiMiResId"`                                                                                                                                         // Azure resource ID of the user-assigned MSI to use, if any.
+	AzureblobMsiObjectId                string          `json:"azureblobMsiObjectId"`                                                                                                                                        // Object ID of the user-assigned MSI to use, if any.
+	AzureblobNoCheckContainer           string          `json:"azureblobNoCheckContainer" default:"false"`                                                                                                                   // If set, don't attempt to check the container exists or create it.
+	AzureblobNoHeadObject               string          `json:"azureblobNoHeadObject" default:"false"`                                                                                                                       // If set, do not do HEAD before GET when getting objects.
+	AzureblobPassword                   string          `json:"azureblobPassword"`                                                                                                                                           // The user's password
+	AzureblobPublicAccess               string          `json:"azureblobPublicAccess"`                                                                                                                                       // Public access level of a container: blob or container.
+	AzureblobSasUrl                     string          `json:"azureblobSasUrl"`                                                                                                                                             // SAS URL for container level access only.
+	AzureblobServicePrincipalFile       string          `json:"azureblobServicePrincipalFile"`                                                                                                                               // Path to file containing credentials for use with a service principal.
+	AzureblobTenant                     string          `json:"azureblobTenant"`                                                                                                                                             // ID of the service principal's tenant. Also called its directory ID.
+	AzureblobUploadConcurrency          string          `json:"azureblobUploadConcurrency" default:"16"`                                                                                                                     // Concurrency for multipart uploads.
+	AzureblobUploadCutoff               string          `json:"azureblobUploadCutoff"`                                                                                                                                       // Cutoff for switching to chunked upload (<= 256 MiB) (deprecated).
+	AzureblobUseEmulator                string          `json:"azureblobUseEmulator" default:"false"`                                                                                                                        // Uses local storage emulator if provided as 'true'.
+	AzureblobUseMsi                     string          `json:"azureblobUseMsi" default:"false"`                                                                                                                             // Use a managed service identity to authenticate (only works in Azure).
+	AzureblobUsername                   string          `json:"azureblobUsername"`                                                                                                                                           // User name (usually an email address)
+	B2Account                           string          `json:"b2Account"`                                                                                                                                                   // Account ID or Application Key ID.
+	B2ChunkSize                         string          `json:"b2ChunkSize" default:"96Mi"`                                                                                                                                  // Upload chunk size.
+	B2CopyCutoff                        string          `json:"b2CopyCutoff" default:"4Gi"`                                                                                                                                  // Cutoff for switching to multipart copy.
+	B2DisableChecksum                   string          `json:"b2DisableChecksum" default:"false"`                                                                                                                           // Disable checksums for large (> upload cutoff) files.
+	B2DownloadAuthDuration              string          `json:"b2DownloadAuthDuration" default:"1w"`                                                                                                                         // Time before the authorization token will expire in s or suffix ms|s|m|h|d.
+	B2DownloadUrl                       string          `json:"b2DownloadUrl"`                                                                                                                                               // Custom endpoint for downloads.
+	B2Encoding                          string          `json:"b2Encoding" default:"Slash,BackSlash,Del,Ctl,InvalidUtf8,Dot"`                                                                                                // The encoding for the backend.
+	B2Endpoint                          string          `json:"b2Endpoint"`                                                                                                                                                  // Endpoint for the service.
+	B2HardDelete                        string          `json:"b2HardDelete" default:"false"`                                                                                                                                // Permanently delete files on remote removal, otherwise hide files.
+	B2Key                               string          `json:"b2Key"`                                                                                                                                                       // Application Key.
+	B2MemoryPoolFlushTime               string          `json:"b2MemoryPoolFlushTime" default:"1m0s"`                                                                                                                        // How often internal memory buffer pools will be flushed.
+	B2MemoryPoolUseMmap                 string          `json:"b2MemoryPoolUseMmap" default:"false"`                                                                                                                         // Whether to use mmap buffers in internal memory pool.
+	B2TestMode                          string          `json:"b2TestMode"`                                                                                                                                                  // A flag string for X-Bz-Test-Mode header for debugging.
+	B2UploadCutoff                      string          `json:"b2UploadCutoff" default:"200Mi"`                                                                                                                              // Cutoff for switching to chunked upload.
+	B2VersionAt                         string          `json:"b2VersionAt" default:"off"`                                                                                                                                   // Show file versions as they were at the specified time.
+	B2Versions                          string          `json:"b2Versions" default:"false"`                                                                                                                                  // Include old versions in directory listings.
+	BoxAccessToken                      string          `json:"boxAccessToken"`                                                                                                                                              // Box App Primary Access Token
+	BoxAuthUrl                          string          `json:"boxAuthUrl"`                                                                                                                                                  // Auth server URL.
+	BoxBoxConfigFile                    string          `json:"boxBoxConfigFile"`                                                                                                                                            // Box App config.json location
+	BoxBoxSubType                       string          `json:"boxBoxSubType" default:"user"`                                                                                                                                //
+	BoxClientId                         string          `json:"boxClientId"`                                                                                                                                                 // OAuth Client Id.
+	BoxClientSecret                     string          `json:"boxClientSecret"`                                                                                                                                             // OAuth Client Secret.
+	BoxCommitRetries                    string          `json:"boxCommitRetries" default:"100"`                                                                                                                              // Max number of times to try committing a multipart file.
+	BoxEncoding                         string          `json:"boxEncoding" default:"Slash,BackSlash,Del,Ctl,RightSpace,InvalidUtf8,Dot"`                                                                                    // The encoding for the backend.
+	BoxListChunk                        string          `json:"boxListChunk" default:"1000"`                                                                                                                                 // Size of listing chunk 1-1000.
+	BoxOwnedBy                          string          `json:"boxOwnedBy"`                                                                                                                                                  // Only show items owned by the login (email address) passed in.
+	BoxRootFolderId                     string          `json:"boxRootFolderId" default:"0"`                                                                                                                                 // Fill in for rclone to use a non root folder as its starting point.
+	BoxToken                            string          `json:"boxToken"`                                                                                                                                                    // OAuth Access Token as a JSON blob.
+	BoxTokenUrl                         string          `json:"boxTokenUrl"`                                                                                                                                                 // Token server url.
+	BoxUploadCutoff                     string          `json:"boxUploadCutoff" default:"50Mi"`                                                                                                                              // Cutoff for switching to multipart upload (>= 50 MiB).
+	DriveAcknowledgeAbuse               string          `json:"driveAcknowledgeAbuse" default:"false"`                                                                                                                       // Set to allow files which return cannotDownloadAbusiveFile to be downloaded.
+	DriveAllowImportNameChange          string          `json:"driveAllowImportNameChange" default:"false"`                                                                                                                  // Allow the filetype to change when uploading Google docs.
+	DriveAlternateExport                string          `json:"driveAlternateExport" default:"false"`                                                                                                                        // Deprecated: No longer needed.
+	DriveAuthOwnerOnly                  string          `json:"driveAuthOwnerOnly" default:"false"`                                                                                                                          // Only consider files owned by the authenticated user.
+	DriveAuthUrl                        string          `json:"driveAuthUrl"`                                                                                                                                                // Auth server URL.
+	DriveChunkSize                      string          `json:"driveChunkSize" default:"8Mi"`                                                                                                                                // Upload chunk size.
+	DriveClientId                       string          `json:"driveClientId"`                                                                                                                                               // Google Application Client Id
+	DriveClientSecret                   string          `json:"driveClientSecret"`                                                                                                                                           // OAuth Client Secret.
+	DriveCopyShortcutContent            string          `json:"driveCopyShortcutContent" default:"false"`                                                                                                                    // Server side copy contents of shortcuts instead of the shortcut.
+	DriveDisableHttp2                   string          `json:"driveDisableHttp2" default:"true"`                                                                                                                            // Disable drive using http2.
+	DriveEncoding                       string          `json:"driveEncoding" default:"InvalidUtf8"`                                                                                                                         // The encoding for the backend.
+	DriveExportFormats                  string          `json:"driveExportFormats" default:"docx,xlsx,pptx,svg"`                                                                                                             // Comma separated list of preferred formats for downloading Google docs.
+	DriveFormats                        string          `json:"driveFormats"`                                                                                                                                                // Deprecated: See export_formats.
+	DriveImpersonate                    string          `json:"driveImpersonate"`                                                                                                                                            // Impersonate this user when using a service account.
+	DriveImportFormats                  string          `json:"driveImportFormats"`                                                                                                                                          // Comma separated list of preferred formats for uploading Google docs.
+	DriveKeepRevisionForever            string          `json:"driveKeepRevisionForever" default:"false"`                                                                                                                    // Keep new head revision of each file forever.
+	DriveListChunk                      string          `json:"driveListChunk" default:"1000"`                                                                                                                               // Size of listing chunk 100-1000, 0 to disable.
+	DrivePacerBurst                     string          `json:"drivePacerBurst" default:"100"`                                                                                                                               // Number of API calls to allow without sleeping.
+	DrivePacerMinSleep                  string          `json:"drivePacerMinSleep" default:"100ms"`                                                                                                                          // Minimum time to sleep between API calls.
+	DriveResourceKey                    string          `json:"driveResourceKey"`                                                                                                                                            // Resource key for accessing a link-shared file.
+	DriveRootFolderId                   string          `json:"driveRootFolderId"`                                                                                                                                           // ID of the root folder.
+	DriveScope                          string          `json:"driveScope"`                                                                                                                                                  // Scope that rclone should use when requesting access from drive.
+	DriveServerSideAcrossConfigs        string          `json:"driveServerSideAcrossConfigs" default:"false"`                                                                                                                // Allow server-side operations (e.g. copy) to work across different drive configs.
+	DriveServiceAccountCredentials      string          `json:"driveServiceAccountCredentials"`                                                                                                                              // Service Account Credentials JSON blob.
+	DriveServiceAccountFile             string          `json:"driveServiceAccountFile"`                                                                                                                                     // Service Account Credentials JSON file path.
+	DriveSharedWithMe                   string          `json:"driveSharedWithMe" default:"false"`                                                                                                                           // Only show files that are shared with me.
+	DriveSizeAsQuota                    string          `json:"driveSizeAsQuota" default:"false"`                                                                                                                            // Show sizes as storage quota usage, not actual size.
+	DriveSkipChecksumGphotos            string          `json:"driveSkipChecksumGphotos" default:"false"`                                                                                                                    // Skip MD5 checksum on Google photos and videos only.
+	DriveSkipDanglingShortcuts          string          `json:"driveSkipDanglingShortcuts" default:"false"`                                                                                                                  // If set skip dangling shortcut files.
+	DriveSkipGdocs                      string          `json:"driveSkipGdocs" default:"false"`                                                                                                                              // Skip google documents in all listings.
+	DriveSkipShortcuts                  string          `json:"driveSkipShortcuts" default:"false"`                                                                                                                          // If set skip shortcut files.
+	DriveStarredOnly                    string          `json:"driveStarredOnly" default:"false"`                                                                                                                            // Only show files that are starred.
+	DriveStopOnDownloadLimit            string          `json:"driveStopOnDownloadLimit" default:"false"`                                                                                                                    // Make download limit errors be fatal.
+	DriveStopOnUploadLimit              string          `json:"driveStopOnUploadLimit" default:"false"`                                                                                                                      // Make upload limit errors be fatal.
+	DriveTeamDrive                      string          `json:"driveTeamDrive"`                                                                                                                                              // ID of the Shared Drive (Team Drive).
+	DriveToken                          string          `json:"driveToken"`                                                                                                                                                  // OAuth Access Token as a JSON blob.
+	DriveTokenUrl                       string          `json:"driveTokenUrl"`                                                                                                                                               // Token server url.
+	DriveTrashedOnly                    string          `json:"driveTrashedOnly" default:"false"`                                                                                                                            // Only show files that are in the trash.
+	DriveUploadCutoff                   string          `json:"driveUploadCutoff" default:"8Mi"`                                                                                                                             // Cutoff for switching to chunked upload.
+	DriveUseCreatedDate                 string          `json:"driveUseCreatedDate" default:"false"`                                                                                                                         // Use file created date instead of modified date.
+	DriveUseSharedDate                  string          `json:"driveUseSharedDate" default:"false"`                                                                                                                          // Use date file was shared instead of modified date.
+	DriveUseTrash                       string          `json:"driveUseTrash" default:"true"`                                                                                                                                // Send files to the trash instead of deleting permanently.
+	DriveV2DownloadMinSize              string          `json:"driveV2DownloadMinSize" default:"off"`                                                                                                                        // If Object's are greater, use drive v2 API to download.
+	DropboxAuthUrl                      string          `json:"dropboxAuthUrl"`                                                                                                                                              // Auth server URL.
+	DropboxBatchCommitTimeout           string          `json:"dropboxBatchCommitTimeout" default:"10m0s"`                                                                                                                   // Max time to wait for a batch to finish committing
+	DropboxBatchMode                    string          `json:"dropboxBatchMode" default:"sync"`                                                                                                                             // Upload file batching sync|async|off.
+	DropboxBatchSize                    string          `json:"dropboxBatchSize" default:"0"`                                                                                                                                // Max number of files in upload batch.
+	DropboxBatchTimeout                 string          `json:"dropboxBatchTimeout" default:"0s"`                                                                                                                            // Max time to allow an idle upload batch before uploading.
+	DropboxChunkSize                    string          `json:"dropboxChunkSize" default:"48Mi"`                                                                                                                             // Upload chunk size (< 150Mi).
+	DropboxClientId                     string          `json:"dropboxClientId"`                                                                                                                                             // OAuth Client Id.
+	DropboxClientSecret                 string          `json:"dropboxClientSecret"`                                                                                                                                         // OAuth Client Secret.
+	DropboxEncoding                     string          `json:"dropboxEncoding" default:"Slash,BackSlash,Del,RightSpace,InvalidUtf8,Dot"`                                                                                    // The encoding for the backend.
+	DropboxImpersonate                  string          `json:"dropboxImpersonate"`                                                                                                                                          // Impersonate this user when using a business account.
+	DropboxSharedFiles                  string          `json:"dropboxSharedFiles" default:"false"`                                                                                                                          // Instructs rclone to work on individual shared files.
+	DropboxSharedFolders                string          `json:"dropboxSharedFolders" default:"false"`                                                                                                                        // Instructs rclone to work on shared folders.
+	DropboxToken                        string          `json:"dropboxToken"`                                                                                                                                                // OAuth Access Token as a JSON blob.
+	DropboxTokenUrl                     string          `json:"dropboxTokenUrl"`                                                                                                                                             // Token server url.
+	FichierApiKey                       string          `json:"fichierApiKey"`                                                                                                                                               // Your API Key, get it from https://1fichier.com/console/params.pl.
+	FichierEncoding                     string          `json:"fichierEncoding" default:"Slash,LtGt,DoubleQuote,SingleQuote,BackQuote,Dollar,BackSlash,Del,Ctl,LeftSpace,RightSpace,InvalidUtf8,Dot"`                        // The encoding for the backend.
+	FichierFilePassword                 string          `json:"fichierFilePassword"`                                                                                                                                         // If you want to download a shared file that is password protected, add this parameter.
+	FichierFolderPassword               string          `json:"fichierFolderPassword"`                                                                                                                                       // If you want to list the files in a shared folder that is password protected, add this parameter.
+	FichierSharedFolder                 string          `json:"fichierSharedFolder"`                                                                                                                                         // If you want to download a shared folder, add this parameter.
+	FilefabricEncoding                  string          `json:"filefabricEncoding" default:"Slash,Del,Ctl,InvalidUtf8,Dot"`                                                                                                  // The encoding for the backend.
+	FilefabricPermanentToken            string          `json:"filefabricPermanentToken"`                                                                                                                                    // Permanent Authentication Token.
+	FilefabricRootFolderId              string          `json:"filefabricRootFolderId"`                                                                                                                                      // ID of the root folder.
+	FilefabricToken                     string          `json:"filefabricToken"`                                                                                                                                             // Session Token.
+	FilefabricTokenExpiry               string          `json:"filefabricTokenExpiry"`                                                                                                                                       // Token expiry time.
+	FilefabricUrl                       string          `json:"filefabricUrl"`                                                                                                                                               // URL of the Enterprise File Fabric to connect to.
+	FilefabricVersion                   string          `json:"filefabricVersion"`                                                                                                                                           // Version read from the file fabric.
+	FtpAskPassword                      string          `json:"ftpAskPassword" default:"false"`                                                                                                                              // Allow asking for FTP password when needed.
+	FtpCloseTimeout                     string          `json:"ftpCloseTimeout" default:"1m0s"`                                                                                                                              // Maximum time to wait for a response to close.
+	FtpConcurrency                      string          `json:"ftpConcurrency" default:"0"`                                                                                                                                  // Maximum number of FTP simultaneous connections, 0 for unlimited.
+	FtpDisableEpsv                      string          `json:"ftpDisableEpsv" default:"false"`                                                                                                                              // Disable using EPSV even if server advertises support.
+	FtpDisableMlsd                      string          `json:"ftpDisableMlsd" default:"false"`                                                                                                                              // Disable using MLSD even if server advertises support.
+	FtpDisableTls13                     string          `json:"ftpDisableTls13" default:"false"`                                                                                                                             // Disable TLS 1.3 (workaround for FTP servers with buggy TLS)
+	FtpDisableUtf8                      string          `json:"ftpDisableUtf8" default:"false"`                                                                                                                              // Disable using UTF-8 even if server advertises support.
+	FtpEncoding                         string          `json:"ftpEncoding" default:"Slash,Del,Ctl,RightSpace,Dot"`                                                                                                          // The encoding for the backend.
+	FtpExplicitTls                      string          `json:"ftpExplicitTls" default:"false"`                                                                                                                              // Use Explicit FTPS (FTP over TLS).
+	FtpForceListHidden                  string          `json:"ftpForceListHidden" default:"false"`                                                                                                                          // Use LIST -a to force listing of hidden files and folders. This will disable the use of MLSD.
+	FtpHost                             string          `json:"ftpHost"`                                                                                                                                                     // FTP host to connect to.
+	FtpIdleTimeout                      string          `json:"ftpIdleTimeout" default:"1m0s"`                                                                                                                               // Max time before closing idle connections.
+	FtpNoCheckCertificate               string          `json:"ftpNoCheckCertificate" default:"false"`                                                                                                                       // Do not verify the TLS certificate of the server.
+	FtpPass                             string          `json:"ftpPass"`                                                                                                                                                     // FTP password.
+	FtpPort                             string          `json:"ftpPort" default:"21"`                                                                                                                                        // FTP port number.
+	FtpShutTimeout                      string          `json:"ftpShutTimeout" default:"1m0s"`                                                                                                                               // Maximum time to wait for data connection closing status.
+	FtpTls                              string          `json:"ftpTls" default:"false"`                                                                                                                                      // Use Implicit FTPS (FTP over TLS).
+	FtpTlsCacheSize                     string          `json:"ftpTlsCacheSize" default:"32"`                                                                                                                                // Size of TLS session cache for all control and data connections.
+	FtpUser                             string          `json:"ftpUser" default:"$USER"`                                                                                                                                     // FTP username.
+	FtpWritingMdtm                      string          `json:"ftpWritingMdtm" default:"false"`                                                                                                                              // Use MDTM to set modification time (VsFtpd quirk)
+	GcsAnonymous                        string          `json:"gcsAnonymous" default:"false"`                                                                                                                                // Access public buckets and objects without credentials.
+	GcsAuthUrl                          string          `json:"gcsAuthUrl"`                                                                                                                                                  // Auth server URL.
+	GcsBucketAcl                        string          `json:"gcsBucketAcl"`                                                                                                                                                // Access Control List for new buckets.
+	GcsBucketPolicyOnly                 string          `json:"gcsBucketPolicyOnly" default:"false"`                                                                                                                         // Access checks should use bucket-level IAM policies.
+	GcsClientId                         string          `json:"gcsClientId"`                                                                                                                                                 // OAuth Client Id.
+	GcsClientSecret                     string          `json:"gcsClientSecret"`                                                                                                                                             // OAuth Client Secret.
+	GcsDecompress                       string          `json:"gcsDecompress" default:"false"`                                                                                                                               // If set this will decompress gzip encoded objects.
+	GcsEncoding                         string          `json:"gcsEncoding" default:"Slash,CrLf,InvalidUtf8,Dot"`                                                                                                            // The encoding for the backend.
+	GcsEndpoint                         string          `json:"gcsEndpoint"`                                                                                                                                                 // Endpoint for the service.
+	GcsEnvAuth                          string          `json:"gcsEnvAuth" default:"false"`                                                                                                                                  // Get GCP IAM credentials from runtime (environment variables or instance meta data if no env vars).
+	GcsLocation                         string          `json:"gcsLocation"`                                                                                                                                                 // Location for the newly created buckets.
+	GcsNoCheckBucket                    string          `json:"gcsNoCheckBucket" default:"false"`                                                                                                                            // If set, don't attempt to check the bucket exists or create it.
+	GcsObjectAcl                        string          `json:"gcsObjectAcl"`                                                                                                                                                // Access Control List for new objects.
+	GcsProjectNumber                    string          `json:"gcsProjectNumber"`                                                                                                                                            // Project number.
+	GcsServiceAccountCredentials        string          `json:"gcsServiceAccountCredentials"`                                                                                                                                // Service Account Credentials JSON blob.
+	GcsServiceAccountFile               string          `json:"gcsServiceAccountFile"`                                                                                                                                       // Service Account Credentials JSON file path.
+	GcsStorageClass                     string          `json:"gcsStorageClass"`                                                                                                                                             // The storage class to use when storing objects in Google Cloud Storage.
+	GcsToken                            string          `json:"gcsToken"`                                                                                                                                                    // OAuth Access Token as a JSON blob.
+	GcsTokenUrl                         string          `json:"gcsTokenUrl"`                                                                                                                                                 // Token server url.
+	GphotosAuthUrl                      string          `json:"gphotosAuthUrl"`                                                                                                                                              // Auth server URL.
+	GphotosClientId                     string          `json:"gphotosClientId"`                                                                                                                                             // OAuth Client Id.
+	GphotosClientSecret                 string          `json:"gphotosClientSecret"`                                                                                                                                         // OAuth Client Secret.
+	GphotosEncoding                     string          `json:"gphotosEncoding" default:"Slash,CrLf,InvalidUtf8,Dot"`                                                                                                        // The encoding for the backend.
+	GphotosIncludeArchived              string          `json:"gphotosIncludeArchived" default:"false"`                                                                                                                      // Also view and download archived media.
+	GphotosReadOnly                     string          `json:"gphotosReadOnly" default:"false"`                                                                                                                             // Set to make the Google Photos backend read only.
+	GphotosReadSize                     string          `json:"gphotosReadSize" default:"false"`                                                                                                                             // Set to read the size of media items.
+	GphotosStartYear                    string          `json:"gphotosStartYear" default:"2000"`                                                                                                                             // Year limits the photos to be downloaded to those which are uploaded after the given year.
+	GphotosToken                        string          `json:"gphotosToken"`                                                                                                                                                // OAuth Access Token as a JSON blob.
+	GphotosTokenUrl                     string          `json:"gphotosTokenUrl"`                                                                                                                                             // Token server url.
+	HdfsDataTransferProtection          string          `json:"hdfsDataTransferProtection"`                                                                                                                                  // Kerberos data transfer protection: authentication|integrity|privacy.
+	HdfsEncoding                        string          `json:"hdfsEncoding" default:"Slash,Colon,Del,Ctl,InvalidUtf8,Dot"`                                                                                                  // The encoding for the backend.
+	HdfsNamenode                        string          `json:"hdfsNamenode"`                                                                                                                                                // Hadoop name node and port.
+	HdfsServicePrincipalName            string          `json:"hdfsServicePrincipalName"`                                                                                                                                    // Kerberos service principal name for the namenode.
+	HdfsUsername                        string          `json:"hdfsUsername"`                                                                                                                                                // Hadoop user name.
+	HidriveAuthUrl                      string          `json:"hidriveAuthUrl"`                                                                                                                                              // Auth server URL.
+	HidriveChunkSize                    string          `json:"hidriveChunkSize" default:"48Mi"`                                                                                                                             // Chunksize for chunked uploads.
+	HidriveClientId                     string          `json:"hidriveClientId"`                                                                                                                                             // OAuth Client Id.
+	HidriveClientSecret                 string          `json:"hidriveClientSecret"`                                                                                                                                         // OAuth Client Secret.
+	HidriveDisableFetchingMemberCount   string          `json:"hidriveDisableFetchingMemberCount" default:"false"`                                                                                                           // Do not fetch number of objects in directories unless it is absolutely necessary.
+	HidriveEncoding                     string          `json:"hidriveEncoding" default:"Slash,Dot"`                                                                                                                         // The encoding for the backend.
+	HidriveEndpoint                     string          `json:"hidriveEndpoint" default:"https://api.hidrive.strato.com/2.1"`                                                                                                // Endpoint for the service.
+	HidriveRootPrefix                   string          `json:"hidriveRootPrefix" default:"/"`                                                                                                                               // The root/parent folder for all paths.
+	HidriveScopeAccess                  string          `json:"hidriveScopeAccess" default:"rw"`                                                                                                                             // Access permissions that rclone should use when requesting access from HiDrive.
+	HidriveScopeRole                    string          `json:"hidriveScopeRole" default:"user"`                                                                                                                             // User-level that rclone should use when requesting access from HiDrive.
+	HidriveToken                        string          `json:"hidriveToken"`                                                                                                                                                // OAuth Access Token as a JSON blob.
+	HidriveTokenUrl                     string          `json:"hidriveTokenUrl"`                                                                                                                                             // Token server url.
+	HidriveUploadConcurrency            string          `json:"hidriveUploadConcurrency" default:"4"`                                                                                                                        // Concurrency for chunked uploads.
+	HidriveUploadCutoff                 string          `json:"hidriveUploadCutoff" default:"96Mi"`                                                                                                                          // Cutoff/Threshold for chunked uploads.
+	HttpHeaders                         string          `json:"httpHeaders"`                                                                                                                                                 // Set HTTP headers for all transactions.
+	HttpNoHead                          string          `json:"httpNoHead" default:"false"`                                                                                                                                  // Don't use HEAD requests.
+	HttpNoSlash                         string          `json:"httpNoSlash" default:"false"`                                                                                                                                 // Set this if the site doesn't end directories with /.
+	HttpUrl                             string          `json:"httpUrl"`                                                                                                                                                     // URL of HTTP host to connect to.
+	InternetarchiveAccessKeyId          string          `json:"internetarchiveAccessKeyId"`                                                                                                                                  // IAS3 Access Key.
+	InternetarchiveDisableChecksum      string          `json:"internetarchiveDisableChecksum" default:"true"`                                                                                                               // Don't ask the server to test against MD5 checksum calculated by rclone.
+	InternetarchiveEncoding             string          `json:"internetarchiveEncoding" default:"Slash,LtGt,CrLf,Del,Ctl,InvalidUtf8,Dot"`                                                                                   // The encoding for the backend.
+	InternetarchiveEndpoint             string          `json:"internetarchiveEndpoint" default:"https://s3.us.archive.org"`                                                                                                 // IAS3 Endpoint.
+	InternetarchiveFrontEndpoint        string          `json:"internetarchiveFrontEndpoint" default:"https://archive.org"`                                                                                                  // Host of InternetArchive Frontend.
+	InternetarchiveSecretAccessKey      string          `json:"internetarchiveSecretAccessKey"`                                                                                                                              // IAS3 Secret Key (password).
+	InternetarchiveWaitArchive          string          `json:"internetarchiveWaitArchive" default:"0s"`                                                                                                                     // Timeout for waiting the server's processing tasks (specifically archive and book_op) to finish.
+	JottacloudEncoding                  string          `json:"jottacloudEncoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,Del,Ctl,InvalidUtf8,Dot"`                                                    // The encoding for the backend.
+	JottacloudHardDelete                string          `json:"jottacloudHardDelete" default:"false"`                                                                                                                        // Delete files permanently rather than putting them into the trash.
+	JottacloudMd5MemoryLimit            string          `json:"jottacloudMd5MemoryLimit" default:"10Mi"`                                                                                                                     // Files bigger than this will be cached on disk to calculate the MD5 if required.
+	JottacloudNoVersions                string          `json:"jottacloudNoVersions" default:"false"`                                                                                                                        // Avoid server side versioning by deleting files and recreating files instead of overwriting them.
+	JottacloudTrashedOnly               string          `json:"jottacloudTrashedOnly" default:"false"`                                                                                                                       // Only show files that are in the trash.
+	JottacloudUploadResumeLimit         string          `json:"jottacloudUploadResumeLimit" default:"10Mi"`                                                                                                                  // Files bigger than this can be resumed if the upload fail's.
+	KoofrEncoding                       string          `json:"koofrEncoding" default:"Slash,BackSlash,Del,Ctl,InvalidUtf8,Dot"`                                                                                             // The encoding for the backend.
+	KoofrEndpoint                       string          `json:"koofrEndpoint"`                                                                                                                                               // The Koofr API endpoint to use.
+	KoofrMountid                        string          `json:"koofrMountid"`                                                                                                                                                // Mount ID of the mount to use.
+	KoofrPassword                       string          `json:"koofrPassword"`                                                                                                                                               // Your password for rclone (generate one at https://app.koofr.net/app/admin/preferences/password).
+	KoofrProvider                       string          `json:"koofrProvider"`                                                                                                                                               // Choose your storage provider.
+	KoofrSetmtime                       string          `json:"koofrSetmtime" default:"true"`                                                                                                                                // Does the backend support setting modification time.
+	KoofrUser                           string          `json:"koofrUser"`                                                                                                                                                   // Your user name.
+	LocalCaseInsensitive                string          `json:"localCaseInsensitive" default:"false"`                                                                                                                        // Force the filesystem to report itself as case insensitive.
+	LocalCaseSensitive                  string          `json:"localCaseSensitive" default:"false"`                                                                                                                          // Force the filesystem to report itself as case sensitive.
+	LocalCopyLinks                      string          `json:"localCopyLinks" default:"false"`                                                                                                                              // Follow symlinks and copy the pointed to item.
+	LocalEncoding                       string          `json:"localEncoding" default:"Slash,Dot"`                                                                                                                           // The encoding for the backend.
+	LocalLinks                          string          `json:"localLinks" default:"false"`                                                                                                                                  // Translate symlinks to/from regular files with a '.rclonelink' extension.
+	LocalNoCheckUpdated                 string          `json:"localNoCheckUpdated" default:"false"`                                                                                                                         // Don't check to see if the files change during upload.
+	LocalNoPreallocate                  string          `json:"localNoPreallocate" default:"false"`                                                                                                                          // Disable preallocation of disk space for transferred files.
+	LocalNoSetModtime                   string          `json:"localNoSetModtime" default:"false"`                                                                                                                           // Disable setting modtime.
+	LocalNoSparse                       string          `json:"localNoSparse" default:"false"`                                                                                                                               // Disable sparse files for multi-thread downloads.
+	LocalNounc                          string          `json:"localNounc" default:"false"`                                                                                                                                  // Disable UNC (long path names) conversion on Windows.
+	LocalOneFileSystem                  string          `json:"localOneFileSystem" default:"false"`                                                                                                                          // Don't cross filesystem boundaries (unix/macOS only).
+	LocalSkipLinks                      string          `json:"localSkipLinks" default:"false"`                                                                                                                              // Don't warn about skipped symlinks.
+	LocalUnicodeNormalization           string          `json:"localUnicodeNormalization" default:"false"`                                                                                                                   // Apply unicode NFC normalization to paths and filenames.
+	LocalZeroSizeLinks                  string          `json:"localZeroSizeLinks" default:"false"`                                                                                                                          // Assume the Stat size of links is zero (and read them instead) (deprecated).
+	MailruCheckHash                     string          `json:"mailruCheckHash" default:"true"`                                                                                                                              // What should copy do if file checksum is mismatched or invalid.
+	MailruEncoding                      string          `json:"mailruEncoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,Del,Ctl,InvalidUtf8,Dot"`                                              // The encoding for the backend.
+	MailruPass                          string          `json:"mailruPass"`                                                                                                                                                  // Password.
+	MailruQuirks                        string          `json:"mailruQuirks"`                                                                                                                                                // Comma separated list of internal maintenance flags.
+	MailruSpeedupEnable                 string          `json:"mailruSpeedupEnable" default:"true"`                                                                                                                          // Skip full upload if there is another file with same data hash.
+	MailruSpeedupFilePatterns           string          `json:"mailruSpeedupFilePatterns" default:"*.mkv,*.avi,*.mp4,*.mp3,*.zip,*.gz,*.rar,*.pdf"`                                                                          // Comma separated list of file name patterns eligible for speedup (put by hash).
+	MailruSpeedupMaxDisk                string          `json:"mailruSpeedupMaxDisk" default:"3Gi"`                                                                                                                          // This option allows you to disable speedup (put by hash) for large files.
+	MailruSpeedupMaxMemory              string          `json:"mailruSpeedupMaxMemory" default:"32Mi"`                                                                                                                       // Files larger than the size given below will always be hashed on disk.
+	MailruUser                          string          `json:"mailruUser"`                                                                                                                                                  // User name (usually email).
+	MailruUserAgent                     string          `json:"mailruUserAgent"`                                                                                                                                             // HTTP user agent used internally by client.
+	MegaDebug                           string          `json:"megaDebug" default:"false"`                                                                                                                                   // Output more debug from Mega.
+	MegaEncoding                        string          `json:"megaEncoding" default:"Slash,InvalidUtf8,Dot"`                                                                                                                // The encoding for the backend.
+	MegaHardDelete                      string          `json:"megaHardDelete" default:"false"`                                                                                                                              // Delete files permanently rather than putting them into the trash.
+	MegaPass                            string          `json:"megaPass"`                                                                                                                                                    // Password.
+	MegaUseHttps                        string          `json:"megaUseHttps" default:"false"`                                                                                                                                // Use HTTPS for transfers.
+	MegaUser                            string          `json:"megaUser"`                                                                                                                                                    // User name.
+	NetstorageAccount                   string          `json:"netstorageAccount"`                                                                                                                                           // Set the NetStorage account name
+	NetstorageHost                      string          `json:"netstorageHost"`                                                                                                                                              // Domain+path of NetStorage host to connect to.
+	NetstorageProtocol                  string          `json:"netstorageProtocol" default:"https"`                                                                                                                          // Select between HTTP or HTTPS protocol.
+	NetstorageSecret                    string          `json:"netstorageSecret"`                                                                                                                                            // Set the NetStorage account secret/G2O key for authentication.
+	OnedriveAccessScopes                string          `json:"onedriveAccessScopes" default:"Files.Read Files.ReadWrite Files.Read.All Files.ReadWrite.All Sites.Read.All offline_access"`                                  // Set scopes to be requested by rclone.
+	OnedriveAuthUrl                     string          `json:"onedriveAuthUrl"`                                                                                                                                             // Auth server URL.
+	OnedriveChunkSize                   string          `json:"onedriveChunkSize" default:"10Mi"`                                                                                                                            // Chunk size to upload files with - must be multiple of 320k (327,680 bytes).
+	OnedriveClientId                    string          `json:"onedriveClientId"`                                                                                                                                            // OAuth Client Id.
+	OnedriveClientSecret                string          `json:"onedriveClientSecret"`                                                                                                                                        // OAuth Client Secret.
+	OnedriveDisableSitePermission       string          `json:"onedriveDisableSitePermission" default:"false"`                                                                                                               // Disable the request for Sites.Read.All permission.
+	OnedriveDriveId                     string          `json:"onedriveDriveId"`                                                                                                                                             // The ID of the drive to use.
+	OnedriveDriveType                   string          `json:"onedriveDriveType"`                                                                                                                                           // The type of the drive (personal | business | documentLibrary).
+	OnedriveEncoding                    string          `json:"onedriveEncoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,Del,Ctl,LeftSpace,LeftTilde,RightSpace,RightPeriod,InvalidUtf8,Dot"` // The encoding for the backend.
+	OnedriveExposeOnenoteFiles          string          `json:"onedriveExposeOnenoteFiles" default:"false"`                                                                                                                  // Set to make OneNote files show up in directory listings.
+	OnedriveHashType                    string          `json:"onedriveHashType" default:"auto"`                                                                                                                             // Specify the hash in use for the backend.
+	OnedriveLinkPassword                string          `json:"onedriveLinkPassword"`                                                                                                                                        // Set the password for links created by the link command.
+	OnedriveLinkScope                   string          `json:"onedriveLinkScope" default:"anonymous"`                                                                                                                       // Set the scope of the links created by the link command.
+	OnedriveLinkType                    string          `json:"onedriveLinkType" default:"view"`                                                                                                                             // Set the type of the links created by the link command.
+	OnedriveListChunk                   string          `json:"onedriveListChunk" default:"1000"`                                                                                                                            // Size of listing chunk.
+	OnedriveNoVersions                  string          `json:"onedriveNoVersions" default:"false"`                                                                                                                          // Remove all versions on modifying operations.
+	OnedriveRegion                      string          `json:"onedriveRegion" default:"global"`                                                                                                                             // Choose national cloud region for OneDrive.
+	OnedriveRootFolderId                string          `json:"onedriveRootFolderId"`                                                                                                                                        // ID of the root folder.
+	OnedriveServerSideAcrossConfigs     string          `json:"onedriveServerSideAcrossConfigs" default:"false"`                                                                                                             // Allow server-side operations (e.g. copy) to work across different onedrive configs.
+	OnedriveToken                       string          `json:"onedriveToken"`                                                                                                                                               // OAuth Access Token as a JSON blob.
+	OnedriveTokenUrl                    string          `json:"onedriveTokenUrl"`                                                                                                                                            // Token server url.
+	OpendriveChunkSize                  string          `json:"opendriveChunkSize" default:"10Mi"`                                                                                                                           // Files will be uploaded in chunks this size.
+	OpendriveEncoding                   string          `json:"opendriveEncoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,LeftSpace,LeftCrLfHtVt,RightSpace,RightCrLfHtVt,InvalidUtf8,Dot"`   // The encoding for the backend.
+	OpendrivePassword                   string          `json:"opendrivePassword"`                                                                                                                                           // Password.
+	OpendriveUsername                   string          `json:"opendriveUsername"`                                                                                                                                           // Username.
+	OosChunkSize                        string          `json:"oosChunkSize" default:"5Mi"`                                                                                                                                  // Chunk size to use for uploading.
+	OosCompartment                      string          `json:"oosCompartment"`                                                                                                                                              // Object storage compartment OCID
+	OosConfigFile                       string          `json:"oosConfigFile" default:"~/.oci/config"`                                                                                                                       // Path to OCI config file
+	OosConfigProfile                    string          `json:"oosConfigProfile" default:"Default"`                                                                                                                          // Profile name inside the oci config file
+	OosCopyCutoff                       string          `json:"oosCopyCutoff" default:"4.656Gi"`                                                                                                                             // Cutoff for switching to multipart copy.
+	OosCopyTimeout                      string          `json:"oosCopyTimeout" default:"1m0s"`                                                                                                                               // Timeout for copy.
+	OosDisableChecksum                  string          `json:"oosDisableChecksum" default:"false"`                                                                                                                          // Don't store MD5 checksum with object metadata.
+	OosEncoding                         string          `json:"oosEncoding" default:"Slash,InvalidUtf8,Dot"`                                                                                                                 // The encoding for the backend.
+	OosEndpoint                         string          `json:"oosEndpoint"`                                                                                                                                                 // Endpoint for Object storage API.
+	OosLeavePartsOnError                string          `json:"oosLeavePartsOnError" default:"false"`                                                                                                                        // If true avoid calling abort upload on a failure, leaving all successfully uploaded parts on S3 for manual recovery.
+	OosNamespace                        string          `json:"oosNamespace"`                                                                                                                                                // Object storage namespace
+	OosNoCheckBucket                    string          `json:"oosNoCheckBucket" default:"false"`                                                                                                                            // If set, don't attempt to check the bucket exists or create it.
+	OosProvider                         string          `json:"oosProvider" default:"env_auth"`                                                                                                                              // Choose your Auth Provider
+	OosRegion                           string          `json:"oosRegion"`                                                                                                                                                   // Object storage Region
+	OosSseCustomerAlgorithm             string          `json:"oosSseCustomerAlgorithm"`                                                                                                                                     // If using SSE-C, the optional header that specifies "AES256" as the encryption algorithm.
+	OosSseCustomerKey                   string          `json:"oosSseCustomerKey"`                                                                                                                                           // To use SSE-C, the optional header that specifies the base64-encoded 256-bit encryption key to use to
+	OosSseCustomerKeyFile               string          `json:"oosSseCustomerKeyFile"`                                                                                                                                       // To use SSE-C, a file containing the base64-encoded string of the AES-256 encryption key associated
+	OosSseCustomerKeySha256             string          `json:"oosSseCustomerKeySha256"`                                                                                                                                     // If using SSE-C, The optional header that specifies the base64-encoded SHA256 hash of the encryption
+	OosSseKmsKeyId                      string          `json:"oosSseKmsKeyId"`                                                                                                                                              // if using using your own master key in vault, this header specifies the
+	OosStorageTier                      string          `json:"oosStorageTier" default:"Standard"`                                                                                                                           // The storage class to use when storing new objects in storage. https://docs.oracle.com/en-us/iaas/Content/Object/Concepts/understandingstoragetiers.htm
+	OosUploadConcurrency                string          `json:"oosUploadConcurrency" default:"10"`                                                                                                                           // Concurrency for multipart uploads.
+	OosUploadCutoff                     string          `json:"oosUploadCutoff" default:"200Mi"`                                                                                                                             // Cutoff for switching to chunked upload.
+	PcloudAuthUrl                       string          `json:"pcloudAuthUrl"`                                                                                                                                               // Auth server URL.
+	PcloudClientId                      string          `json:"pcloudClientId"`                                                                                                                                              // OAuth Client Id.
+	PcloudClientSecret                  string          `json:"pcloudClientSecret"`                                                                                                                                          // OAuth Client Secret.
+	PcloudEncoding                      string          `json:"pcloudEncoding" default:"Slash,BackSlash,Del,Ctl,InvalidUtf8,Dot"`                                                                                            // The encoding for the backend.
+	PcloudHostname                      string          `json:"pcloudHostname" default:"api.pcloud.com"`                                                                                                                     // Hostname to connect to.
+	PcloudPassword                      string          `json:"pcloudPassword"`                                                                                                                                              // Your pcloud password.
+	PcloudRootFolderId                  string          `json:"pcloudRootFolderId" default:"d0"`                                                                                                                             // Fill in for rclone to use a non root folder as its starting point.
+	PcloudToken                         string          `json:"pcloudToken"`                                                                                                                                                 // OAuth Access Token as a JSON blob.
+	PcloudTokenUrl                      string          `json:"pcloudTokenUrl"`                                                                                                                                              // Token server url.
+	PcloudUsername                      string          `json:"pcloudUsername"`                                                                                                                                              // Your pcloud username.
+	PremiumizemeApiKey                  string          `json:"premiumizemeApiKey"`                                                                                                                                          // API Key.
+	PremiumizemeEncoding                string          `json:"premiumizemeEncoding" default:"Slash,DoubleQuote,BackSlash,Del,Ctl,InvalidUtf8,Dot"`                                                                          // The encoding for the backend.
+	PutioEncoding                       string          `json:"putioEncoding" default:"Slash,BackSlash,Del,Ctl,InvalidUtf8,Dot"`                                                                                             // The encoding for the backend.
+	QingstorAccessKeyId                 string          `json:"qingstorAccessKeyId"`                                                                                                                                         // QingStor Access Key ID.
+	QingstorChunkSize                   string          `json:"qingstorChunkSize" default:"4Mi"`                                                                                                                             // Chunk size to use for uploading.
+	QingstorConnectionRetries           string          `json:"qingstorConnectionRetries" default:"3"`                                                                                                                       // Number of connection retries.
+	QingstorEncoding                    string          `json:"qingstorEncoding" default:"Slash,Ctl,InvalidUtf8"`                                                                                                            // The encoding for the backend.
+	QingstorEndpoint                    string          `json:"qingstorEndpoint"`                                                                                                                                            // Enter an endpoint URL to connection QingStor API.
+	QingstorEnvAuth                     string          `json:"qingstorEnvAuth" default:"false"`                                                                                                                             // Get QingStor credentials from runtime.
+	QingstorSecretAccessKey             string          `json:"qingstorSecretAccessKey"`                                                                                                                                     // QingStor Secret Access Key (password).
+	QingstorUploadConcurrency           string          `json:"qingstorUploadConcurrency" default:"1"`                                                                                                                       // Concurrency for multipart uploads.
+	QingstorUploadCutoff                string          `json:"qingstorUploadCutoff" default:"200Mi"`                                                                                                                        // Cutoff for switching to chunked upload.
+	QingstorZone                        string          `json:"qingstorZone"`                                                                                                                                                // Zone to connect to.
+	S3AccessKeyId                       string          `json:"s3AccessKeyId"`                                                                                                                                               // AWS Access Key ID.
+	S3Acl                               string          `json:"s3Acl"`                                                                                                                                                       // Canned ACL used when creating buckets and storing or copying objects.
+	S3BucketAcl                         string          `json:"s3BucketAcl"`                                                                                                                                                 // Canned ACL used when creating buckets.
+	S3ChunkSize                         string          `json:"s3ChunkSize" default:"5Mi"`                                                                                                                                   // Chunk size to use for uploading.
+	S3CopyCutoff                        string          `json:"s3CopyCutoff" default:"4.656Gi"`                                                                                                                              // Cutoff for switching to multipart copy.
+	S3Decompress                        string          `json:"s3Decompress" default:"false"`                                                                                                                                // If set this will decompress gzip encoded objects.
+	S3DisableChecksum                   string          `json:"s3DisableChecksum" default:"false"`                                                                                                                           // Don't store MD5 checksum with object metadata.
+	S3DisableHttp2                      string          `json:"s3DisableHttp2" default:"false"`                                                                                                                              // Disable usage of http2 for S3 backends.
+	S3DownloadUrl                       string          `json:"s3DownloadUrl"`                                                                                                                                               // Custom endpoint for downloads.
+	S3Encoding                          string          `json:"s3Encoding" default:"Slash,InvalidUtf8,Dot"`                                                                                                                  // The encoding for the backend.
+	S3Endpoint                          string          `json:"s3Endpoint"`                                                                                                                                                  // Endpoint for S3 API.
+	S3EnvAuth                           string          `json:"s3EnvAuth" default:"false"`                                                                                                                                   // Get AWS credentials from runtime (environment variables or EC2/ECS meta data if no env vars).
+	S3ForcePathStyle                    string          `json:"s3ForcePathStyle" default:"true"`                                                                                                                             // If true use path style access if false use virtual hosted style.
+	S3LeavePartsOnError                 string          `json:"s3LeavePartsOnError" default:"false"`                                                                                                                         // If true avoid calling abort upload on a failure, leaving all successfully uploaded parts on S3 for manual recovery.
+	S3ListChunk                         string          `json:"s3ListChunk" default:"1000"`                                                                                                                                  // Size of listing chunk (response list for each ListObject S3 request).
+	S3ListUrlEncode                     string          `json:"s3ListUrlEncode" default:"unset"`                                                                                                                             // Whether to url encode listings: true/false/unset
+	S3ListVersion                       string          `json:"s3ListVersion" default:"0"`                                                                                                                                   // Version of ListObjects to use: 1,2 or 0 for auto.
+	S3LocationConstraint                string          `json:"s3LocationConstraint"`                                                                                                                                        // Location constraint - must be set to match the Region.
+	S3MaxUploadParts                    string          `json:"s3MaxUploadParts" default:"10000"`                                                                                                                            // Maximum number of parts in a multipart upload.
+	S3MemoryPoolFlushTime               string          `json:"s3MemoryPoolFlushTime" default:"1m0s"`                                                                                                                        // How often internal memory buffer pools will be flushed.
+	S3MemoryPoolUseMmap                 string          `json:"s3MemoryPoolUseMmap" default:"false"`                                                                                                                         // Whether to use mmap buffers in internal memory pool.
+	S3MightGzip                         string          `json:"s3MightGzip" default:"unset"`                                                                                                                                 // Set this if the backend might gzip objects.
+	S3NoCheckBucket                     string          `json:"s3NoCheckBucket" default:"false"`                                                                                                                             // If set, don't attempt to check the bucket exists or create it.
+	S3NoHead                            string          `json:"s3NoHead" default:"false"`                                                                                                                                    // If set, don't HEAD uploaded objects to check integrity.
+	S3NoHeadObject                      string          `json:"s3NoHeadObject" default:"false"`                                                                                                                              // If set, do not do HEAD before GET when getting objects.
+	S3NoSystemMetadata                  string          `json:"s3NoSystemMetadata" default:"false"`                                                                                                                          // Suppress setting and reading of system metadata
+	S3Profile                           string          `json:"s3Profile"`                                                                                                                                                   // Profile to use in the shared credentials file.
+	S3Provider                          string          `json:"s3Provider"`                                                                                                                                                  // Choose your S3 provider.
+	S3Region                            string          `json:"s3Region"`                                                                                                                                                    // Region to connect to.
+	S3RequesterPays                     string          `json:"s3RequesterPays" default:"false"`                                                                                                                             // Enables requester pays option when interacting with S3 bucket.
+	S3SecretAccessKey                   string          `json:"s3SecretAccessKey"`                                                                                                                                           // AWS Secret Access Key (password).
+	S3ServerSideEncryption              string          `json:"s3ServerSideEncryption"`                                                                                                                                      // The server-side encryption algorithm used when storing this object in S3.
+	S3SessionToken                      string          `json:"s3SessionToken"`                                                                                                                                              // An AWS session token.
+	S3SharedCredentialsFile             string          `json:"s3SharedCredentialsFile"`                                                                                                                                     // Path to the shared credentials file.
+	S3SseCustomerAlgorithm              string          `json:"s3SseCustomerAlgorithm"`                                                                                                                                      // If using SSE-C, the server-side encryption algorithm used when storing this object in S3.
+	S3SseCustomerKey                    string          `json:"s3SseCustomerKey"`                                                                                                                                            // To use SSE-C you may provide the secret encryption key used to encrypt/decrypt your data.
+	S3SseCustomerKeyBase64              string          `json:"s3SseCustomerKeyBase64"`                                                                                                                                      // If using SSE-C you must provide the secret encryption key encoded in base64 format to encrypt/decrypt your data.
+	S3SseCustomerKeyMd5                 string          `json:"s3SseCustomerKeyMd5"`                                                                                                                                         // If using SSE-C you may provide the secret encryption key MD5 checksum (optional).
+	S3SseKmsKeyId                       string          `json:"s3SseKmsKeyId"`                                                                                                                                               // If using KMS ID you must provide the ARN of Key.
+	S3StorageClass                      string          `json:"s3StorageClass"`                                                                                                                                              // The storage class to use when storing new objects in S3.
+	S3StsEndpoint                       string          `json:"s3StsEndpoint"`                                                                                                                                               // Endpoint for STS.
+	S3UploadConcurrency                 string          `json:"s3UploadConcurrency" default:"4"`                                                                                                                             // Concurrency for multipart uploads.
+	S3UploadCutoff                      string          `json:"s3UploadCutoff" default:"200Mi"`                                                                                                                              // Cutoff for switching to chunked upload.
+	S3UseAccelerateEndpoint             string          `json:"s3UseAccelerateEndpoint" default:"false"`                                                                                                                     // If true use the AWS S3 accelerated endpoint.
+	S3UseMultipartEtag                  string          `json:"s3UseMultipartEtag" default:"unset"`                                                                                                                          // Whether to use ETag in multipart uploads for verification
+	S3UsePresignedRequest               string          `json:"s3UsePresignedRequest" default:"false"`                                                                                                                       // Whether to use a presigned request or PutObject for single part uploads
+	S3V2Auth                            string          `json:"s3V2Auth" default:"false"`                                                                                                                                    // If true use v2 authentication.
+	S3VersionAt                         string          `json:"s3VersionAt" default:"off"`                                                                                                                                   // Show file versions as they were at the specified time.
+	S3Versions                          string          `json:"s3Versions" default:"false"`                                                                                                                                  // Include old versions in directory listings.
+	Seafile2fa                          string          `json:"seafile2fa" default:"false"`                                                                                                                                  // Two-factor authentication ('true' if the account has 2FA enabled).
+	SeafileAuthToken                    string          `json:"seafileAuthToken"`                                                                                                                                            // Authentication token.
+	SeafileCreateLibrary                string          `json:"seafileCreateLibrary" default:"false"`                                                                                                                        // Should rclone create a library if it doesn't exist.
+	SeafileEncoding                     string          `json:"seafileEncoding" default:"Slash,DoubleQuote,BackSlash,Ctl,InvalidUtf8"`                                                                                       // The encoding for the backend.
+	SeafileLibrary                      string          `json:"seafileLibrary"`                                                                                                                                              // Name of the library.
+	SeafileLibraryKey                   string          `json:"seafileLibraryKey"`                                                                                                                                           // Library password (for encrypted libraries only).
+	SeafilePass                         string          `json:"seafilePass"`                                                                                                                                                 // Password.
+	SeafileUrl                          string          `json:"seafileUrl"`                                                                                                                                                  // URL of seafile host to connect to.
+	SeafileUser                         string          `json:"seafileUser"`                                                                                                                                                 // User name (usually email address).
+	SftpAskPassword                     string          `json:"sftpAskPassword" default:"false"`                                                                                                                             // Allow asking for SFTP password when needed.
+	SftpChunkSize                       string          `json:"sftpChunkSize" default:"32Ki"`                                                                                                                                // Upload and download chunk size.
+	SftpCiphers                         string          `json:"sftpCiphers"`                                                                                                                                                 // Space separated list of ciphers to be used for session encryption, ordered by preference.
+	SftpConcurrency                     string          `json:"sftpConcurrency" default:"64"`                                                                                                                                // The maximum number of outstanding requests for one file
+	SftpDisableConcurrentReads          string          `json:"sftpDisableConcurrentReads" default:"false"`                                                                                                                  // If set don't use concurrent reads.
+	SftpDisableConcurrentWrites         string          `json:"sftpDisableConcurrentWrites" default:"false"`                                                                                                                 // If set don't use concurrent writes.
+	SftpDisableHashcheck                string          `json:"sftpDisableHashcheck" default:"false"`                                                                                                                        // Disable the execution of SSH commands to determine if remote file hashing is available.
+	SftpHost                            string          `json:"sftpHost"`                                                                                                                                                    // SSH host to connect to.
+	SftpIdleTimeout                     string          `json:"sftpIdleTimeout" default:"1m0s"`                                                                                                                              // Max time before closing idle connections.
+	SftpKeyExchange                     string          `json:"sftpKeyExchange"`                                                                                                                                             // Space separated list of key exchange algorithms, ordered by preference.
+	SftpKeyFile                         string          `json:"sftpKeyFile"`                                                                                                                                                 // Path to PEM-encoded private key file.
+	SftpKeyFilePass                     string          `json:"sftpKeyFilePass"`                                                                                                                                             // The passphrase to decrypt the PEM-encoded private key file.
+	SftpKeyPem                          string          `json:"sftpKeyPem"`                                                                                                                                                  // Raw PEM-encoded private key.
+	SftpKeyUseAgent                     string          `json:"sftpKeyUseAgent" default:"false"`                                                                                                                             // When set forces the usage of the ssh-agent.
+	SftpKnownHostsFile                  string          `json:"sftpKnownHostsFile"`                                                                                                                                          // Optional path to known_hosts file.
+	SftpMacs                            string          `json:"sftpMacs"`                                                                                                                                                    // Space separated list of MACs (message authentication code) algorithms, ordered by preference.
+	SftpMd5sumCommand                   string          `json:"sftpMd5sumCommand"`                                                                                                                                           // The command used to read md5 hashes.
+	SftpPass                            string          `json:"sftpPass"`                                                                                                                                                    // SSH password, leave blank to use ssh-agent.
+	SftpPathOverride                    string          `json:"sftpPathOverride"`                                                                                                                                            // Override path used by SSH shell commands.
+	SftpPort                            string          `json:"sftpPort" default:"22"`                                                                                                                                       // SSH port number.
+	SftpPubkeyFile                      string          `json:"sftpPubkeyFile"`                                                                                                                                              // Optional path to public key file.
+	SftpServerCommand                   string          `json:"sftpServerCommand"`                                                                                                                                           // Specifies the path or command to run a sftp server on the remote host.
+	SftpSetEnv                          string          `json:"sftpSetEnv"`                                                                                                                                                  // Environment variables to pass to sftp and commands
+	SftpSetModtime                      string          `json:"sftpSetModtime" default:"true"`                                                                                                                               // Set the modified time on the remote if set.
+	SftpSha1sumCommand                  string          `json:"sftpSha1sumCommand"`                                                                                                                                          // The command used to read sha1 hashes.
+	SftpShellType                       string          `json:"sftpShellType"`                                                                                                                                               // The type of SSH shell on remote server, if any.
+	SftpSkipLinks                       string          `json:"sftpSkipLinks" default:"false"`                                                                                                                               // Set to skip any symlinks and any other non regular files.
+	SftpSubsystem                       string          `json:"sftpSubsystem" default:"sftp"`                                                                                                                                // Specifies the SSH2 subsystem on the remote host.
+	SftpUseFstat                        string          `json:"sftpUseFstat" default:"false"`                                                                                                                                // If set use fstat instead of stat.
+	SftpUseInsecureCipher               string          `json:"sftpUseInsecureCipher" default:"false"`                                                                                                                       // Enable the use of insecure ciphers and key exchange methods.
+	SftpUser                            string          `json:"sftpUser" default:"$USER"`                                                                                                                                    // SSH username.
+	SharefileChunkSize                  string          `json:"sharefileChunkSize" default:"64Mi"`                                                                                                                           // Upload chunk size.
+	SharefileEncoding                   string          `json:"sharefileEncoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,Ctl,LeftSpace,LeftPeriod,RightSpace,RightPeriod,InvalidUtf8,Dot"`   // The encoding for the backend.
+	SharefileEndpoint                   string          `json:"sharefileEndpoint"`                                                                                                                                           // Endpoint for API calls.
+	SharefileRootFolderId               string          `json:"sharefileRootFolderId"`                                                                                                                                       // ID of the root folder.
+	SharefileUploadCutoff               string          `json:"sharefileUploadCutoff" default:"128Mi"`                                                                                                                       // Cutoff for switching to multipart upload.
+	SiaApiPassword                      string          `json:"siaApiPassword"`                                                                                                                                              // Sia Daemon API Password.
+	SiaApiUrl                           string          `json:"siaApiUrl" default:"http://127.0.0.1:9980"`                                                                                                                   // Sia daemon API URL, like http://sia.daemon.host:9980.
+	SiaEncoding                         string          `json:"siaEncoding" default:"Slash,Question,Hash,Percent,Del,Ctl,InvalidUtf8,Dot"`                                                                                   // The encoding for the backend.
+	SiaUserAgent                        string          `json:"siaUserAgent" default:"Sia-Agent"`                                                                                                                            // Siad User Agent
+	SmbCaseInsensitive                  string          `json:"smbCaseInsensitive" default:"true"`                                                                                                                           // Whether the server is configured to be case-insensitive.
+	SmbDomain                           string          `json:"smbDomain" default:"WORKGROUP"`                                                                                                                               // Domain name for NTLM authentication.
+	SmbEncoding                         string          `json:"smbEncoding" default:"Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,Ctl,RightSpace,RightPeriod,InvalidUtf8,Dot"`                              // The encoding for the backend.
+	SmbHideSpecialShare                 string          `json:"smbHideSpecialShare" default:"true"`                                                                                                                          // Hide special shares (e.g. print$) which users aren't supposed to access.
+	SmbHost                             string          `json:"smbHost"`                                                                                                                                                     // SMB server hostname to connect to.
+	SmbIdleTimeout                      string          `json:"smbIdleTimeout" default:"1m0s"`                                                                                                                               // Max time before closing idle connections.
+	SmbPass                             string          `json:"smbPass"`                                                                                                                                                     // SMB password.
+	SmbPort                             string          `json:"smbPort" default:"445"`                                                                                                                                       // SMB port number.
+	SmbSpn                              string          `json:"smbSpn"`                                                                                                                                                      // Service principal name.
+	SmbUser                             string          `json:"smbUser" default:"$USER"`                                                                                                                                     // SMB username.
+	StorjAccessGrant                    string          `json:"storjAccessGrant"`                                                                                                                                            // Access grant.
+	StorjApiKey                         string          `json:"storjApiKey"`                                                                                                                                                 // API key.
+	StorjPassphrase                     string          `json:"storjPassphrase"`                                                                                                                                             // Encryption passphrase.
+	StorjProvider                       string          `json:"storjProvider" default:"existing"`                                                                                                                            // Choose an authentication method.
+	StorjSatelliteAddress               string          `json:"storjSatelliteAddress" default:"us1.storj.io"`                                                                                                                // Satellite address.
+	SugarsyncAccessKeyId                string          `json:"sugarsyncAccessKeyId"`                                                                                                                                        // Sugarsync Access Key ID.
+	SugarsyncAppId                      string          `json:"sugarsyncAppId"`                                                                                                                                              // Sugarsync App ID.
+	SugarsyncAuthorization              string          `json:"sugarsyncAuthorization"`                                                                                                                                      // Sugarsync authorization.
+	SugarsyncAuthorizationExpiry        string          `json:"sugarsyncAuthorizationExpiry"`                                                                                                                                // Sugarsync authorization expiry.
+	SugarsyncDeletedId                  string          `json:"sugarsyncDeletedId"`                                                                                                                                          // Sugarsync deleted folder id.
+	SugarsyncEncoding                   string          `json:"sugarsyncEncoding" default:"Slash,Ctl,InvalidUtf8,Dot"`                                                                                                       // The encoding for the backend.
+	SugarsyncHardDelete                 string          `json:"sugarsyncHardDelete" default:"false"`                                                                                                                         // Permanently delete files if true
+	SugarsyncPrivateAccessKey           string          `json:"sugarsyncPrivateAccessKey"`                                                                                                                                   // Sugarsync Private Access Key.
+	SugarsyncRefreshToken               string          `json:"sugarsyncRefreshToken"`                                                                                                                                       // Sugarsync refresh token.
+	SugarsyncRootId                     string          `json:"sugarsyncRootId"`                                                                                                                                             // Sugarsync root id.
+	SugarsyncUser                       string          `json:"sugarsyncUser"`                                                                                                                                               // Sugarsync user.
+	SwiftApplicationCredentialId        string          `json:"swiftApplicationCredentialId"`                                                                                                                                // Application Credential ID (OS_APPLICATION_CREDENTIAL_ID).
+	SwiftApplicationCredentialName      string          `json:"swiftApplicationCredentialName"`                                                                                                                              // Application Credential Name (OS_APPLICATION_CREDENTIAL_NAME).
+	SwiftApplicationCredentialSecret    string          `json:"swiftApplicationCredentialSecret"`                                                                                                                            // Application Credential Secret (OS_APPLICATION_CREDENTIAL_SECRET).
+	SwiftAuth                           string          `json:"swiftAuth"`                                                                                                                                                   // Authentication URL for server (OS_AUTH_URL).
+	SwiftAuthToken                      string          `json:"swiftAuthToken"`                                                                                                                                              // Auth Token from alternate authentication - optional (OS_AUTH_TOKEN).
+	SwiftAuthVersion                    string          `json:"swiftAuthVersion" default:"0"`                                                                                                                                // AuthVersion - optional - set to (1,2,3) if your auth URL has no version (ST_AUTH_VERSION).
+	SwiftChunkSize                      string          `json:"swiftChunkSize" default:"5Gi"`                                                                                                                                // Above this size files will be chunked into a _segments container.
+	SwiftDomain                         string          `json:"swiftDomain"`                                                                                                                                                 // User domain - optional (v3 auth) (OS_USER_DOMAIN_NAME)
+	SwiftEncoding                       string          `json:"swiftEncoding" default:"Slash,InvalidUtf8"`                                                                                                                   // The encoding for the backend.
+	SwiftEndpointType                   string          `json:"swiftEndpointType" default:"public"`                                                                                                                          // Endpoint type to choose from the service catalogue (OS_ENDPOINT_TYPE).
+	SwiftEnvAuth                        string          `json:"swiftEnvAuth" default:"false"`                                                                                                                                // Get swift credentials from environment variables in standard OpenStack form.
+	SwiftKey                            string          `json:"swiftKey"`                                                                                                                                                    // API key or password (OS_PASSWORD).
+	SwiftLeavePartsOnError              string          `json:"swiftLeavePartsOnError" default:"false"`                                                                                                                      // If true avoid calling abort upload on a failure.
+	SwiftNoChunk                        string          `json:"swiftNoChunk" default:"false"`                                                                                                                                // Don't chunk files during streaming upload.
+	SwiftNoLargeObjects                 string          `json:"swiftNoLargeObjects" default:"false"`                                                                                                                         // Disable support for static and dynamic large objects
+	SwiftRegion                         string          `json:"swiftRegion"`                                                                                                                                                 // Region name - optional (OS_REGION_NAME).
+	SwiftStoragePolicy                  string          `json:"swiftStoragePolicy"`                                                                                                                                          // The storage policy to use when creating a new container.
+	SwiftStorageUrl                     string          `json:"swiftStorageUrl"`                                                                                                                                             // Storage URL - optional (OS_STORAGE_URL).
+	SwiftTenant                         string          `json:"swiftTenant"`                                                                                                                                                 // Tenant name - optional for v1 auth, this or tenant_id required otherwise (OS_TENANT_NAME or OS_PROJECT_NAME).
+	SwiftTenantDomain                   string          `json:"swiftTenantDomain"`                                                                                                                                           // Tenant domain - optional (v3 auth) (OS_PROJECT_DOMAIN_NAME).
+	SwiftTenantId                       string          `json:"swiftTenantId"`                                                                                                                                               // Tenant ID - optional for v1 auth, this or tenant required otherwise (OS_TENANT_ID).
+	SwiftUser                           string          `json:"swiftUser"`                                                                                                                                                   // User name to log in (OS_USERNAME).
+	SwiftUserId                         string          `json:"swiftUserId"`                                                                                                                                                 // User ID to log in - optional - most swift systems use user and leave this blank (v3 auth) (OS_USER_ID).
+	UptoboxAccessToken                  string          `json:"uptoboxAccessToken"`                                                                                                                                          // Your access token.
+	UptoboxEncoding                     string          `json:"uptoboxEncoding" default:"Slash,LtGt,DoubleQuote,BackQuote,Del,Ctl,LeftSpace,InvalidUtf8,Dot"`                                                                // The encoding for the backend.
+	WebdavBearerToken                   string          `json:"webdavBearerToken"`                                                                                                                                           // Bearer token instead of user/pass (e.g. a Macaroon).
+	WebdavBearerTokenCommand            string          `json:"webdavBearerTokenCommand"`                                                                                                                                    // Command to run to get a bearer token.
+	WebdavEncoding                      string          `json:"webdavEncoding"`                                                                                                                                              // The encoding for the backend.
+	WebdavHeaders                       string          `json:"webdavHeaders"`                                                                                                                                               // Set HTTP headers for all transactions.
+	WebdavPass                          string          `json:"webdavPass"`                                                                                                                                                  // Password.
+	WebdavUrl                           string          `json:"webdavUrl"`                                                                                                                                                   // URL of http host to connect to.
+	WebdavUser                          string          `json:"webdavUser"`                                                                                                                                                  // User name.
+	WebdavVendor                        string          `json:"webdavVendor"`                                                                                                                                                // Name of the WebDAV site/service/software you are using.
+	YandexAuthUrl                       string          `json:"yandexAuthUrl"`                                                                                                                                               // Auth server URL.
+	YandexClientId                      string          `json:"yandexClientId"`                                                                                                                                              // OAuth Client Id.
+	YandexClientSecret                  string          `json:"yandexClientSecret"`                                                                                                                                          // OAuth Client Secret.
+	YandexEncoding                      string          `json:"yandexEncoding" default:"Slash,Del,Ctl,InvalidUtf8,Dot"`                                                                                                      // The encoding for the backend.
+	YandexHardDelete                    string          `json:"yandexHardDelete" default:"false"`                                                                                                                            // Delete files permanently rather than putting them into the trash.
+	YandexToken                         string          `json:"yandexToken"`                                                                                                                                                 // OAuth Access Token as a JSON blob.
+	YandexTokenUrl                      string          `json:"yandexTokenUrl"`                                                                                                                                              // Token server url.
+	ZohoAuthUrl                         string          `json:"zohoAuthUrl"`                                                                                                                                                 // Auth server URL.
+	ZohoClientId                        string          `json:"zohoClientId"`                                                                                                                                                // OAuth Client Id.
+	ZohoClientSecret                    string          `json:"zohoClientSecret"`                                                                                                                                            // OAuth Client Secret.
+	ZohoEncoding                        string          `json:"zohoEncoding" default:"Del,Ctl,InvalidUtf8"`                                                                                                                  // The encoding for the backend.
+	ZohoRegion                          string          `json:"zohoRegion"`                                                                                                                                                  // Zoho region to connect to.
+	ZohoToken                           string          `json:"zohoToken"`                                                                                                                                                   // OAuth Access Token as a JSON blob.
+	ZohoTokenUrl                        string          `json:"zohoTokenUrl"`                                                                                                                                                // Token server url.
 }

--- a/handler/datasource/generate/add.go
+++ b/handler/datasource/generate/add.go
@@ -17,6 +17,10 @@ const header = `
 //lint:file-ignore U1000 Ignore all unused code, it's generated
 // Code generated. DO NOT EDIT.
 package datasource
+
+import (
+	"github.com/data-preservation-programs/singularity/model"
+)
 `
 
 const structTemplate = `
@@ -24,7 +28,8 @@ type {{.Name}} struct {
     SourcePath string ` + "`validate:\"required\" json:\"sourcePath\"`" + `// The path of the source to scan items
     DeleteAfterExport bool ` + "`validate:\"required\" json:\"deleteAfterExport\"`" + `// Delete the source after exporting to CAR files
     RescanInterval string ` + "`validate:\"required\" json:\"rescanInterval\"`" + `// Automatically rescan the source directory when this interval has passed from last successful scan
-    {{- range .Fields }}
+    ScanningState model.WorkState ` + "`validate:\"required\" json:\"scanningState\"`" + `// Starting state for scanning
+		{{- range .Fields }}
     {{.Name}} {{.Type}} {{.Tag}} // {{.Description}}
 	{{- end }}
 }
@@ -35,7 +40,8 @@ type {{.Name}} struct {
 		SourcePath string ` + "`validate:\"required\" json:\"sourcePath\"`" + `// The path of the source to scan items
     DeleteAfterExport bool ` + "`validate:\"optional\" json:\"deleteAfterExport\"`" + `// Delete the source after exporting to CAR files
     RescanInterval string ` + "`validate:\"optional\" json:\"rescanInterval\"`" + `// Automatically rescan the source directory when this interval has passed from last successful scan
-    {{- range .Fields }}
+    ScanningState model.WorkState ` + "`validate:\"optional\" json:\"scanningState\"`" + `// Starting state for scanning
+		{{- range .Fields }}
     {{.Name}} {{.Type}} {{.Tag}} // {{.Description}}
 	{{- end }}
 }

--- a/model/dataset.go
+++ b/model/dataset.go
@@ -177,6 +177,22 @@ const (
 	Error WorkState = "error"
 )
 
+var ErrInvalidWorkState = errors.New("invalid work state")
+
+func (ws *WorkState) Set(value string) error {
+	for _, state := range WorkStates {
+		if state == WorkState(value) {
+			*ws = state
+			return nil
+		}
+	}
+	return ErrInvalidWorkState
+}
+
+func (ws *WorkState) String() string {
+	return string(*ws)
+}
+
 type Worker struct {
 	ID            string    `gorm:"primaryKey;size:64" json:"id"`
 	WorkType      WorkType  `json:"workType"`


### PR DESCRIPTION
# Goals

Give users the ability to create datasources that are not immediately set to Ready for scanning state.

# Implementation

- expose parameter in CLI
- add processing to the handler
- add params to the add gen command