### PR TITLE
Restrict output directory to no more than 1

### DIFF
--- a/handler/dataset/create.go
+++ b/handler/dataset/create.go
@@ -52,6 +52,10 @@ func parseCreateRequest(request CreateRequest) (*model.Dataset, error) {
 	}
 
 	outDirs := make([]string, len(request.OutputDirs))
+	if len(request.OutputDirs) > 1 {
+		return nil, handler.NewInvalidParameterErr("multiple output directories will not supported in the future hence no longer allowed")
+	}
+
 	for i, outputDir := range request.OutputDirs {
 		info, err := os.Stat(outputDir)
 		if err != nil || !info.IsDir() {

--- a/handler/dataset/update.go
+++ b/handler/dataset/update.go
@@ -104,7 +104,7 @@ func parseUpdateRequest(request UpdateRequest, dataset *model.Dataset) error {
 	}
 
 	if request.OutputDirs != nil {
-		if len(request.OutputDirs) == 0 && request.OutputDirs[0] == "" {
+		if len(request.OutputDirs) == 1 && request.OutputDirs[0] == "" {
 			dataset.OutputDirs = nil
 		} else {
 			outDirs := make([]string, len(request.OutputDirs))


### PR DESCRIPTION
Purpose of this change:
* In the future we're going to connect CAR file output directory to any Rclone storage backend however we can no longer offer multiple output directories.
* This PR makes sure each dataset will be associated with up to one output directory, making possible to migrate to a single Rclone backend in the future
* Intentionally not changing the database model and API payload to be less disruptive for other concurrent dev work

Changes Made:
* More than 1 output directories will return an error
* Update dataset with empty output directory will now remove all output directory - not ideal solution but good for now until we move to Rclone backend