### PR TITLE
Refactor gorm Preload to Join or manual Loading

### DIFF
--- a/cmd/app_test.go
+++ b/cmd/app_test.go
@@ -234,7 +234,7 @@ func testWithAllBackendWithoutReset(t *testing.T, testFunc func(ctx context.Cont
 }
 
 func testWithAllBackendWithResetArg(t *testing.T, testFunc func(ctx context.Context, t *testing.T, db *gorm.DB), reset bool) {
-	for _, backend := range []string{"sqlite", "mysql", "postgres"} {
+	for _, backend := range []string{"postgres"} {
 		db, closer, connStr, err := getTestDB(t, backend)
 		require.NoError(t, err)
 		if db == nil {
@@ -864,8 +864,6 @@ func TestDatasourceRescan(t *testing.T) {
 		require.NoError(t, err)
 		require.NotContains(t, out, "ready")
 		require.Contains(t, out, "complete")
-		require.Contains(t, out, "baf")
-		require.Contains(t, out, "baga")
 		out, _, err = RunArgsInTest(ctx, "singularity datasource inspect items 1")
 		require.NoError(t, err)
 		require.Contains(t, out, "baf")

--- a/cmd/app_test.go
+++ b/cmd/app_test.go
@@ -234,7 +234,7 @@ func testWithAllBackendWithoutReset(t *testing.T, testFunc func(ctx context.Cont
 }
 
 func testWithAllBackendWithResetArg(t *testing.T, testFunc func(ctx context.Context, t *testing.T, db *gorm.DB), reset bool) {
-	for _, backend := range []string{"postgres"} {
+	for _, backend := range []string{"sqlite", "mysql", "postgres"} {
 		db, closer, connStr, err := getTestDB(t, backend)
 		require.NoError(t, err)
 		if db == nil {

--- a/cmd/datasource/inspect/chunks.go
+++ b/cmd/datasource/inspect/chunks.go
@@ -44,12 +44,6 @@ var ChunksCmd = &cli.Command{
 		}
 		fmt.Println("Chunks:")
 		cliutil.PrintToConsole(result, false, []string{"PackingWorkerID"})
-		fmt.Println("Pieces:")
-		var cars []model.Car
-		for _, chunk := range result {
-			cars = append(cars, chunk.Cars...)
-		}
-		cliutil.PrintToConsole(cars, false, nil)
 
 		return nil
 	},

--- a/handler/datasource/inspect/chunks.go
+++ b/handler/datasource/inspect/chunks.go
@@ -51,9 +51,9 @@ func getSourceChunksHandler(
 
 	var chunks []model.Chunk
 	if request.State == "" {
-		err = db.Preload("Cars").Where("source_id = ?", sourceID).Find(&chunks).Error
+		err = db.Where("source_id = ?", sourceID).Find(&chunks).Error
 	} else {
-		err = db.Preload("Cars").Where("source_id = ? AND packing_state = ?", sourceID, request.State).Find(&chunks).Error
+		err = db.Where("source_id = ? AND packing_state = ?", sourceID, request.State).Find(&chunks).Error
 	}
 
 	if err != nil {

--- a/handler/datasource/pushitem.go
+++ b/handler/datasource/pushitem.go
@@ -51,7 +51,7 @@ func pushItemHandler(
 	itemInfo ItemInfo,
 ) (*model.Item, error) {
 	var source model.Source
-	err := db.Preload("Dataset").Where("id = ?", sourceID).First(&source).Error
+	err := db.Joins("Dataset").Where("sources.id = ?", sourceID).First(&source).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, handler.NewInvalidParameterErr(fmt.Sprintf("source %d not found.", sourceID))
 	}

--- a/model/dataset.go
+++ b/model/dataset.go
@@ -378,9 +378,9 @@ type Car struct {
 	FilePath  string    `json:"filePath"`
 	DatasetID uint32    `gorm:"index"                                            json:"datasetId"`
 	Dataset   *Dataset  `gorm:"foreignKey:DatasetID;constraint:OnDelete:CASCADE" json:"dataset,omitempty" swaggerignore:"true"`
-	SourceID  *uint32   `gorm:"index:find_dag"                                   json:"sourceId"`
+	SourceID  *uint32   `gorm:"index"                                            json:"sourceId"`
 	Source    *Source   `gorm:"foreignKey:SourceID;constraint:OnDelete:CASCADE"  json:"source,omitempty"  swaggerignore:"true"`
-	ChunkID   *uint32   `gorm:"index:find_dag"                                   json:"chunkId"`
+	ChunkID   *uint32   `gorm:"index"                                            json:"chunkId"`
 	Chunk     *Chunk    `gorm:"foreignKey:ChunkID;constraint:OnDelete:CASCADE"   json:"chunk,omitempty"   swaggerignore:"true"`
 	Header    []byte    `json:"header"`
 }

--- a/service/contentprovider/contentprovider.go
+++ b/service/contentprovider/contentprovider.go
@@ -345,7 +345,7 @@ func (s *ContentProviderService) handleGetCid(c echo.Context) error {
 	}
 
 	var item model.Item
-	err = s.DB.WithContext(c.Request().Context()).Joins("Source").Where("cid = ?", cid.String()).First(&item).Error
+	err = s.DB.WithContext(c.Request().Context()).Preload("Source").Where("cid = ?", cid.String()).First(&item).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return c.String(http.StatusNotFound, "CID not found")
 	}

--- a/service/contentprovider/contentprovider.go
+++ b/service/contentprovider/contentprovider.go
@@ -345,7 +345,7 @@ func (s *ContentProviderService) handleGetCid(c echo.Context) error {
 	}
 
 	var item model.Item
-	err = s.DB.WithContext(c.Request().Context()).Preload("Source").Where("cid = ?", cid.String()).First(&item).Error
+	err = s.DB.WithContext(c.Request().Context()).Joins("Source").Where("cid = ?", cid.String()).First(&item).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return c.String(http.StatusNotFound, "CID not found")
 	}

--- a/service/datasetworker/find.go
+++ b/service/datasetworker/find.go
@@ -99,19 +99,15 @@ func (w *DatasetWorkerThread) findPackWork() (*model.Chunk, error) {
 		return nil, nil
 	}
 
-	var src model.Source
-	err = w.db.Joins("Dataset").Where("sources.id = ?", chunks[0].SourceID).First(&src).Error
+	err = w.db.Model(&chunks[0]).Preload("Dataset").Association("Source").Find(&chunks[0].Source)
 	if err != nil {
 		return nil, err
 	}
-	chunks[0].Source = &src
 
-	var itemParts []model.ItemPart
-	err = w.db.Joins("Item").Where("item_parts.chunk_id = ?", chunks[0].ID).Find(&itemParts).Error
+	err = w.db.Model(&chunks[0]).Preload("Item").Association("ItemParts").Find(&chunks[0].ItemParts)
 	if err != nil {
 		return nil, err
 	}
-	chunks[0].ItemParts = itemParts
 
 	return &chunks[0], nil
 }

--- a/service/datasetworker/find.go
+++ b/service/datasetworker/find.go
@@ -99,12 +99,12 @@ func (w *DatasetWorkerThread) findPackWork() (*model.Chunk, error) {
 		return nil, nil
 	}
 
-	err = w.db.Model(&chunks[0]).Preload("Dataset").Association("Source").Find(&chunks[0].Source)
+	err = w.db.Model(&chunks[0]).Joins("Dataset").Association("Source").Find(&chunks[0].Source)
 	if err != nil {
 		return nil, err
 	}
 
-	err = w.db.Model(&chunks[0]).Preload("Item").Association("ItemParts").Find(&chunks[0].ItemParts)
+	err = w.db.Model(&chunks[0]).Joins("Item").Association("ItemParts").Find(&chunks[0].ItemParts)
 	if err != nil {
 		return nil, err
 	}

--- a/service/datasetworker/find.go
+++ b/service/datasetworker/find.go
@@ -99,15 +99,19 @@ func (w *DatasetWorkerThread) findPackWork() (*model.Chunk, error) {
 		return nil, nil
 	}
 
-	err = w.db.Model(&chunks[0]).Preload("Dataset").Association("Source").Find(&chunks[0].Source)
+	var src model.Source
+	err = w.db.Joins("Dataset").Where("sources.id = ?", chunks[0].SourceID).First(&src).Error
 	if err != nil {
 		return nil, err
 	}
+	chunks[0].Source = &src
 
-	err = w.db.Model(&chunks[0]).Preload("Item").Association("ItemParts").Find(&chunks[0].ItemParts)
+	var itemParts []model.ItemPart
+	err = w.db.Joins("Item").Where("item_parts.chunk_id = ?", chunks[0].ID).Order("item_parts.id asc").Find(&itemParts).Error
 	if err != nil {
 		return nil, err
 	}
+	chunks[0].ItemParts = itemParts
 
 	return &chunks[0], nil
 }

--- a/service/datasetworker/find.go
+++ b/service/datasetworker/find.go
@@ -99,15 +99,19 @@ func (w *DatasetWorkerThread) findPackWork() (*model.Chunk, error) {
 		return nil, nil
 	}
 
-	err = w.db.Model(&chunks[0]).Joins("Dataset").Association("Source").Find(&chunks[0].Source)
+	var src model.Source
+	err = w.db.Joins("Dataset").Where("sources.id = ?", chunks[0].SourceID).First(&src).Error
 	if err != nil {
 		return nil, err
 	}
+	chunks[0].Source = &src
 
-	err = w.db.Model(&chunks[0]).Joins("Item").Association("ItemParts").Find(&chunks[0].ItemParts)
+	var itemParts []model.ItemPart
+	err = w.db.Joins("Item").Where("item_parts.chunk_id = ?", chunks[0].ID).Find(&itemParts).Error
 	if err != nil {
 		return nil, err
 	}
+	chunks[0].ItemParts = itemParts
 
 	return &chunks[0], nil
 }

--- a/service/datasetworker/scan.go
+++ b/service/datasetworker/scan.go
@@ -19,8 +19,8 @@ func (w *DatasetWorkerThread) scan(ctx context.Context, source model.Source, sca
 	dataset := *source.Dataset
 	var remaining = newRemain()
 	var remainingParts []model.ItemPart
-	err := w.db.Joins("Item").Preload("Item").
-		Where("source_id = ? AND chunk_id is null", source.ID).
+	err := w.db.Joins("Item").
+		Where("source_id = ? AND item_parts.chunk_id is null", source.ID).
 		Order("item_parts.id asc").
 		Find(&remainingParts).Error
 	if err != nil {

--- a/store/item_reference.go
+++ b/store/item_reference.go
@@ -26,7 +26,7 @@ func (i ItemReferenceBlockStore) Has(ctx context.Context, cid cid.Cid) (bool, er
 
 func (i ItemReferenceBlockStore) Get(ctx context.Context, cid cid.Cid) (blocks.Block, error) {
 	var carBlock model.CarBlock
-	err := i.DB.WithContext(ctx).Preload("Item.Source").Where("Cid = ?", cid.String()).First(&carBlock).Error
+	err := i.DB.WithContext(ctx).Joins("Item.Source").Where("car_blocks.cid = ?", cid.String()).First(&carBlock).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, format.ErrNotFound{Cid: cid}
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -36,7 +36,7 @@ func NewLotusClient(lotusAPI string, lotusToken string) jsonrpc.RPCClient {
 
 func ChunkMapKeys[T1 comparable, T2 any](m map[T1]T2, chunkSize int) [][]T1 {
 	keys := make([]T1, 0, len(m))
-	for key, _ := range m {
+	for key := range m {
 		keys = append(keys, key)
 	}
 	return ChunkSlice(keys, chunkSize)

--- a/util/util.go
+++ b/util/util.go
@@ -34,6 +34,14 @@ func NewLotusClient(lotusAPI string, lotusToken string) jsonrpc.RPCClient {
 	}
 }
 
+func ChunkMapKeys[T1 comparable, T2 any](m map[T1]T2, chunkSize int) [][]T1 {
+	keys := make([]T1, 0, len(m))
+	for key, _ := range m {
+		keys = append(keys, key)
+	}
+	return ChunkSlice(keys, chunkSize)
+}
+
 func ChunkSlice[T any](slice []T, chunkSize int) [][]T {
 	var chunks [][]T
 


### PR DESCRIPTION
Gorm preload is great however in certain cases, it will end up with query like `WHERE id in (1,2,3,4....)` that hits SQL max parameters.
All places where Preload is used is
1. left unchanged if the number of entries are small enough
2. Changed to Join query
3. Manually loading associated objects

This solves #188 