### PR TITLE
refactor: invert `PushItem()` dependency to facilitate chunk handler

### DIFF
--- a/handler/datasource/logger.go
+++ b/handler/datasource/logger.go
@@ -1,0 +1,5 @@
+package datasource
+
+import "github.com/ipfs/go-log/v2"
+
+var logger = log.Logger("singularity/handler/datasource")

--- a/handler/datasource/pushitem.go
+++ b/handler/datasource/pushitem.go
@@ -2,14 +2,18 @@ package datasource
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"strings"
+	"time"
 
+	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/datasource"
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
-	"github.com/data-preservation-programs/singularity/service/datasetworker"
-	fs2 "github.com/rclone/rclone/fs"
+	"github.com/data-preservation-programs/singularity/util"
+	"github.com/pkg/errors"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/hash"
 	"gorm.io/gorm"
 )
 
@@ -65,12 +69,12 @@ func pushItemHandler(
 		return nil, handler.InvalidParameterError{Err: err}
 	}
 
-	obj, ok := entry.(fs2.ObjectInfo)
+	obj, ok := entry.(fs.ObjectInfo)
 	if !ok {
 		return nil, handler.NewInvalidParameterErr(fmt.Sprintf("%s is not an object", itemInfo.Path))
 	}
 
-	item, itemParts, err := datasetworker.PushItem(ctx, db, obj, source, *source.Dataset, map[string]uint64{})
+	item, itemParts, err := PushItem(ctx, db, obj, source, *source.Dataset, map[string]uint64{})
 
 	if err != nil {
 		return nil, err
@@ -83,4 +87,158 @@ func pushItemHandler(
 	item.ItemParts = itemParts
 
 	return item, nil
+}
+
+func PushItem(ctx context.Context, db *gorm.DB, obj fs.ObjectInfo,
+	source model.Source, dataset model.Dataset,
+	directoryCache map[string]uint64) (*model.Item, []model.ItemPart, error) {
+	logger.Debugw("pushed item", "item", obj.Remote(), "source_id", source.ID, "dataset_id", dataset.ID)
+	db = db.WithContext(ctx)
+	splitSize := MaxSizeToSplitSize(dataset.MaxSize)
+	rootID, err := source.RootDirectoryID(db)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to get root directory id")
+	}
+	size, hashValue, lastModified, lastModifiedReliable := ExtractFromFsObject(ctx, obj)
+	existing := int64(0)
+	logger.Debugw("finding if the item already exists",
+		"source_id", source.ID, "path", obj.Remote(),
+		"hash", hashValue, "size", size, "last_modified_reliable", lastModifiedReliable, "last_modified", lastModified.UnixNano())
+	err = db.Model(&model.Item{}).Where(
+		"source_id = ? AND path = ? AND "+
+			"(( hash = ? AND hash != '' ) "+
+			"OR (size = ? AND (? OR last_modified_timestamp_nano = ?)))",
+		source.ID, obj.Remote(),
+		hashValue, size, !lastModifiedReliable, lastModified.UnixNano(),
+	).Count(&existing).Error
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to check existing item")
+	}
+	if existing > 0 {
+		logger.Debugw("item already exists", "source_id", source.ID, "path", obj.Remote())
+		return nil, nil, nil
+	}
+	item := model.Item{
+		SourceID:                  source.ID,
+		Path:                      obj.Remote(),
+		Size:                      size,
+		LastModifiedTimestampNano: lastModified.UnixNano(),
+		Hash:                      hashValue,
+	}
+	logger.Debugw("new item", "item", item)
+	err = EnsureParentDirectories(db, &item, rootID, directoryCache)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to ensure parent directories")
+	}
+	var itemParts []model.ItemPart
+	err = database.DoRetry(func() error {
+		return db.Transaction(func(db *gorm.DB) error {
+			err := db.Create(&item).Error
+			if err != nil {
+				return errors.Wrap(err, "failed to create item")
+			}
+			if dataset.UseEncryption() {
+				itemParts = append(itemParts, model.ItemPart{
+					ItemID: item.ID,
+					Offset: 0,
+					Length: item.Size,
+				})
+			} else {
+				offset := int64(0)
+				for {
+					length := splitSize
+					if item.Size-offset < length {
+						length = item.Size - offset
+					}
+					itemParts = append(itemParts, model.ItemPart{
+						ItemID: item.ID,
+						Offset: offset,
+						Length: length,
+					})
+					offset += length
+					if offset >= item.Size {
+						break
+					}
+				}
+			}
+			err = db.Create(&itemParts).Error
+			if err != nil {
+				return errors.Wrap(err, "failed to create item parts")
+			}
+			return nil
+		})
+	})
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to create item")
+	}
+	return &item, itemParts, nil
+}
+
+func EnsureParentDirectories(db *gorm.DB,
+	item *model.Item, rootDirID uint64,
+	directoryCache map[string]uint64) error {
+	if item.DirectoryID != nil {
+		return nil
+	}
+	last := rootDirID
+	segments := strings.Split(item.Path, "/")
+	for i, segment := range segments[:len(segments)-1] {
+		p := strings.Join(segments[:i+1], "/")
+		if dirID, ok := directoryCache[p]; ok {
+			last = dirID
+			continue
+		}
+		newDir := model.Directory{
+			SourceID: item.SourceID,
+			Name:     segment,
+			ParentID: &last,
+		}
+		logger.Debugw("creating directory", "path", p, "dir", newDir)
+		err := database.DoRetry(func() error {
+			return db.Transaction(func(db *gorm.DB) error {
+				return db.
+					Where("parent_id = ? AND name = ?", last, segment).
+					FirstOrCreate(&newDir).Error
+			})
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to create directory")
+		}
+		directoryCache[p] = newDir.ID
+		last = newDir.ID
+	}
+
+	item.DirectoryID = &last
+	return nil
+}
+
+func MaxSizeToSplitSize(m int64) int64 {
+	r := util.NextPowerOfTwo(uint64(m)) / 4
+	if r > 1<<30 {
+		r = 1 << 30
+	}
+
+	return int64(r)
+}
+
+func ExtractFromFsObject(ctx context.Context, info fs.ObjectInfo) (size int64, hashValue string, lastModified time.Time, lastModifiedReliable bool) {
+	// last modified can be time.Now() if fetch failed so it may not be reliable.
+	// This usually won't happen for most cloud provider i.e. S3
+	// Because during scanning, the modified time is already fetched.
+	lastModified = info.ModTime(ctx)
+	// If last modified is not reliable, we will skip using it as a way to determine if the file has already scanned
+	lastModifiedReliable = !lastModified.IsZero() && lastModified.Before(time.Now().Add(-time.Millisecond))
+	supportedHash := info.Fs().Hashes().GetOne()
+	// For local file system, rclone is actually hashing the file stream which is not efficient.
+	// So we skip hashing for local file system.
+	// For some of the remote storage, there may not have any supported hash type.
+	if supportedHash != hash.None && info.Fs().Name() != "local" {
+		var err error
+		hashValue, err = info.Hash(ctx, supportedHash)
+		if err != nil {
+			logger.Errorw("failed to hash", "error", err)
+		}
+	}
+	size = info.Size()
+	return
 }

--- a/service/datasetworker/scan.go
+++ b/service/datasetworker/scan.go
@@ -2,134 +2,14 @@ package datasetworker
 
 import (
 	"context"
-	"strings"
-	"time"
 
 	"github.com/data-preservation-programs/singularity/database"
+	"github.com/data-preservation-programs/singularity/handler/datasource"
 	"github.com/data-preservation-programs/singularity/model"
-	"github.com/data-preservation-programs/singularity/util"
 	"github.com/pkg/errors"
-	"github.com/rclone/rclone/fs"
-	"github.com/rclone/rclone/fs/hash"
 	"github.com/rjNemo/underscore"
 	"gorm.io/gorm"
 )
-
-func MaxSizeToSplitSize(m int64) int64 {
-	r := util.NextPowerOfTwo(uint64(m)) / 4
-	if r > 1<<30 {
-		r = 1 << 30
-	}
-
-	return int64(r)
-}
-
-func ExtractFromFsObject(ctx context.Context, info fs.ObjectInfo) (size int64, hashValue string, lastModified time.Time, lastModifiedReliable bool) {
-	// last modified can be time.Now() if fetch failed so it may not be reliable.
-	// This usually won't happen for most cloud provider i.e. S3
-	// Because during scanning, the modified time is already fetched.
-	lastModified = info.ModTime(ctx)
-	// If last modified is not reliable, we will skip using it as a way to determine if the file has already scanned
-	lastModifiedReliable = !lastModified.IsZero() && lastModified.Before(time.Now().Add(-time.Millisecond))
-	supportedHash := info.Fs().Hashes().GetOne()
-	// For local file system, rclone is actually hashing the file stream which is not efficient.
-	// So we skip hashing for local file system.
-	// For some of the remote storage, there may not have any supported hash type.
-	if supportedHash != hash.None && info.Fs().Name() != "local" {
-		var err error
-		hashValue, err = info.Hash(ctx, supportedHash)
-		if err != nil {
-			logger.Errorw("failed to hash", "error", err)
-		}
-	}
-	size = info.Size()
-	return
-}
-
-func PushItem(ctx context.Context, db *gorm.DB, obj fs.ObjectInfo,
-	source model.Source, dataset model.Dataset,
-	directoryCache map[string]uint64) (*model.Item, []model.ItemPart, error) {
-	logger.Debugw("pushed item", "item", obj.Remote(), "source_id", source.ID, "dataset_id", dataset.ID)
-	db = db.WithContext(ctx)
-	splitSize := MaxSizeToSplitSize(dataset.MaxSize)
-	rootID, err := source.RootDirectoryID(db)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to get root directory id")
-	}
-	size, hashValue, lastModified, lastModifiedReliable := ExtractFromFsObject(ctx, obj)
-	existing := int64(0)
-	logger.Debugw("finding if the item already exists",
-		"source_id", source.ID, "path", obj.Remote(),
-		"hash", hashValue, "size", size, "last_modified_reliable", lastModifiedReliable, "last_modified", lastModified.UnixNano())
-	err = db.Model(&model.Item{}).Where(
-		"source_id = ? AND path = ? AND "+
-			"(( hash = ? AND hash != '' ) "+
-			"OR (size = ? AND (? OR last_modified_timestamp_nano = ?)))",
-		source.ID, obj.Remote(),
-		hashValue, size, !lastModifiedReliable, lastModified.UnixNano(),
-	).Count(&existing).Error
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to check existing item")
-	}
-	if existing > 0 {
-		logger.Debugw("item already exists", "source_id", source.ID, "path", obj.Remote())
-		return nil, nil, nil
-	}
-	item := model.Item{
-		SourceID:                  source.ID,
-		Path:                      obj.Remote(),
-		Size:                      size,
-		LastModifiedTimestampNano: lastModified.UnixNano(),
-		Hash:                      hashValue,
-	}
-	logger.Debugw("new item", "item", item)
-	err = EnsureParentDirectories(db, &item, rootID, directoryCache)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to ensure parent directories")
-	}
-	var itemParts []model.ItemPart
-	err = database.DoRetry(func() error {
-		return db.Transaction(func(db *gorm.DB) error {
-			err := db.Create(&item).Error
-			if err != nil {
-				return errors.Wrap(err, "failed to create item")
-			}
-			if dataset.UseEncryption() {
-				itemParts = append(itemParts, model.ItemPart{
-					ItemID: item.ID,
-					Offset: 0,
-					Length: item.Size,
-				})
-			} else {
-				offset := int64(0)
-				for {
-					length := splitSize
-					if item.Size-offset < length {
-						length = item.Size - offset
-					}
-					itemParts = append(itemParts, model.ItemPart{
-						ItemID: item.ID,
-						Offset: offset,
-						Length: length,
-					})
-					offset += length
-					if offset >= item.Size {
-						break
-					}
-				}
-			}
-			err = db.Create(&itemParts).Error
-			if err != nil {
-				return errors.Wrap(err, "failed to create item parts")
-			}
-			return nil
-		})
-	})
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to create item")
-	}
-	return &item, itemParts, nil
-}
 
 // scan scans the data source and inserts the chunking strategy back to database
 // scanSource is true if the source will be actually scanned in addition to just picking up remaining ones
@@ -169,7 +49,7 @@ func (w *DatasetWorkerThread) scan(ctx context.Context, source model.Source, sca
 			continue
 		}
 
-		item, itemParts, err := PushItem(ctx, w.db, entry.Info, source, dataset, w.directoryCache)
+		item, itemParts, err := datasource.PushItem(ctx, w.db, entry.Info, source, dataset, w.directoryCache)
 		if err != nil {
 			return errors.Wrap(err, "failed to push item")
 		}
@@ -284,43 +164,5 @@ func (w *DatasetWorkerThread) chunkOnce(
 	}
 	remaining.itemParts = remaining.itemParts[si:]
 	remaining.carSize = remaining.carSize - s + carHeaderSize
-	return nil
-}
-
-func EnsureParentDirectories(db *gorm.DB,
-	item *model.Item, rootDirID uint64,
-	directoryCache map[string]uint64) error {
-	if item.DirectoryID != nil {
-		return nil
-	}
-	last := rootDirID
-	segments := strings.Split(item.Path, "/")
-	for i, segment := range segments[:len(segments)-1] {
-		p := strings.Join(segments[:i+1], "/")
-		if dirID, ok := directoryCache[p]; ok {
-			last = dirID
-			continue
-		}
-		newDir := model.Directory{
-			SourceID: item.SourceID,
-			Name:     segment,
-			ParentID: &last,
-		}
-		logger.Debugw("creating directory", "path", p, "dir", newDir)
-		err := database.DoRetry(func() error {
-			return db.Transaction(func(db *gorm.DB) error {
-				return db.
-					Where("parent_id = ? AND name = ?", last, segment).
-					FirstOrCreate(&newDir).Error
-			})
-		})
-		if err != nil {
-			return errors.Wrap(err, "failed to create directory")
-		}
-		directoryCache[p] = newDir.ID
-		last = newDir.ID
-	}
-
-	item.DirectoryID = &last
 	return nil
 }


### PR DESCRIPTION
Reason: need to add a handler to the client to manually chunk items in order to complete the test for #151, but it will require a dependency from `datasetworker` to `handler/datasource`. `PushItem()` needs to be moved to `handler/datasource` to prevent a circular dependency there.