### PR TITLE
Put in a retry loop at the start of TestRunAPI 

### DIFF
--- a/cmd/app_test.go
+++ b/cmd/app_test.go
@@ -290,12 +290,18 @@ func TestRunAPI(t *testing.T) {
 			require.ErrorContains(t, err, "Server closed")
 			close(serverClosed)
 		}()
-		time.Sleep(time.Second)
 		var resp *http.Response
 		var body string
 		var errs []error
-		resp, body, errs = gorequest.New().
-			Get("http://127.0.0.1:9090/robots.txt").End()
+		// try every 100ms for up to 5 seconds for server to come up
+		for i := 0; i < 50; i++ {
+			time.Sleep(100 * time.Millisecond)
+			resp, body, errs = gorequest.New().
+				Get("http://127.0.0.1:9090/robots.txt").End()
+			if resp != nil && resp.StatusCode == http.StatusOK {
+				break
+			}
+		}
 		require.Len(t, errs, 0)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		require.Contains(t, body, "robotstxt.org")


### PR DESCRIPTION

In some cases it was taking more than a second for the server to start up.