### PR TITLE
Make deal tracking working

### DIFF
--- a/cmd/run/dealtracker.go
+++ b/cmd/run/dealtracker.go
@@ -1,12 +1,14 @@
 package run
 
 import (
+	"context"
 	"time"
 
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/service/dealtracker"
 	"github.com/data-preservation-programs/singularity/service/epochutil"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 )
 
@@ -26,6 +28,12 @@ var DealTrackerCmd = &cli.Command{
 			Usage:   "How often to check for new deals",
 			Aliases: []string{"i"},
 			Value:   1 * time.Hour,
+		},
+		&cli.BoolFlag{
+			Name:    "once",
+			Usage:   "Run once and exit",
+			Aliases: []string{"o"},
+			Value:   false,
 		},
 	},
 	Action: func(c *cli.Context) error {
@@ -52,6 +60,11 @@ var DealTrackerCmd = &cli.Command{
 			c.String("lotus-token"),
 		)
 
-		return tracker.Run(c.Context)
+		err = tracker.Run(c.Context, c.Bool("once"))
+		if errors.Is(err, context.Canceled) {
+			return nil
+		} else {
+			return err
+		}
 	},
 }

--- a/cmd/run/dealtracker.go
+++ b/cmd/run/dealtracker.go
@@ -30,10 +30,9 @@ var DealTrackerCmd = &cli.Command{
 			Value:   1 * time.Hour,
 		},
 		&cli.BoolFlag{
-			Name:    "once",
-			Usage:   "Run once and exit",
-			Aliases: []string{"o"},
-			Value:   false,
+			Name:  "once",
+			Usage: "Run once and exit",
+			Value: false,
 		},
 	},
 	Action: func(c *cli.Context) error {

--- a/docs/en/cli-reference/run/deal-tracker.md
+++ b/docs/en/cli-reference/run/deal-tracker.md
@@ -11,6 +11,7 @@ USAGE:
 OPTIONS:
    --market-deal-url value, -m value  The URL for ZST compressed state market deals json. Set to empty to use Lotus API. (default: "https://marketdeals.s3.amazonaws.com/StateMarketDeals.json.zst") [$MARKET_DEAL_URL]
    --interval value, -i value         How often to check for new deals (default: 1h0m0s)
+   --once, -o                         Run once and exit (default: false)
    --help, -h                         show help
 ```
 {% endcode %}

--- a/docs/en/cli-reference/run/deal-tracker.md
+++ b/docs/en/cli-reference/run/deal-tracker.md
@@ -11,7 +11,7 @@ USAGE:
 OPTIONS:
    --market-deal-url value, -m value  The URL for ZST compressed state market deals json. Set to empty to use Lotus API. (default: "https://marketdeals.s3.amazonaws.com/StateMarketDeals.json.zst") [$MARKET_DEAL_URL]
    --interval value, -i value         How often to check for new deals (default: 1h0m0s)
-   --once, -o                         Run once and exit (default: false)
+   --once                             Run once and exit (default: false)
    --help, -h                         show help
 ```
 {% endcode %}

--- a/model/replication.go
+++ b/model/replication.go
@@ -77,7 +77,7 @@ type Deal struct {
 }
 
 func (d Deal) Key() string {
-	return fmt.Sprintf("%s-%s-%s-%d-%d", d.ClientID, d.Provider, d.PieceCID, d.StartEpoch, d.EndEpoch)
+	return fmt.Sprintf("%s-%s-%s-%d-%d", d.ClientID, d.Provider, d.PieceCID.String(), d.StartEpoch, d.EndEpoch)
 }
 
 type Schedule struct {

--- a/service/dealtracker/countreader.go
+++ b/service/dealtracker/countreader.go
@@ -1,0 +1,55 @@
+package dealtracker
+
+import (
+	"io"
+	"sync"
+	"time"
+)
+
+// CountingReader is an io.Reader that counts the number of bytes read
+type CountingReader struct {
+	r io.Reader
+
+	mu        sync.RWMutex // guards n and startTime
+	n         int64
+	startTime time.Time
+}
+
+func NewCountingReader(r io.Reader) *CountingReader {
+	return &CountingReader{
+		r:         r,
+		startTime: time.Now(),
+	}
+}
+
+func (cr *CountingReader) Read(p []byte) (n int, err error) {
+	n, err = cr.r.Read(p)
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+	cr.n += int64(n)
+	return
+}
+
+// N returns the number of bytes read so far.
+func (cr *CountingReader) N() int64 {
+	cr.mu.RLock()
+	defer cr.mu.RUnlock()
+	n := cr.n
+	return n
+}
+
+// Speed returns the number of bytes read per second
+func (cr *CountingReader) Speed() float64 {
+	cr.mu.RLock()
+	defer cr.mu.RUnlock()
+	duration := time.Since(cr.startTime).Seconds()
+	if duration == 0 {
+		return 0
+	}
+	return float64(cr.n) / duration
+}
+
+type Counter interface {
+	N() int64
+	Speed() float64
+}

--- a/service/dealtracker/dealtracker.go
+++ b/service/dealtracker/dealtracker.go
@@ -312,7 +312,7 @@ func (d *DealTracker) runOnce(ctx context.Context) error {
 			}
 		} else {
 			key := deal.Key()
-			unknownDeals[key] = append(unknownDeals[deal.Key()], UnknownDeal{
+			unknownDeals[key] = append(unknownDeals[key], UnknownDeal{
 				ID:         deal.ID,
 				ClientID:   deal.ClientID,
 				Provider:   deal.Provider,
@@ -444,7 +444,7 @@ func (d *DealTracker) trackDeal(ctx context.Context, callback func(dealID uint64
 			select {
 			case <-countingCtx.Done():
 				return
-			case <-time.After(5 * time.Second):
+			case <-time.After(15 * time.Second):
 				downloaded := humanize.Bytes(uint64(counter.N()))
 				speed := humanize.Bytes(uint64(counter.Speed()))
 				logger.Infof("Downloaded %s with average speed %s / s", downloaded, speed)


### PR DESCRIPTION
* Allow deal tracking to run once for easy tester testing
* Correct the logic to be same as the current singularity deal updater
* Print the download statistics every 15 secs
* go generate