### PR TITLE
Quick fix to send-manual to unblock tester

### DIFF
--- a/cmd/deal/send-manual.go
+++ b/cmd/deal/send-manual.go
@@ -157,7 +157,8 @@ Notes:
 			return err2
 		}
 		cliutil.PrintToConsole(dealModel, cctx.Bool("json"), []string{
-			"CreatedAt", "UpdatedAt", "DealID", "DatasetID", "SectorStartEpoch"})
+			"CreatedAt", "UpdatedAt", "DealID", "DatasetID", "SectorStartEpoch",
+			"ID", "State", "ErrorMessage", "ScheduleID"})
 		return nil
 	},
 }

--- a/cmd/deal/send-manual.go
+++ b/cmd/deal/send-manual.go
@@ -19,6 +19,12 @@ var SendManualCmd = &cli.Command{
 	Name:      "send-manual",
 	Usage:     "Send a manual deal proposal to boost or legacy market",
 	ArgsUsage: "CLIENT_ADDRESS PROVIDER_ID PIECE_CID PIECE_SIZE",
+	Description: `Send a manual deal proposal to boost or legacy market
+  Example: singularity deal send-manual f01234 f05678 bagaxxxx 32GiB
+Notes:
+  * The client address must have been imported to the wallet using 'singularity wallet import'
+  * The deal proposal will not be saved in the database however will eventually be tracked if the deal tracker is running
+  * There is a quick address verification using GLIF API which can be made faster by setting LOTUS_API and LOTUS_TOKEN to your own lotus node`,
 	Flags: []cli.Flag{
 		&cli.StringSliceFlag{
 			Name:     "http-header",
@@ -150,7 +156,8 @@ var SendManualCmd = &cli.Command{
 		if err2 != nil {
 			return err2
 		}
-		cliutil.PrintToConsole(dealModel, cctx.Bool("json"), nil)
+		cliutil.PrintToConsole(dealModel, cctx.Bool("json"), []string{
+			"CreatedAt", "UpdatedAt", "DealID", "DatasetID", "SectorStartEpoch"})
 		return nil
 	},
 }

--- a/docs/en/cli-reference/deal/send-manual.md
+++ b/docs/en/cli-reference/deal/send-manual.md
@@ -8,6 +8,14 @@ NAME:
 USAGE:
    singularity deal send-manual [command options] CLIENT_ADDRESS PROVIDER_ID PIECE_CID PIECE_SIZE
 
+DESCRIPTION:
+   Send a manual deal proposal to boost or legacy market
+     Example: singularity deal send-manual f01234 f05678 bagaxxxx 32GiB
+   Notes:
+     * The client address must have been imported to the wallet using 'singularity wallet import'
+     * The deal proposal will not be saved in the database however will eventually be tracked if the deal tracker is running
+     * There is a quick address verification using GLIF API which can be made faster by setting LOTUS_API and LOTUS_TOKEN to your own lotus node
+
 OPTIONS:
    --help, -h       show help
    --timeout value  Timeout for the deal proposal (default: 1m)

--- a/handler/deal/send-manual.go
+++ b/handler/deal/send-manual.go
@@ -74,7 +74,7 @@ func sendManualHandler(
 ) (*model.Deal, error) {
 	// Get the wallet object
 	wallet := model.Wallet{}
-	err := db.Where("id = ?", request.ClientAddress).First(&wallet).Error
+	err := db.Where("id = ? OR address = ?", request.ClientAddress, request.ClientAddress).First(&wallet).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, handler.NewInvalidParameterErr("client address not found")
 	}
@@ -122,8 +122,8 @@ func sendManualHandler(
 		Verified:       request.Verified,
 		KeepUnsealed:   request.KeepUnsealed,
 		AnnounceToIPNI: request.IPNI,
-		StartDelay:     duration,
-		Duration:       startDelay,
+		StartDelay:     startDelay,
+		Duration:       duration,
 	}
 
 	dealModel, err := dealMaker.MakeDeal(ctx, wallet, car, dealConfig)

--- a/handler/deal/send-manual_test.go
+++ b/handler/deal/send-manual_test.go
@@ -3,6 +3,7 @@ package deal
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/model"
@@ -216,8 +217,21 @@ func TestSendManualHandler(t *testing.T) {
 	ctx := context.Background()
 
 	mockDealMaker := new(MockDealMaker)
-	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return(&model.Deal{}, nil)
+	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, replication.DealConfig{
+		Provider:        proposal.ProviderID,
+		StartDelay:      24 * time.Hour,
+		Duration:        2400 * time.Hour,
+		Verified:        proposal.Verified,
+		HTTPHeaders:     proposal.HTTPHeaders,
+		URLTemplate:     proposal.URLTemplate,
+		KeepUnsealed:    proposal.KeepUnsealed,
+		AnnounceToIPNI:  proposal.IPNI,
+		PricePerDeal:    proposal.PricePerDeal,
+		PricePerGB:      proposal.PricePerGB,
+		PricePerGBEpoch: proposal.PricePerGBEpoch,
+	}).Return(&model.Deal{}, nil)
 	resp, err := SendManualHandler(db, ctx, mockDealMaker, proposal)
+	mockDealMaker.AssertExpectations(t)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 }

--- a/replication/makedeal.go
+++ b/replication/makedeal.go
@@ -330,7 +330,7 @@ func (d DealConfig) GetPrice(pieceSize int64, duration time.Duration) big.Int {
 
 func (d DealMakerImpl) MakeDeal(ctx context.Context, walletObj model.Wallet,
 	car model.Car, dealConfig DealConfig) (*model.Deal, error) {
-	logger.Info("making deal", "client", walletObj.ID, "pieceCID", car.PieceCID.String(), "provider", dealConfig.Provider)
+	logger.Infow("making deal", "client", walletObj.ID, "pieceCID", car.PieceCID.String(), "provider", dealConfig.Provider)
 	now := time.Now().UTC()
 	addr, err := address.NewFromString(walletObj.Address)
 	if err != nil {


### PR DESCRIPTION
* Fix send-manual command (that incorrectly swapped duration and startDelay)
* Works with boost market (legacy market test pending with real SP)
* go generate