### PR TITLE
Enable testing for other database backend

### DIFF
--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -21,6 +21,8 @@ runs:
     - name: Setup MySQL database
       uses: shogo82148/actions-setup-mysql@v1
       with:
-        root-password: 'singularity'
         user: 'singularity'
         password: 'singularity'
+    - name: Create MySQL database
+      shell: bash
+      run: mysql -u root -e "create database singularity"

--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -13,14 +13,14 @@ runs:
         restore-keys: |
           ${{ matrix.os }}-golang-${{ matrix.go }}-
     - name: Setup PostgreSQL database
-      uses: harmon758/postgresql-action@v1
+      uses: ikalnytskyi/action-setup-postgres@v4
       with:
-        postgresql db: 'singularity'
-        postgresql user: 'singularity'
-        postgresql password: 'singularity'
+        username: 'singularity'
+        password: 'singularity'
+        database: 'singularity'
     - name: Setup MySQL database
-      uses: mirromutth/mysql-action@v1.1
+      uses: shogo82148/actions-setup-mysql@v1
       with:
-        mysql database: 'singularity'
-        mysql user: 'singularity'
-        mysql password: 'singularity'
+        root-password: 'singularity'
+        user: 'singularity'
+        password: 'singularity'

--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -12,3 +12,15 @@ runs:
         key: ${{ matrix.os }}-golang-${{ matrix.go }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ matrix.os }}-golang-${{ matrix.go }}-
+    - name: Setup PostgreSQL database
+      uses: harmon758/postgresql-action@v1
+      with:
+        postgresql db: 'singularity'
+        postgresql user: 'singularity'
+        postgresql password: 'singularity'
+    - name: Setup MySQL database
+      uses: mirromutth/mysql-action@v1.1
+      with:
+        mysql database: 'singularity'
+        mysql user: 'singularity'
+        mysql password: 'singularity'

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -20,8 +20,9 @@ import (
 func TestHandlePostSource(t *testing.T) {
 	tmp := os.TempDir()
 	tmp = strings.TrimSuffix(tmp, "/")
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/source/local/dataset/test", bytes.NewBuffer([]byte(
 		`{"deleteAfterExport":true,"sourcePath":"`+tmp+`","rescanInterval":"1h","caseInsensitive":"false","scanningState":"ready"}`,
@@ -56,8 +57,9 @@ func TestHandlePostSource(t *testing.T) {
 }
 
 func TestPushItem_InvalidID(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/source/1/push", bytes.NewBuffer([]byte(`{"path":"test.txt"}`)))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -77,8 +79,9 @@ func TestPushItem_InvalidID(t *testing.T) {
 }
 
 func TestPushItem_InvalidPayload(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/source/1/push", bytes.NewBuffer([]byte(`invalid payload`)))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -98,8 +101,9 @@ func TestPushItem_InvalidPayload(t *testing.T) {
 }
 
 func TestPushItem_SourceNotFound(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/source/1/push", bytes.NewBuffer([]byte(`{"path":"test.txt"}`)))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -119,8 +123,9 @@ func TestPushItem_SourceNotFound(t *testing.T) {
 }
 
 func TestPushItem_EntryNotFound(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/source/1/push", bytes.NewBuffer([]byte(`{"path":"test.txt"}`)))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -155,8 +160,9 @@ func TestPushItem_EntryNotFound(t *testing.T) {
 }
 
 func TestPushItem_DuplicateItem(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/source/1/push", bytes.NewBuffer([]byte(`{"path":"test.txt"}`)))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -209,8 +215,9 @@ func TestPushItem_DuplicateItem(t *testing.T) {
 }
 
 func TestPushItem(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/source/1/push", bytes.NewBuffer([]byte(`{"path":"test.txt"}`)))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -115,8 +115,9 @@ func testWithAllClients(ctx context.Context, t *testing.T, test func(*testing.T,
 		test(t, client)
 	})
 	t.Run("lib", func(t *testing.T) {
-		db, err := database.OpenWithDefaults("sqlite:" + t.TempDir() + "/singularity.db")
+		db, closer, err := database.OpenWithDefaults("sqlite:" + t.TempDir() + "/singularity.db")
 		require.NoError(t, err)
+		defer closer.Close()
 		client, err := libclient.NewClient(db)
 		require.NoError(t, err)
 		test(t, client)

--- a/client/swagger/models/model_dataset.go
+++ b/client/swagger/models/model_dataset.go
@@ -8,6 +8,7 @@ package models
 import (
 	"context"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -32,6 +33,9 @@ type ModelDataset struct {
 	// max size
 	MaxSize int64 `json:"maxSize,omitempty"`
 
+	// metadata
+	Metadata ModelMetadata `json:"metadata,omitempty"`
+
 	// name
 	Name string `json:"name,omitempty"`
 
@@ -47,11 +51,66 @@ type ModelDataset struct {
 
 // Validate validates this model dataset
 func (m *ModelDataset) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateMetadata(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
 	return nil
 }
 
-// ContextValidate validates this model dataset based on context it is used
+func (m *ModelDataset) validateMetadata(formats strfmt.Registry) error {
+	if swag.IsZero(m.Metadata) { // not required
+		return nil
+	}
+
+	if m.Metadata != nil {
+		if err := m.Metadata.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("metadata")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("metadata")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ContextValidate validate this model dataset based on the context it is used
 func (m *ModelDataset) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateMetadata(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *ModelDataset) contextValidateMetadata(ctx context.Context, formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Metadata) { // not required
+		return nil
+	}
+
+	if err := m.Metadata.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("metadata")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("metadata")
+		}
+		return err
+	}
+
 	return nil
 }
 

--- a/cmd/admin/init.go
+++ b/cmd/admin/init.go
@@ -10,10 +10,11 @@ var InitCmd = &cli.Command{
 	Name:  "init",
 	Usage: "Initialize the database",
 	Action: func(context *cli.Context) error {
-		db, err := database.OpenFromCLI(context)
+		db, closer, err := database.OpenFromCLI(context)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		return admin.InitHandler(db)
 	},
 }

--- a/cmd/admin/reset.go
+++ b/cmd/admin/reset.go
@@ -10,10 +10,11 @@ var ResetCmd = &cli.Command{
 	Name:  "reset",
 	Usage: "Reset the database",
 	Action: func(context *cli.Context) error {
-		db, err := database.OpenFromCLI(context)
+		db, closer, err := database.OpenFromCLI(context)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		return admin.ResetHandler(db)
 	},
 }

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -30,9 +30,7 @@ var App = &cli.App{
   Singularity supports multiple database backend: sqlite3, postgres, mysql
   Use '--database-connection-string' or $DATABASE_CONNECTION_STRING to specify the database connection string.
     Example for postgres  - postgres://user:pass@example.com:5432/dbname
-    Example for mysql     - mysql://user:pass@tcp(localhost:3306)/dbname?charset=ascii&parseTime=true
-                            Note: the database needs to be created using ascii Character Set:
-                              CREATE DATABASE <dbname> DEFAULT CHARACTER SET ascii
+    Example for mysql     - mysql://user:pass@tcp(localhost:3306)/dbname?parseTime=true
     Example for sqlite3   - sqlite:/absolute/path/to/database.db
                 or        - sqlite:relative/path/to/database.db
 

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -27,7 +27,7 @@ var App = &cli.App{
 	Name:  "singularity",
 	Usage: "A tool for large-scale clients with PB-scale data onboarding to Filecoin network",
 	Description: `Database Backend Support:
-  Singularity supports multiple database backend: sqlite3, postgres, mysql
+  Singularity supports multiple database backend: sqlite3, postgres, mysql5.7+
   Use '--database-connection-string' or $DATABASE_CONNECTION_STRING to specify the database connection string.
     Example for postgres  - postgres://user:pass@example.com:5432/dbname
     Example for mysql     - mysql://user:pass@tcp(localhost:3306)/dbname?parseTime=true

--- a/cmd/app_test.go
+++ b/cmd/app_test.go
@@ -938,6 +938,11 @@ func downloadPiece(t *testing.T, ctx context.Context, pieceCID string) []byte {
 	resp, err := client.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		t.Error("Download failed", string(body))
+	}
 	require.Less(t, resp.StatusCode, 300)
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)

--- a/cmd/dataset/addpiece.go
+++ b/cmd/dataset/addpiece.go
@@ -31,10 +31,11 @@ var AddPieceCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 
 		car, err := dataset.AddPieceHandler(
 			db, c.Args().Get(0), dataset.AddPieceRequest{

--- a/cmd/dataset/addwallet.go
+++ b/cmd/dataset/addwallet.go
@@ -12,10 +12,11 @@ var AddWalletCmd = &cli.Command{
 	Usage:     "Associate a wallet with the dataset. The wallet needs to be imported first using the `singularity wallet import` command.",
 	ArgsUsage: "DATASET_NAME WALLET_ADDRESS",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		wallet, err := wallet.AddWalletHandler(db, c.Args().Get(0), c.Args().Get(1))
 		if err != nil {
 			return err

--- a/cmd/dataset/create.go
+++ b/cmd/dataset/create.go
@@ -47,10 +47,11 @@ var CreateCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		dataset, err := dataset.CreateHandler(
 			db,
 			dataset.CreateRequest{

--- a/cmd/dataset/list.go
+++ b/cmd/dataset/list.go
@@ -11,10 +11,11 @@ var ListDatasetCmd = &cli.Command{
 	Name:  "list",
 	Usage: "List all datasets",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		datasets, err := dataset.ListHandler(
 			db,
 		)

--- a/cmd/dataset/listpieces.go
+++ b/cmd/dataset/listpieces.go
@@ -12,10 +12,11 @@ var ListPiecesCmd = &cli.Command{
 	Usage:     "List all pieces for the dataset that are available for deal making",
 	ArgsUsage: "<dataset_name>",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 
 		car, err := dataset.ListPiecesHandler(
 			db, c.Args().Get(0),

--- a/cmd/dataset/listwallet.go
+++ b/cmd/dataset/listwallet.go
@@ -12,10 +12,11 @@ var ListWalletCmd = &cli.Command{
 	Usage:     "List all associated wallets with the dataset",
 	ArgsUsage: "DATASET_NAME",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		wallets, err := wallet.ListWalletHandler(db, c.Args().Get(0))
 		if err != nil {
 			return err

--- a/cmd/dataset/remove.go
+++ b/cmd/dataset/remove.go
@@ -12,10 +12,11 @@ var RemoveDatasetCmd = &cli.Command{
 	Description: "Important! If the dataset is large, this command will take some time to remove all relevant data.",
 	ArgsUsage:   "<dataset_name>",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		return dataset.RemoveHandler(
 			db,
 			c.Args().Get(0),

--- a/cmd/dataset/removewallet.go
+++ b/cmd/dataset/removewallet.go
@@ -11,10 +11,11 @@ var RemoveWalletCmd = &cli.Command{
 	Usage:     "Remove an associated wallet from the dataset",
 	ArgsUsage: "DATASET_NAME WALLET_ADDRESS",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		return wallet.RemoveWalletHandler(db, c.Args().Get(0), c.Args().Get(1))
 	},
 }

--- a/cmd/dataset/update.go
+++ b/cmd/dataset/update.go
@@ -45,10 +45,11 @@ var UpdateCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		var maxSizeStr *string
 		if c.IsSet("max-size") {
 			s := c.String("max-size")

--- a/cmd/datasource/add.go
+++ b/cmd/datasource/add.go
@@ -48,10 +48,11 @@ var AddCmd = &cli.Command{
 		cmd.Action = func(c *cli.Context) error {
 			datasetName := c.Args().Get(0)
 			path := c.Args().Get(1)
-			db, err := database.OpenFromCLI(c)
+			db, closer, err := database.OpenFromCLI(c)
 			if err != nil {
 				return err
 			}
+			defer closer.Close()
 			dataset, err := database.FindDatasetByName(db, datasetName)
 			if err != nil {
 				return handler.InvalidParameterError{Err: err}

--- a/cmd/datasource/check.go
+++ b/cmd/datasource/check.go
@@ -14,10 +14,11 @@ var CheckCmd = &cli.Command{
 	Description: "This command will list entries in a data source under <sub_path>. " +
 		"If <sub_path> is not provided, it will use the root directory",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		entries, err := datasource.CheckSourceHandler(
 			db,
 			c.Context,

--- a/cmd/datasource/daggen.go
+++ b/cmd/datasource/daggen.go
@@ -15,10 +15,11 @@ var DagGenCmd = &cli.Command{
 		"  1. Lookup and download files or folders using unixfs path\n" +
 		"  2. Retrieve file that are splited across multiple pieces/deals",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		source, err := datasource.DagGenHandler(db, c.Args().Get(0))
 		if err != nil {
 			return err

--- a/cmd/datasource/inspect/chunkdetail.go
+++ b/cmd/datasource/inspect/chunkdetail.go
@@ -31,10 +31,11 @@ var ChunkDetailCmd = &cli.Command{
 	Usage:     "Get details about a specific chunk",
 	ArgsUsage: "<chunk_id>",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		result, err := inspect.GetSourceChunkDetailHandler(
 			db,
 			c.Args().Get(0),

--- a/cmd/datasource/inspect/chunks.go
+++ b/cmd/datasource/inspect/chunks.go
@@ -15,10 +15,11 @@ var ChunksCmd = &cli.Command{
 	Usage:     "Get all chunk details of a data source",
 	ArgsUsage: "<source_id>",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		result, err := inspect.GetSourceChunksHandler(
 			db,
 			c.Args().Get(0),

--- a/cmd/datasource/inspect/dags.go
+++ b/cmd/datasource/inspect/dags.go
@@ -12,10 +12,11 @@ var DagsCmd = &cli.Command{
 	Usage:     "Get all piece details for generated dags",
 	ArgsUsage: "<source_id>",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		cars, err := inspect.GetDagsHandler(
 			db,
 			c.Args().Get(0),

--- a/cmd/datasource/inspect/itemdetail.go
+++ b/cmd/datasource/inspect/itemdetail.go
@@ -14,10 +14,11 @@ var ItemDetailCmd = &cli.Command{
 	Usage:     "Get details about a specific item",
 	ArgsUsage: "<item_id>",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		result, err := inspect.GetSourceItemDetailHandler(
 			db,
 			c.Args().Get(0),

--- a/cmd/datasource/inspect/items.go
+++ b/cmd/datasource/inspect/items.go
@@ -13,10 +13,11 @@ var ItemsCmd = &cli.Command{
 	ArgsUsage:   "<source_id>",
 	Description: "This command will list all items in a data source. This may be very large list.",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		result, err := inspect.GetSourceItemsHandler(
 			db,
 			c.Args().Get(0),

--- a/cmd/datasource/inspect/path.go
+++ b/cmd/datasource/inspect/path.go
@@ -14,10 +14,11 @@ var PathCmd = &cli.Command{
 	Usage:     "Get details about a path within a data source",
 	ArgsUsage: "<source_id> <path>",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		result, err := inspect.GetPathHandler(
 			db,
 			c.Args().Get(0),

--- a/cmd/datasource/list.go
+++ b/cmd/datasource/list.go
@@ -17,10 +17,11 @@ var ListCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		datasetName := c.String("dataset")
 		sources, err := datasource.ListSourceByDatasetHandler(
 			db,

--- a/cmd/datasource/remove.go
+++ b/cmd/datasource/remove.go
@@ -11,10 +11,11 @@ var RemoveCmd = &cli.Command{
 	Usage:     "Remove a data source",
 	ArgsUsage: "<source_id>",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		return datasource.RemoveSourceHandler(
 			db,
 			c.Args().Get(0),

--- a/cmd/datasource/rescan.go
+++ b/cmd/datasource/rescan.go
@@ -13,10 +13,11 @@ var RescanCmd = &cli.Command{
 	ArgsUsage:   "<source_id>",
 	Description: "This command will clear any error of a data source and rescan it",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		source, err := datasource.RescanSourceHandler(
 			db,
 			c.Args().Get(0),

--- a/cmd/datasource/status.go
+++ b/cmd/datasource/status.go
@@ -15,10 +15,11 @@ var StatusCmd = &cli.Command{
 	Usage:     "Get the data preparation summary of a data source",
 	ArgsUsage: "<source_id>",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		result, err := datasource.GetSourceStatusHandler(
 			db,
 			c.Args().Get(0),

--- a/cmd/datasource/update.go
+++ b/cmd/datasource/update.go
@@ -38,10 +38,11 @@ var UpdateCmd = &cli.Command{
 		return newFlags
 	}(),
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		config := map[string]any{}
 		for _, name := range c.LocalFlagNames() {
 			if c.IsSet(name) {

--- a/cmd/deal/list.go
+++ b/cmd/deal/list.go
@@ -29,10 +29,11 @@ var ListCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		deals, err := deal.ListHandler(db, deal.ListDealRequest{})
 		if err != nil {
 			return err

--- a/cmd/deal/schedule/create.go
+++ b/cmd/deal/schedule/create.go
@@ -158,10 +158,11 @@ var CreateCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		cids := map[string]struct{}{}
 		for _, f := range c.StringSlice("allowed-piece-cid-file") {
 			cidsFromFile, err := readCIDsFromFile(f)

--- a/cmd/deal/schedule/list.go
+++ b/cmd/deal/schedule/list.go
@@ -11,10 +11,11 @@ var ListCmd = &cli.Command{
 	Name:  "list",
 	Usage: "List all deal making schedules",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		schedules, err := schedule.ListHandler(db)
 		if err != nil {
 			return err

--- a/cmd/deal/schedule/pause.go
+++ b/cmd/deal/schedule/pause.go
@@ -12,10 +12,11 @@ var PauseCmd = &cli.Command{
 	Usage:     "Pause a specific schedule",
 	ArgsUsage: "SCHEDULE_ID",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		schedule, err := schedule.PauseHandler(db, c.Args().Get(0))
 		if err != nil {
 			return err

--- a/cmd/deal/schedule/resume.go
+++ b/cmd/deal/schedule/resume.go
@@ -12,10 +12,11 @@ var ResumeCmd = &cli.Command{
 	Usage:     "Resume a specific schedule",
 	ArgsUsage: "SCHEDULE_ID",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		schedule, err := schedule.ResumeHandler(db, c.Args().Get(0))
 		if err != nil {
 			return err

--- a/cmd/deal/send-manual.go
+++ b/cmd/deal/send-manual.go
@@ -129,10 +129,11 @@ var SendManualCmd = &cli.Command{
 			FileSize:        cctx.Uint64("file-size"),
 		}
 		timeout := cctx.Duration("timeout")
-		db, err := database.OpenFromCLI(cctx)
+		db, closer, err := database.OpenFromCLI(cctx)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		ctx, cancel := context.WithTimeout(cctx.Context, timeout)
 		defer cancel()
 		h, err := util.InitHost(nil)

--- a/cmd/ez/prep.go
+++ b/cmd/ez/prep.go
@@ -77,10 +77,12 @@ var PrepCmd = &cli.Command{
 				return errors.Wrap(err, "failed to get absolute path")
 			}
 		}
-		db, err := database.Open("sqlite:"+databaseFile, &gorm.Config{})
+		db, closer, err := database.Open("sqlite:"+databaseFile, &gorm.Config{})
 		if err != nil {
 			return errors.Wrapf(err, "failed to open database %s", databaseFile)
 		}
+
+		defer closer.Close()
 
 		// Step 1, initialize the database
 		err = admin.InitHandler(db)

--- a/cmd/run/contentprovider.go
+++ b/cmd/run/contentprovider.go
@@ -43,10 +43,11 @@ var ContentProviderCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		if err := model.AutoMigrate(db); err != nil {
 			return err
 		}

--- a/cmd/run/datasetworker.go
+++ b/cmd/run/datasetworker.go
@@ -49,10 +49,11 @@ var DatasetWorkerCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		if err := model.AutoMigrate(db); err != nil {
 			return err
 		}

--- a/cmd/run/dealmaker.go
+++ b/cmd/run/dealmaker.go
@@ -12,10 +12,11 @@ var DealMakerCmd = &cli.Command{
 	Name:  "dealmaker",
 	Usage: "Start a deal making/tracking worker to process deal making",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		if err := model.AutoMigrate(db); err != nil {
 			return err
 		}

--- a/cmd/run/dealtracker.go
+++ b/cmd/run/dealtracker.go
@@ -29,10 +29,11 @@ var DealTrackerCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		if err := model.AutoMigrate(db); err != nil {
 			return err
 		}

--- a/cmd/run/spadeapi.go
+++ b/cmd/run/spadeapi.go
@@ -22,10 +22,11 @@ var SpadeAPICmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		if err := model.AutoMigrate(db); err != nil {
 			return err
 		}

--- a/cmd/wallet/addremote.go
+++ b/cmd/wallet/addremote.go
@@ -14,10 +14,11 @@ var AddRemoteCmd = &cli.Command{
 	ArgsUsage: "<address> <remote_peer>",
 	Flags:     []cli.Flag{},
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 
 		lotusClient := util.NewLotusClient(c.String("lotus-api"), c.String("lotus-token"))
 		w, err2 := wallet.AddRemoteHandler(db,

--- a/cmd/wallet/import.go
+++ b/cmd/wallet/import.go
@@ -13,10 +13,11 @@ var ImportCmd = &cli.Command{
 	Usage:     "Import a wallet from exported private key",
 	ArgsUsage: "PRIVATE_KEY",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 
 		lotusClient := util.NewLotusClient(c.String("lotus-api"), c.String("lotus-token"))
 		w, err := wallet.ImportHandler(db,

--- a/cmd/wallet/list.go
+++ b/cmd/wallet/list.go
@@ -11,10 +11,11 @@ var ListCmd = &cli.Command{
 	Name:  "list",
 	Usage: "List all imported wallets",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		wallets, err := wallet.ListHandler(db)
 		if err != nil {
 			return err

--- a/cmd/wallet/remove.go
+++ b/cmd/wallet/remove.go
@@ -11,10 +11,11 @@ var RemoveCmd = &cli.Command{
 	Usage:     "Remove a wallet",
 	ArgsUsage: "<address>",
 	Action: func(c *cli.Context) error {
-		db, err := database.OpenFromCLI(c)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
+		defer closer.Close()
 		return wallet.RemoveHandler(db, c.Args().Get(0))
 	},
 }

--- a/dashboard/src/model/model.ts
+++ b/dashboard/src/model/model.ts
@@ -24,6 +24,7 @@ export interface Dataset {
 	outputDirs: string[]
 	encryptionRecipients: string[]
 	encryptionScript: string
+	metadata: {[key: string]: string}
 	wallets: Wallet[] | undefined
 }
 export interface Source {

--- a/database/connstring_cgo.go
+++ b/database/connstring_cgo.go
@@ -3,6 +3,7 @@
 package database
 
 import (
+	"io"
 	"strings"
 
 	"github.com/ipfs/go-log/v2"
@@ -17,38 +18,59 @@ var ErrDatabaseNotSupported = errors.New("database not supported")
 
 var logger = log.Logger("database")
 
-func Open(connString string, config *gorm.Config) (*gorm.DB, error) {
+func Open(connString string, config *gorm.Config) (*gorm.DB, io.Closer, error) {
+	var db *gorm.DB
+	var closer io.Closer
+	var err error
 	if strings.HasPrefix(connString, "sqlite:") {
-		db, err := gorm.Open(sqlite.Open(connString[7:]), config)
+		db, err = gorm.Open(sqlite.Open(connString[7:]), config)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
+		}
+
+		closer, err = db.DB()
+		if err != nil {
+			return nil, nil, err
 		}
 
 		err = db.Exec("PRAGMA foreign_keys = ON").Error
 		if err != nil {
-			return nil, err
+			closer.Close()
+			return nil, nil, err
 		}
 
 		err = db.Exec("PRAGMA busy_timeout = 50000").Error
 		if err != nil {
-			return nil, err
+			closer.Close()
+			return nil, nil, err
 		}
 
 		err = db.Exec("PRAGMA journal_mode = WAL").Error
 		if err != nil {
-			return nil, err
+			closer.Close()
+			return nil, nil, err
 		}
 
-		return db, nil
+		return db, closer, nil
 	}
 
 	if strings.HasPrefix(connString, "postgres:") {
-		return gorm.Open(postgres.Open(connString), config)
+		db, err = gorm.Open(postgres.Open(connString), config)
+		if err != nil {
+			return nil, nil, err
+		}
+		closer, err = db.DB()
+		return db, closer, err
 	}
 
 	if strings.HasPrefix(connString, "mysql://") {
-		return gorm.Open(mysql.Open(connString[8:]), config)
+		db, err = gorm.Open(mysql.Open(connString[8:]), config)
+		if err != nil {
+			return nil, nil, err
+		}
+		closer, err = db.DB()
+		return db, closer, err
 	}
 
-	return nil, ErrDatabaseNotSupported
+	return nil, nil, ErrDatabaseNotSupported
 }

--- a/database/util_test.go
+++ b/database/util_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 func TestAutoMigrate(t *testing.T) {
-	db, err := OpenInMemory()
+	db, closer, err := OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	require.NotNil(t, db)
 }

--- a/docs/en/cli-reference/README.md
+++ b/docs/en/cli-reference/README.md
@@ -10,12 +10,10 @@ USAGE:
 
 DESCRIPTION:
    Database Backend Support:
-     Singularity supports multiple database backend: sqlite3, postgres, mysql
+     Singularity supports multiple database backend: sqlite3, postgres, mysql5.7+
      Use '--database-connection-string' or $DATABASE_CONNECTION_STRING to specify the database connection string.
        Example for postgres  - postgres://user:pass@example.com:5432/dbname
-       Example for mysql     - mysql://user:pass@tcp(localhost:3306)/dbname?charset=ascii&parseTime=true
-                               Note: the database needs to be created using ascii Character Set:
-                                 CREATE DATABASE <dbname> DEFAULT CHARACTER SET ascii
+       Example for mysql     - mysql://user:pass@tcp(localhost:3306)/dbname?parseTime=true
        Example for sqlite3   - sqlite:/absolute/path/to/database.db
                    or        - sqlite:relative/path/to/database.db
 

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -9894,6 +9894,9 @@ const docTemplate = `{
                 "maxSize": {
                     "type": "integer"
                 },
+                "metadata": {
+                    "$ref": "#/definitions/model.Metadata"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -9887,6 +9887,9 @@
                 "maxSize": {
                     "type": "integer"
                 },
+                "metadata": {
+                    "$ref": "#/definitions/model.Metadata"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -4889,6 +4889,8 @@ definitions:
         type: integer
       maxSize:
         type: integer
+      metadata:
+        $ref: '#/definitions/model.Metadata'
       name:
         type: string
       outputDirs:

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.7
 	github.com/go-openapi/swag v0.22.4
 	github.com/go-openapi/validate v0.22.1
+	github.com/go-sql-driver/mysql v1.7.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.3.0
 	github.com/hannahhoward/cbor-gen-for v0.0.0-20230214144701-5d17c9d5243c
@@ -122,7 +123,6 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/loads v0.21.2 // indirect
 	github.com/go-openapi/spec v0.20.9 // indirect
-	github.com/go-sql-driver/mysql v1.7.0 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect

--- a/handler/admin/init_test.go
+++ b/handler/admin/init_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 func TestInitHandler(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	defer model.DropAll(db)
 	require.NoError(t, InitHandler(db))
 }

--- a/handler/dataset/create_test.go
+++ b/handler/dataset/create_test.go
@@ -9,80 +9,90 @@ import (
 )
 
 func TestCreateHandler_NoDatasetName(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	defer model.DropAll(db)
 	_, err = CreateHandler(db, CreateRequest{})
 	require.ErrorContains(t, err, "name is required")
 }
 
 func TestCreateHandler_MaxSizeNotValid(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	defer model.DropAll(db)
 	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "not valid"})
 	require.ErrorContains(t, err, "invalid value for max-size")
 }
 
 func TestCreateHandler_PieceSizeNotValid(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	defer model.DropAll(db)
 	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", PieceSizeStr: "not valid"})
 	require.ErrorContains(t, err, "invalid value for piece-size")
 }
 
 func TestCreateHandler_PieceSizeNotPowerOfTwo(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	defer model.DropAll(db)
 	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", PieceSizeStr: "3GB"})
 	require.ErrorContains(t, err, "piece size must be a power of two")
 }
 
 func TestCreateHandler_PieceSizeTooLarge(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	defer model.DropAll(db)
 	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", PieceSizeStr: "128GiB"})
 	require.ErrorContains(t, err, "piece size cannot be larger than 64 GiB")
 }
 
 func TestCreateHandler_MaxSizeTooLarge(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	defer model.DropAll(db)
 	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "63.9GiB"})
 	require.ErrorContains(t, err, "max size needs to be reduced to leave space for padding")
 }
 
 func TestCreateHandler_OutDirDoesNotExist(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	defer model.DropAll(db)
 	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", OutputDirs: []string{"not exist"}})
 	require.ErrorContains(t, err, "output directory does not exist")
 }
 
 func TestCreateHandler_RecipientsScriptCannotBeUsedTogether(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	defer model.DropAll(db)
 	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", EncryptionRecipients: []string{"test"}, EncryptionScript: "test"})
 	require.ErrorContains(t, err, "encryption recipients and script cannot be used together")
 }
 
 func TestCreateHandler_EncryptionNeedsOutputDir(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	defer model.DropAll(db)
 	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", EncryptionRecipients: []string{"test"}})
 	require.ErrorContains(t, err, "encryption is not compatible with inline preparation")
 }
 
 func TestCreateHandler_Success(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	defer model.DropAll(db)
 	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB"})
 	require.NoError(t, err)

--- a/handler/deal/schedule/create_test.go
+++ b/handler/deal/schedule/create_test.go
@@ -73,15 +73,17 @@ var createRequest = CreateRequest{
 }
 
 func TestCreateHandler_DatasetNotFound(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), createRequest)
 	require.ErrorContains(t, err, "dataset not found")
 }
 
 func TestCreateHandler_InvalidStartDelay(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	require.NoError(t, db.Create(&model.Dataset{Name: "test"}).Error)
 	badRequest := createRequest
 	badRequest.StartDelay = "1year"
@@ -90,8 +92,9 @@ func TestCreateHandler_InvalidStartDelay(t *testing.T) {
 }
 
 func TestCreateHandler_InvalidDuration(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	require.NoError(t, db.Create(&model.Dataset{Name: "test"}).Error)
 	badRequest := createRequest
 	badRequest.Duration = "1year"
@@ -100,8 +103,9 @@ func TestCreateHandler_InvalidDuration(t *testing.T) {
 }
 
 func TestCreateHandler_InvalidScheduleInterval(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	require.NoError(t, db.Create(&model.Dataset{Name: "test"}).Error)
 	badRequest := createRequest
 	badRequest.ScheduleCron = "1year"
@@ -110,8 +114,9 @@ func TestCreateHandler_InvalidScheduleInterval(t *testing.T) {
 }
 
 func TestCreateHandler_InvalidScheduleDealSize(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	err = db.Create(&model.Dataset{Name: "test"}).Error
 	require.NoError(t, err)
 	badRequest := createRequest
@@ -121,8 +126,9 @@ func TestCreateHandler_InvalidScheduleDealSize(t *testing.T) {
 }
 
 func TestCreateHandler_InvalidTotalDealSize(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	err = db.Create(&model.Dataset{Name: "test"}).Error
 	require.NoError(t, err)
 	badRequest := createRequest
@@ -132,8 +138,9 @@ func TestCreateHandler_InvalidTotalDealSize(t *testing.T) {
 }
 
 func TestCreateHandler_InvalidPendingDealSize(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	err = db.Create(&model.Dataset{Name: "test"}).Error
 	require.NoError(t, err)
 	badRequest := createRequest
@@ -143,8 +150,9 @@ func TestCreateHandler_InvalidPendingDealSize(t *testing.T) {
 }
 
 func TestCreateHandler_InvalidAllowedPieceCID_NotCID(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	err = db.Create(&model.Dataset{Name: "test"}).Error
 	require.NoError(t, err)
 	badRequest := createRequest
@@ -154,8 +162,9 @@ func TestCreateHandler_InvalidAllowedPieceCID_NotCID(t *testing.T) {
 }
 
 func TestCreateHandler_InvalidAllowedPieceCID_NotCommp(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	err = db.Create(&model.Dataset{Name: "test"}).Error
 	require.NoError(t, err)
 	badRequest := createRequest
@@ -165,8 +174,9 @@ func TestCreateHandler_InvalidAllowedPieceCID_NotCommp(t *testing.T) {
 }
 
 func TestCreateHandler_NoAssociatedWallet(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	err = db.Create(&model.Dataset{Name: "test"}).Error
 	require.NoError(t, err)
 	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), createRequest)
@@ -174,8 +184,9 @@ func TestCreateHandler_NoAssociatedWallet(t *testing.T) {
 }
 
 func TestCreateHandler_InvalidProvider(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	err = db.Create(&model.Dataset{Name: "test"}).Error
 	require.NoError(t, err)
 	err = db.Create(&model.Wallet{ID: "f01"}).Error
@@ -190,8 +201,9 @@ func TestCreateHandler_InvalidProvider(t *testing.T) {
 }
 
 func TestCreateHandler_Success(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	err = db.Create(&model.Dataset{Name: "test"}).Error
 	require.NoError(t, err)
 	err = db.Create(&model.Wallet{ID: "f01"}).Error

--- a/handler/deal/send-manual_test.go
+++ b/handler/deal/send-manual_test.go
@@ -42,8 +42,9 @@ func TestSendManualHandler_WalletNotFound(t *testing.T) {
 		Address: "f10000",
 	}
 
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	err = db.Create(&wallet).Error
 	require.NoError(t, err)
 	ctx := context.Background()
@@ -60,8 +61,9 @@ func TestSendManualHandler_InvalidPieceCID(t *testing.T) {
 		Address: "f10000",
 	}
 
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	err = db.Create(&wallet).Error
 	require.NoError(t, err)
 	ctx := context.Background()
@@ -80,8 +82,9 @@ func TestSendManualHandler_InvalidPieceCID_NOTCOMMP(t *testing.T) {
 		Address: "f10000",
 	}
 
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	err = db.Create(&wallet).Error
 	require.NoError(t, err)
 	ctx := context.Background()
@@ -100,8 +103,9 @@ func TestSendManualHandler_InvalidPieceSize(t *testing.T) {
 		Address: "f10000",
 	}
 
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	err = db.Create(&wallet).Error
 	require.NoError(t, err)
 	ctx := context.Background()
@@ -120,8 +124,9 @@ func TestSendManualHandler_InvalidPieceSize_NotPowerOfTwo(t *testing.T) {
 		Address: "f10000",
 	}
 
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	err = db.Create(&wallet).Error
 	require.NoError(t, err)
 	ctx := context.Background()
@@ -140,8 +145,9 @@ func TestSendManualHandler_InvalidRootCID(t *testing.T) {
 		Address: "f10000",
 	}
 
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	err = db.Create(&wallet).Error
 	require.NoError(t, err)
 	ctx := context.Background()
@@ -160,8 +166,9 @@ func TestSendManualHandler_InvalidDuration(t *testing.T) {
 		Address: "f10000",
 	}
 
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	err = db.Create(&wallet).Error
 	require.NoError(t, err)
 	ctx := context.Background()
@@ -180,8 +187,9 @@ func TestSendManualHandler_InvalidStartDelay(t *testing.T) {
 		Address: "f10000",
 	}
 
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	err = db.Create(&wallet).Error
 	require.NoError(t, err)
 	ctx := context.Background()
@@ -200,8 +208,9 @@ func TestSendManualHandler(t *testing.T) {
 		Address: "f10000",
 	}
 
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	err = db.Create(&wallet).Error
 	require.NoError(t, err)
 	ctx := context.Background()

--- a/model/migrate.go
+++ b/model/migrate.go
@@ -37,6 +37,11 @@ func AutoMigrate(db *gorm.DB) error {
 		return errors.Wrap(err, "failed to auto migrate")
 	}
 
+	err = CreateIndexes(db)
+	if err != nil {
+		return errors.Wrap(err, "failed to create indexes")
+	}
+
 	logger.Debug("Creating instance id")
 	err = db.Clauses(clause.OnConflict{
 		DoNothing: true,

--- a/model/replication.go
+++ b/model/replication.go
@@ -58,19 +58,19 @@ type Deal struct {
 	DealID           *uint64   `gorm:"unique"                                             json:"dealId"`
 	DatasetID        *uint32   `json:"datasetId"`
 	Dataset          *Dataset  `gorm:"foreignKey:DatasetID;constraint:OnDelete:SET NULL"  json:"dataset,omitempty"  swaggerignore:"true"`
-	State            DealState `gorm:"index:idx_stat;index:idx_pending;size:16"           json:"state"`
-	ClientID         string    `gorm:"index:idx_pending;size:16"                          json:"clientId"`
+	State            DealState `gorm:"index:idx_stat;index:idx_pending"                   json:"state"`
+	ClientID         string    `gorm:"index:idx_pending"                                  json:"clientId"`
 	Wallet           *Wallet   `gorm:"foreignKey:ClientID;constraint:OnDelete:SET NULL"   json:"wallet,omitempty"   swaggerignore:"true"`
-	Provider         string    `gorm:"index:idx_stat;size:16"                             json:"provider"`
+	Provider         string    `gorm:"index:idx_stat"                                     json:"provider"`
 	ProposalID       string    `json:"proposalId"`
 	Label            string    `json:"label"`
-	PieceCID         CID       `gorm:"column:piece_cid;index"                             json:"pieceCid"`
+	PieceCID         CID       `gorm:"column:piece_cid;index;size:255"                    json:"pieceCid"`
 	PieceSize        int64     `json:"pieceSize"`
 	StartEpoch       int32     `json:"startEpoch"`
 	EndEpoch         int32     `json:"endEpoch"`
 	SectorStartEpoch int32     `json:"sectorStartEpoch"`
 	Price            string    `json:"price"`
-	Verified         bool      `gorm:"index:idx_pending"                                  json:"verified"`
+	Verified         bool      `json:"verified"`
 	ErrorMessage     string    `json:"errorMessage"`
 	ScheduleID       *uint32   `json:"scheduleId"`
 	Schedule         *Schedule `gorm:"foreignKey:ScheduleID;constraint:OnDelete:SET NULL" json:"schedule,omitempty" swaggerignore:"true"`
@@ -111,10 +111,10 @@ type Schedule struct {
 }
 
 type Wallet struct {
-	ID         string `gorm:"primaryKey;size:16"   json:"id"`      // ID is the short ID of the wallet
-	Address    string `gorm:"unique;size:256"      json:"address"` // Address is the Filecoin full address of the wallet
-	PrivateKey string `json:"privateKey,omitempty"`                // PrivateKey is the private key of the wallet
-	RemotePeer string `json:"remotePeer,omitempty"`                // RemotePeer is the remote peer ID of the wallet, for remote signing purpose
+	ID         string `gorm:"primaryKey;size:15"   json:"id"` // ID is the short ID of the wallet
+	Address    string `json:"address"`                        // Address is the Filecoin full address of the wallet
+	PrivateKey string `json:"privateKey,omitempty"`           // PrivateKey is the private key of the wallet
+	RemotePeer string `json:"remotePeer,omitempty"`           // RemotePeer is the remote peer ID of the wallet, for remote signing purpose
 }
 
 type WalletAssignment struct {

--- a/replication/wallet_test.go
+++ b/replication/wallet_test.go
@@ -42,8 +42,9 @@ func (m *MockRPCClient) CallBatchRaw(ctx context.Context, requests jsonrpc.RPCRe
 }
 
 func TestDatacapWalletChooser_Choose(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	lotusClient := new(MockRPCClient)
 
 	// Set up the test data

--- a/service/contentprovider/contentprovider.go
+++ b/service/contentprovider/contentprovider.go
@@ -137,6 +137,7 @@ func (s *ContentProviderService) Start(ctx context.Context) error {
 			logger.Fatal(err)
 		}
 	}
+	httpDone := make(chan struct{})
 	if s.bind != "" {
 		e := echo.New()
 		e.Use(middleware.GzipWithConfig(middleware.GzipConfig{}))
@@ -193,6 +194,7 @@ func (s *ContentProviderService) Start(ctx context.Context) error {
 			if err := e.Shutdown(shutdownCtx); err != nil {
 				fmt.Printf("Error shutting down the server: %v\n", err)
 			}
+			httpDone <- struct{}{}
 		}()
 
 		err := e.Start(s.bind)
@@ -202,6 +204,9 @@ func (s *ContentProviderService) Start(ctx context.Context) error {
 	}
 
 	<-ctx.Done()
+	if s.bind != "" {
+		<-httpDone
+	}
 	return nil
 }
 

--- a/service/datasetworker/datasetworker_test.go
+++ b/service/datasetworker/datasetworker_test.go
@@ -14,8 +14,9 @@ import (
 )
 
 func TestDatasetWorkerRun(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	worker := NewDatasetWorker(db, DatasetWorkerConfig{
 		Concurrency:    1,
 		ExitOnComplete: true,
@@ -39,8 +40,9 @@ func TestDatasetWorkerThread_pack(t *testing.T) {
 	require.NoError(t, err)
 	err = file.Close()
 	require.NoError(t, err)
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	thread := DatasetWorkerThread{
 		id:                        uuid.New(),
 		db:                        db,
@@ -165,8 +167,9 @@ func TestDatasetWorkerThread_pack(t *testing.T) {
 
 func TestDatasetWorkerThread_scan(t *testing.T) {
 	ctx := context.Background()
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	thread := DatasetWorkerThread{
 		id:                        uuid.New(),
 		db:                        db,
@@ -220,8 +223,9 @@ func TestDatasetWorkerThread_scan(t *testing.T) {
 }
 
 func TestDatasetWorkerThread_findPackWork(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	thread := DatasetWorkerThread{
 		id:                        uuid.New(),
 		db:                        db,
@@ -323,8 +327,9 @@ func TestDatasetWorkerThread_findPackWork(t *testing.T) {
 }
 
 func TestDatasetWorkerThread_findScanWork(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	thread := DatasetWorkerThread{
 		id:                        uuid.New(),
 		db:                        db,

--- a/service/dealmaker/dealmaker.go
+++ b/service/dealmaker/dealmaker.go
@@ -382,6 +382,9 @@ func (d *DealMakerService) Run(ctx context.Context) error {
 			d.cleanup()
 			return cli.Exit("received signal", 130)
 		case <-ctx.Done():
+			for _, cancel := range d.activeScheduleCancelFunc {
+				cancel()
+			}
 			//nolint:errcheck
 			d.cleanup()
 			return ctx.Err()

--- a/service/dealmaker/dealmaker_test.go
+++ b/service/dealmaker/dealmaker_test.go
@@ -52,8 +52,9 @@ func (m *MockDealMaker) MakeDeal(ctx context.Context, walletObj model.Wallet, ca
 }
 
 func TestDealMakerService_StartRun(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	service, err := NewDealMakerService(db, "https://api.node.glif.io", "")
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -69,8 +70,9 @@ func TestDealMakerService_StartRun(t *testing.T) {
 }
 
 func TestDealMakerService_Cron(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	service, err := NewDealMakerService(db, "https://api.node.glif.io", "")
 	require.NoError(t, err)
 	mockDealmaker := new(MockDealMaker)
@@ -149,8 +151,9 @@ func TestDealMakerService_Cron(t *testing.T) {
 }
 
 func TestDealMakerService_NewScheduleOneOff(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	service, err := NewDealMakerService(db, "https://api.node.glif.io", "")
 	require.NoError(t, err)
 	mockDealmaker := new(MockDealMaker)

--- a/service/dealtracker/dealtracker_test.go
+++ b/service/dealtracker/dealtracker_test.go
@@ -99,8 +99,9 @@ func TestTrackDeal(t *testing.T) {
 }
 
 func TestShouldTrackDeal(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	tracker := NewDealTracker(db, time.Second, "", "", "")
 	should, err := tracker.shouldTrackDeal(context.Background())
 	require.NoError(t, err)
@@ -118,8 +119,9 @@ func TestShouldTrackDeal(t *testing.T) {
 }
 
 func TestRunOnce(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	err = db.Create(&model.Wallet{
 		ID:      "t0100",
 		Address: "t3xxx",

--- a/service/healthcheck/healthcheck_test.go
+++ b/service/healthcheck/healthcheck_test.go
@@ -13,8 +13,9 @@ import (
 
 func TestHealthCheck(t *testing.T) {
 	req := require.New(t)
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	defer database.DropAll(db)
 
 	id := uuid.New()

--- a/store/item_reference_test.go
+++ b/store/item_reference_test.go
@@ -30,8 +30,9 @@ func TestItemReferenceBlockStore(t *testing.T) {
 	require.NoError(t, err)
 
 	// Initialize a new in-memory SQLite database for testing
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	defer database.DropAll(db)
 
 	// Create a new instance of the CarReferenceBlockStore

--- a/store/piece_store_test.go
+++ b/store/piece_store_test.go
@@ -14,8 +14,9 @@ import (
 )
 
 func TestReadAt2(t *testing.T) {
-	db, err := database.OpenInMemory()
+	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
+	defer closer.Close()
 	defer database.DropAll(db)
 
 	car := model.Car{


### PR DESCRIPTION
Enables testing with mysql and postgres backend and fixes below
* opening database using connections tring will also return an io.Closer, which is useful for tests otherwise, too many connections are open during testing causing test failure
* API service will now wait for all requests to finish before closing the database
* database model change
  * dataset now contains a Metadata (string to string map) to store custom attributes for this dataset. This will be used for displaying attributes such as author, license, website for a dataset at the frontend
  * remove not useful size constraints
  * remove not useful unique constraints
  * added a custom index for mysql - mysql has an index length limit so we need to create the index in a different way