### PR TITLE
Add context to multiple function calls

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -128,7 +128,9 @@ func (s Server) toEchoHandler(handlerFunc any) echo.HandlerFunc {
 		handlerFuncType := handlerFuncValue.Type()
 
 		// Check the number of input parameters
-		if handlerFuncType.NumIn() == 0 || handlerFuncType.In(1) != reflect.TypeOf(s.db) {
+		if handlerFuncType.NumIn() == 0 ||
+			handlerFuncType.In(1).String() != "*gorm.DB" ||
+			handlerFuncType.In(0).String() != "context.Context" {
 			logger.Error("Invalid handler function signature.")
 			return echo.NewHTTPError(http.StatusInternalServerError, "Invalid handler function signature.")
 		}

--- a/api/api.go
+++ b/api/api.go
@@ -139,13 +139,11 @@ func (s Server) toEchoHandler(handlerFunc any) echo.HandlerFunc {
 		var inputParams []reflect.Value
 
 		var j int
-		var hasContext bool
 		// Get path parameters
 		for i := 0; i < handlerFuncType.NumIn(); i++ {
 			paramType := handlerFuncType.In(i)
 			if paramType.String() == "context.Context" {
 				inputParams = append(inputParams, reflect.ValueOf(c.Request().Context()))
-				hasContext = true
 				continue
 			}
 			if paramType.String() == "*gorm.DB" {
@@ -207,10 +205,6 @@ func (s Server) toEchoHandler(handlerFunc any) echo.HandlerFunc {
 			}
 			inputParams = append(inputParams, bodyParam)
 			break
-		}
-
-		if !hasContext {
-			return c.JSON(http.StatusInternalServerError, HTTPError{Err: "handler function must have context.Context as input parameter"})
 		}
 
 		// Call the handler function

--- a/client/lib/client.go
+++ b/client/lib/client.go
@@ -30,11 +30,11 @@ func NewClient(db *gorm.DB) (*Client, error) {
 }
 
 func (c *Client) CreateDataset(ctx context.Context, request dataset.CreateRequest) (*model.Dataset, error) {
-	return dataset.CreateHandler(c.db.WithContext(ctx), request)
+	return dataset.CreateHandler(ctx, c.db.WithContext(ctx), request)
 }
 
 func (c *Client) ListSourcesByDataset(ctx context.Context, datasetName string) ([]model.Source, error) {
-	return dshandler.ListSourcesByDatasetHandler(c.db, datasetName)
+	return dshandler.ListSourcesByDatasetHandler(ctx, c.db, datasetName)
 }
 
 func (c *Client) CreateLocalSource(ctx context.Context, datasetName string, params dshandler.LocalRequest) (*model.Source, error) {
@@ -47,26 +47,26 @@ func (c *Client) CreateLocalSource(ctx context.Context, datasetName string, para
 	if err != nil {
 		return nil, err
 	}
-	return dshandler.CreateDatasourceHandler(c.db.WithContext(ctx), ctx, c.datasourceHandlerResolver, "local", datasetName, paramsMap)
+	return dshandler.CreateDatasourceHandler(ctx, c.db.WithContext(ctx), "local", datasetName, paramsMap)
 }
 
 func (c *Client) GetSourceChunks(ctx context.Context, sourceID uint32, request inspect.GetSourceChunksRequest) ([]model.Chunk, error) {
-	return inspect.GetSourceChunksHandler(c.db.WithContext(ctx), sourceID, request)
+	return inspect.GetSourceChunksHandler(ctx, c.db.WithContext(ctx), sourceID, request)
 }
 func (c *Client) GetSourceItems(ctx context.Context, sourceID uint32) ([]model.Item, error) {
-	return inspect.GetSourceItemsHandler(c.db.WithContext(ctx), strconv.FormatUint(uint64(sourceID), 10))
+	return inspect.GetSourceItemsHandler(ctx, c.db.WithContext(ctx), strconv.FormatUint(uint64(sourceID), 10))
 }
 
 func (c *Client) GetItem(ctx context.Context, id uint64) (*model.Item, error) {
-	return inspect.GetSourceItemDetailHandler(c.db.WithContext(ctx), strconv.FormatUint(id, 10))
+	return inspect.GetSourceItemDetailHandler(ctx, c.db.WithContext(ctx), strconv.FormatUint(id, 10))
 }
 
 func (c *Client) PushItem(ctx context.Context, sourceID uint32, itemInfo dshandler.ItemInfo) (*model.Item, error) {
-	return dshandler.PushItemHandler(c.db.WithContext(ctx), ctx, c.datasourceHandlerResolver, sourceID, itemInfo)
+	return dshandler.PushItemHandler(ctx, c.db.WithContext(ctx), c.datasourceHandlerResolver, sourceID, itemInfo)
 }
 
 func (c *Client) Chunk(ctx context.Context, sourceID uint32, request dshandler.ChunkRequest) (*model.Chunk, error) {
-	return dshandler.ChunkHandler(c.db.WithContext(ctx), strconv.FormatUint(uint64(sourceID), 10), request)
+	return dshandler.ChunkHandler(ctx, c.db.WithContext(ctx), strconv.FormatUint(uint64(sourceID), 10), request)
 }
 
 func (c *Client) Pack(ctx context.Context, chunkID uint64) ([]model.Car, error) {

--- a/client/testutil/testallclients.go
+++ b/client/testutil/testallclients.go
@@ -16,6 +16,7 @@ import (
 
 func TestWithAllClients(ctx context.Context, t *testing.T, test func(*testing.T, client.Client)) {
 	t.Run("http", func(t *testing.T) {
+		//nolint:contextcheck
 		_, closer, err := database.OpenInMemory()
 		require.NoError(t, err)
 		closer.Close()

--- a/cmd/admin/init.go
+++ b/cmd/admin/init.go
@@ -9,12 +9,12 @@ import (
 var InitCmd = &cli.Command{
 	Name:  "init",
 	Usage: "Initialize the database",
-	Action: func(context *cli.Context) error {
-		db, closer, err := database.OpenFromCLI(context)
+	Action: func(c *cli.Context) error {
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
 		defer closer.Close()
-		return admin.InitHandler(db)
+		return admin.InitHandler(c.Context, db)
 	},
 }

--- a/cmd/admin/reset.go
+++ b/cmd/admin/reset.go
@@ -11,15 +11,15 @@ var ResetCmd = &cli.Command{
 	Name:  "reset",
 	Usage: "Reset the database",
 	Flags: []cli.Flag{cliutil.ReallyDotItFlag},
-	Action: func(context *cli.Context) error {
-		if err := cliutil.HandleReallyDoIt(context); err != nil {
+	Action: func(c *cli.Context) error {
+		if err := cliutil.HandleReallyDoIt(c); err != nil {
 			return err
 		}
-		db, closer, err := database.OpenFromCLI(context)
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
 		defer closer.Close()
-		return admin.ResetHandler(db)
+		return admin.ResetHandler(c.Context, db)
 	},
 }

--- a/cmd/dataset/addpiece.go
+++ b/cmd/dataset/addpiece.go
@@ -38,7 +38,7 @@ var AddPieceCmd = &cli.Command{
 		defer closer.Close()
 
 		car, err := dataset.AddPieceHandler(
-			db, c.Args().Get(0), dataset.AddPieceRequest{
+			c.Context, db, c.Args().Get(0), dataset.AddPieceRequest{
 				PieceCID:  c.Args().Get(1),
 				PieceSize: c.Args().Get(2),
 				FilePath:  c.String("file-path"),

--- a/cmd/dataset/addwallet.go
+++ b/cmd/dataset/addwallet.go
@@ -17,7 +17,7 @@ var AddWalletCmd = &cli.Command{
 			return err
 		}
 		defer closer.Close()
-		wallet, err := wallet.AddWalletHandler(db, c.Args().Get(0), c.Args().Get(1))
+		wallet, err := wallet.AddWalletHandler(c.Context, db, c.Args().Get(0), c.Args().Get(1))
 		if err != nil {
 			return err
 		}

--- a/cmd/dataset/create.go
+++ b/cmd/dataset/create.go
@@ -53,6 +53,7 @@ var CreateCmd = &cli.Command{
 		}
 		defer closer.Close()
 		dataset, err := dataset.CreateHandler(
+			c.Context,
 			db,
 			dataset.CreateRequest{
 				Name:                 c.Args().Get(0),

--- a/cmd/dataset/list.go
+++ b/cmd/dataset/list.go
@@ -17,6 +17,7 @@ var ListDatasetCmd = &cli.Command{
 		}
 		defer closer.Close()
 		datasets, err := dataset.ListHandler(
+			c.Context,
 			db,
 		)
 		if err != nil {

--- a/cmd/dataset/listpieces.go
+++ b/cmd/dataset/listpieces.go
@@ -19,6 +19,7 @@ var ListPiecesCmd = &cli.Command{
 		defer closer.Close()
 
 		car, err := dataset.ListPiecesHandler(
+			c.Context,
 			db, c.Args().Get(0),
 		)
 		if err != nil {

--- a/cmd/dataset/listwallet.go
+++ b/cmd/dataset/listwallet.go
@@ -17,7 +17,7 @@ var ListWalletCmd = &cli.Command{
 			return err
 		}
 		defer closer.Close()
-		wallets, err := wallet.ListWalletHandler(db, c.Args().Get(0))
+		wallets, err := wallet.ListWalletHandler(c.Context, db, c.Args().Get(0))
 		if err != nil {
 			return err
 		}

--- a/cmd/dataset/remove.go
+++ b/cmd/dataset/remove.go
@@ -25,6 +25,7 @@ var RemoveDatasetCmd = &cli.Command{
 		}
 		defer closer.Close()
 		return dataset.RemoveHandler(
+			c.Context,
 			db,
 			c.Args().Get(0),
 		)

--- a/cmd/dataset/removewallet.go
+++ b/cmd/dataset/removewallet.go
@@ -16,6 +16,6 @@ var RemoveWalletCmd = &cli.Command{
 			return err
 		}
 		defer closer.Close()
-		return wallet.RemoveWalletHandler(db, c.Args().Get(0), c.Args().Get(1))
+		return wallet.RemoveWalletHandler(c.Context, db, c.Args().Get(0), c.Args().Get(1))
 	},
 }

--- a/cmd/dataset/update.go
+++ b/cmd/dataset/update.go
@@ -66,6 +66,7 @@ var UpdateCmd = &cli.Command{
 			encryptionScript = &s
 		}
 		dataset, err := dataset.UpdateHandler(
+			c.Context,
 			db,
 			c.Args().Get(0),
 			dataset.UpdateRequest{

--- a/cmd/datasource/add.go
+++ b/cmd/datasource/add.go
@@ -53,6 +53,7 @@ var AddCmd = &cli.Command{
 				return err
 			}
 			defer closer.Close()
+			db = db.WithContext(c.Context)
 			dataset, err := database.FindDatasetByName(db, datasetName)
 			if err != nil {
 				return handler.InvalidParameterError{Err: err}
@@ -106,7 +107,7 @@ var AddCmd = &cli.Command{
 				return errors.Wrap(err, "failed to check source")
 			}
 
-			err = database.DoRetry(func() error {
+			err = database.DoRetry(c.Context, func() error {
 				return db.Transaction(func(db *gorm.DB) error {
 					err := db.Create(&source).Error
 					if err != nil {

--- a/cmd/datasource/check.go
+++ b/cmd/datasource/check.go
@@ -20,8 +20,8 @@ var CheckCmd = &cli.Command{
 		}
 		defer closer.Close()
 		entries, err := datasource.CheckSourceHandler(
-			db,
 			c.Context,
+			db,
 			c.Args().Get(0),
 			datasource.CheckSourceRequest{
 				Path: c.Args().Get(1),

--- a/cmd/datasource/daggen.go
+++ b/cmd/datasource/daggen.go
@@ -20,7 +20,7 @@ var DagGenCmd = &cli.Command{
 			return err
 		}
 		defer closer.Close()
-		source, err := datasource.DagGenHandler(db, c.Args().Get(0))
+		source, err := datasource.DagGenHandler(c.Context, db, c.Args().Get(0))
 		if err != nil {
 			return err
 		}

--- a/cmd/datasource/inspect/chunkdetail.go
+++ b/cmd/datasource/inspect/chunkdetail.go
@@ -37,6 +37,7 @@ var ChunkDetailCmd = &cli.Command{
 		}
 		defer closer.Close()
 		result, err := inspect.GetSourceChunkDetailHandler(
+			c.Context,
 			db,
 			c.Args().Get(0),
 		)

--- a/cmd/datasource/inspect/chunks.go
+++ b/cmd/datasource/inspect/chunks.go
@@ -36,6 +36,7 @@ var ChunksCmd = &cli.Command{
 			return err
 		}
 		result, err := inspect.GetSourceChunksHandler(
+			c.Context,
 			db,
 			uint32(sourceID),
 			inspect.GetSourceChunksRequest{State: *(c.Generic("state").(*model.WorkState))},

--- a/cmd/datasource/inspect/dags.go
+++ b/cmd/datasource/inspect/dags.go
@@ -18,6 +18,7 @@ var DagsCmd = &cli.Command{
 		}
 		defer closer.Close()
 		cars, err := inspect.GetDagsHandler(
+			c.Context,
 			db,
 			c.Args().Get(0),
 		)

--- a/cmd/datasource/inspect/itemdetail.go
+++ b/cmd/datasource/inspect/itemdetail.go
@@ -20,6 +20,7 @@ var ItemDetailCmd = &cli.Command{
 		}
 		defer closer.Close()
 		result, err := inspect.GetSourceItemDetailHandler(
+			c.Context,
 			db,
 			c.Args().Get(0),
 		)

--- a/cmd/datasource/inspect/items.go
+++ b/cmd/datasource/inspect/items.go
@@ -19,6 +19,7 @@ var ItemsCmd = &cli.Command{
 		}
 		defer closer.Close()
 		result, err := inspect.GetSourceItemsHandler(
+			c.Context,
 			db,
 			c.Args().Get(0),
 		)

--- a/cmd/datasource/inspect/path.go
+++ b/cmd/datasource/inspect/path.go
@@ -20,6 +20,7 @@ var PathCmd = &cli.Command{
 		}
 		defer closer.Close()
 		result, err := inspect.GetPathHandler(
+			c.Context,
 			db,
 			c.Args().Get(0),
 			inspect.GetPathRequest{

--- a/cmd/datasource/list.go
+++ b/cmd/datasource/list.go
@@ -24,6 +24,7 @@ var ListCmd = &cli.Command{
 		defer closer.Close()
 		datasetName := c.String("dataset")
 		sources, err := datasource.ListSourcesByDatasetHandler(
+			c.Context,
 			db,
 			datasetName,
 		)

--- a/cmd/datasource/remove.go
+++ b/cmd/datasource/remove.go
@@ -22,6 +22,7 @@ var RemoveCmd = &cli.Command{
 		}
 		defer closer.Close()
 		return datasource.RemoveSourceHandler(
+			c.Context,
 			db,
 			c.Args().Get(0),
 		)

--- a/cmd/datasource/repack.go
+++ b/cmd/datasource/repack.go
@@ -29,6 +29,7 @@ var RepackCmd = &cli.Command{
 			chunkID = &c2
 		}
 		chunks, err := datasource.RepackHandler(
+			c.Context,
 			db,
 			c.Args().Get(0),
 			datasource.RepackRequest{

--- a/cmd/datasource/rescan.go
+++ b/cmd/datasource/rescan.go
@@ -19,6 +19,7 @@ var RescanCmd = &cli.Command{
 		}
 		defer closer.Close()
 		source, err := datasource.RescanSourceHandler(
+			c.Context,
 			db,
 			c.Args().Get(0),
 		)

--- a/cmd/datasource/status.go
+++ b/cmd/datasource/status.go
@@ -21,6 +21,7 @@ var StatusCmd = &cli.Command{
 		}
 		defer closer.Close()
 		result, err := datasource.GetSourceStatusHandler(
+			c.Context,
 			db,
 			c.Args().Get(0),
 		)

--- a/cmd/datasource/update.go
+++ b/cmd/datasource/update.go
@@ -62,8 +62,8 @@ var UpdateCmd = &cli.Command{
 		}
 
 		source, err := datasource.UpdateSourceHandler(
-			db,
 			c.Context,
+			db,
 			c.Args().Get(0),
 			config,
 		)

--- a/cmd/deal/list.go
+++ b/cmd/deal/list.go
@@ -34,7 +34,7 @@ var ListCmd = &cli.Command{
 			return err
 		}
 		defer closer.Close()
-		deals, err := deal.ListHandler(db, deal.ListDealRequest{
+		deals, err := deal.ListHandler(c.Context, db, deal.ListDealRequest{
 			Datasets:  c.StringSlice("dataset"),
 			Schedules: c.UintSlice("schedule"),
 			Providers: c.StringSlice("provider"),

--- a/cmd/deal/schedule/create.go
+++ b/cmd/deal/schedule/create.go
@@ -235,7 +235,7 @@ var CreateCmd = &cli.Command{
 			AllowedPieceCIDs:     allowedPieceCIDs,
 		}
 		lotusClient := util.NewLotusClient(c.String("lotus-api"), c.String("lotus-token"))
-		schedule, err := schedule.CreateHandler(db, c.Context, lotusClient, request)
+		schedule, err := schedule.CreateHandler(c.Context, db, lotusClient, request)
 		if err != nil {
 			return err
 		}

--- a/cmd/deal/schedule/list.go
+++ b/cmd/deal/schedule/list.go
@@ -16,7 +16,7 @@ var ListCmd = &cli.Command{
 			return err
 		}
 		defer closer.Close()
-		schedules, err := schedule.ListHandler(db)
+		schedules, err := schedule.ListHandler(c.Context, db)
 		if err != nil {
 			return err
 		}

--- a/cmd/deal/schedule/pause.go
+++ b/cmd/deal/schedule/pause.go
@@ -17,7 +17,7 @@ var PauseCmd = &cli.Command{
 			return err
 		}
 		defer closer.Close()
-		schedule, err := schedule.PauseHandler(db, c.Args().Get(0))
+		schedule, err := schedule.PauseHandler(c.Context, db, c.Args().Get(0))
 		if err != nil {
 			return err
 		}

--- a/cmd/deal/schedule/resume.go
+++ b/cmd/deal/schedule/resume.go
@@ -17,7 +17,7 @@ var ResumeCmd = &cli.Command{
 			return err
 		}
 		defer closer.Close()
-		schedule, err := schedule.ResumeHandler(db, c.Args().Get(0))
+		schedule, err := schedule.ResumeHandler(c.Context, db, c.Args().Get(0))
 		if err != nil {
 			return err
 		}

--- a/cmd/deal/send-manual.go
+++ b/cmd/deal/send-manual.go
@@ -109,54 +109,54 @@ Notes:
 			DefaultText: "1m",
 		},
 	},
-	Action: func(cctx *cli.Context) error {
-		lotusAPI := cctx.String("lotus-api")
-		lotusToken := cctx.String("lotus-token")
-		err := epochutil.Initialize(cctx.Context, lotusAPI, lotusToken)
+	Action: func(c *cli.Context) error {
+		lotusAPI := c.String("lotus-api")
+		lotusToken := c.String("lotus-token")
+		err := epochutil.Initialize(c.Context, lotusAPI, lotusToken)
 		if err != nil {
 			return err
 		}
 		proposal := deal.Proposal{
-			HTTPHeaders:     cctx.StringSlice("http-header"),
-			URLTemplate:     cctx.String("url-template"),
-			PricePerGBEpoch: cctx.Float64("price-per-gb-epoch"),
-			PricePerGB:      cctx.Float64("price-per-gb"),
-			PricePerDeal:    cctx.Float64("price-per-deal"),
-			RootCID:         cctx.String("root-cid"),
-			Verified:        cctx.Bool("verified"),
-			IPNI:            cctx.Bool("ipni"),
-			KeepUnsealed:    cctx.Bool("keep-unsealed"),
-			StartDelay:      cctx.String("start-delay"),
-			Duration:        cctx.String("duration"),
-			ClientAddress:   cctx.Args().Get(0),
-			ProviderID:      cctx.Args().Get(1),
-			PieceCID:        cctx.Args().Get(2),
-			PieceSize:       cctx.Args().Get(3),
-			FileSize:        cctx.Uint64("file-size"),
+			HTTPHeaders:     c.StringSlice("http-header"),
+			URLTemplate:     c.String("url-template"),
+			PricePerGBEpoch: c.Float64("price-per-gb-epoch"),
+			PricePerGB:      c.Float64("price-per-gb"),
+			PricePerDeal:    c.Float64("price-per-deal"),
+			RootCID:         c.String("root-cid"),
+			Verified:        c.Bool("verified"),
+			IPNI:            c.Bool("ipni"),
+			KeepUnsealed:    c.Bool("keep-unsealed"),
+			StartDelay:      c.String("start-delay"),
+			Duration:        c.String("duration"),
+			ClientAddress:   c.Args().Get(0),
+			ProviderID:      c.Args().Get(1),
+			PieceCID:        c.Args().Get(2),
+			PieceSize:       c.Args().Get(3),
+			FileSize:        c.Uint64("file-size"),
 		}
-		timeout := cctx.Duration("timeout")
-		db, closer, err := database.OpenFromCLI(cctx)
+		timeout := c.Duration("timeout")
+		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {
 			return err
 		}
 		defer closer.Close()
-		ctx, cancel := context.WithTimeout(cctx.Context, timeout)
+		ctx, cancel := context.WithTimeout(c.Context, timeout)
 		defer cancel()
 		h, err := util.InitHost(nil)
 		if err != nil {
 			return errors.Wrap(err, "failed to init host")
 		}
 		dealMaker := replication.NewDealMaker(
-			util.NewLotusClient(cctx.String("lotus-api"), cctx.String("lotus-token")),
+			util.NewLotusClient(c.String("lotus-api"), c.String("lotus-token")),
 			h,
 			10*timeout,
 			timeout,
 		)
-		dealModel, err2 := deal.SendManualHandler(db.WithContext(ctx), ctx, dealMaker, proposal)
+		dealModel, err2 := deal.SendManualHandler(ctx, db, dealMaker, proposal)
 		if err2 != nil {
 			return err2
 		}
-		cliutil.PrintToConsole(dealModel, cctx.Bool("json"), []string{
+		cliutil.PrintToConsole(dealModel, c.Bool("json"), []string{
 			"CreatedAt", "UpdatedAt", "DealID", "DatasetID", "SectorStartEpoch",
 			"ID", "State", "ErrorMessage", "ScheduleID"})
 		return nil

--- a/cmd/ez/prep.go
+++ b/cmd/ez/prep.go
@@ -85,7 +85,7 @@ var PrepCmd = &cli.Command{
 		defer closer.Close()
 
 		// Step 1, initialize the database
-		err = admin.InitHandler(db)
+		err = admin.InitHandler(c.Context, db)
 		if err != nil {
 			return err
 		}
@@ -99,7 +99,7 @@ var PrepCmd = &cli.Command{
 				return errors.Wrap(err, "failed to create output directory")
 			}
 		}
-		ds, err2 := dataset.CreateHandler(db, dataset.CreateRequest{
+		ds, err2 := dataset.CreateHandler(c.Context, db, dataset.CreateRequest{
 			Name:       "ez",
 			MaxSizeStr: c.String("max-size"),
 			OutputDirs: outputDirs,
@@ -151,7 +151,7 @@ var PrepCmd = &cli.Command{
 		}
 
 		// Step 4, Initiate dag gen
-		_, err2 = datasource.DagGenHandler(db, strconv.Itoa(int(source.ID)))
+		_, err2 = datasource.DagGenHandler(c.Context, db, strconv.Itoa(int(source.ID)))
 		if err2 != nil {
 			return err2
 		}
@@ -164,7 +164,7 @@ var PrepCmd = &cli.Command{
 
 		// Step 6, print all information
 		cars, err2 := dataset.ListPiecesHandler(
-			db, ds.Name,
+			c.Context, db, ds.Name,
 		)
 		if err2 != nil {
 			return err2

--- a/cmd/tool/extractcar.go
+++ b/cmd/tool/extractcar.go
@@ -30,15 +30,15 @@ var ExtractCarCmd = &cli.Command{
 			Aliases:  []string{"c"},
 		},
 	},
-	Action: func(context *cli.Context) error {
-		inputDir := context.String("input-dir")
-		output := context.String("output")
-		id := context.String("cid")
-		c, err := cid.Decode(id)
+	Action: func(c *cli.Context) error {
+		inputDir := c.String("input-dir")
+		output := c.String("output")
+		id := c.String("cid")
+		cidValue, err := cid.Decode(id)
 		if err != nil {
 			return errors.Wrap(err, "failed to decode CID")
 		}
 
-		return tool.ExtractCarHandler(context.Context, inputDir, output, c)
+		return tool.ExtractCarHandler(c.Context, inputDir, output, cidValue)
 	},
 }

--- a/cmd/wallet/addremote.go
+++ b/cmd/wallet/addremote.go
@@ -21,8 +21,9 @@ var AddRemoteCmd = &cli.Command{
 		defer closer.Close()
 
 		lotusClient := util.NewLotusClient(c.String("lotus-api"), c.String("lotus-token"))
-		w, err2 := wallet.AddRemoteHandler(db,
+		w, err2 := wallet.AddRemoteHandler(
 			c.Context,
+			db,
 			lotusClient,
 			wallet.AddRemoteRequest{
 				Address:    c.Args().Get(0),

--- a/cmd/wallet/import.go
+++ b/cmd/wallet/import.go
@@ -20,8 +20,9 @@ var ImportCmd = &cli.Command{
 		defer closer.Close()
 
 		lotusClient := util.NewLotusClient(c.String("lotus-api"), c.String("lotus-token"))
-		w, err := wallet.ImportHandler(db,
+		w, err := wallet.ImportHandler(
 			c.Context,
+			db,
 			lotusClient,
 			wallet.ImportRequest{
 				PrivateKey: c.Args().Get(0),

--- a/cmd/wallet/list.go
+++ b/cmd/wallet/list.go
@@ -16,7 +16,7 @@ var ListCmd = &cli.Command{
 			return err
 		}
 		defer closer.Close()
-		wallets, err := wallet.ListHandler(db)
+		wallets, err := wallet.ListHandler(c.Context, db)
 		if err != nil {
 			return err
 		}

--- a/cmd/wallet/remove.go
+++ b/cmd/wallet/remove.go
@@ -23,6 +23,6 @@ var RemoveCmd = &cli.Command{
 			return err
 		}
 		defer closer.Close()
-		return wallet.RemoveHandler(db, c.Args().Get(0))
+		return wallet.RemoveHandler(c.Context, db, c.Args().Get(0))
 	},
 }

--- a/database/testdb.go
+++ b/database/testdb.go
@@ -3,6 +3,7 @@
 package database
 
 import (
+	"context"
 	"io"
 
 	"github.com/data-preservation-programs/singularity/model"
@@ -18,13 +19,14 @@ func OpenInMemory() (*gorm.DB, io.Closer, error) {
 		return nil, nil, err
 	}
 
-	err = DoRetry(func() error { return model.DropAll(db) })
+	ctx := context.Background()
+	err = DoRetry(ctx, func() error { return model.DropAll(db) })
 	if err != nil {
 		logger.Error(err)
 		closer.Close()
 		return nil, nil, err
 	}
-	err = DoRetry(func() error { return model.AutoMigrate(db) })
+	err = DoRetry(ctx, func() error { return model.AutoMigrate(db) })
 	if err != nil {
 		logger.Error(err)
 		closer.Close()

--- a/database/testdb_win32.go
+++ b/database/testdb_win32.go
@@ -3,6 +3,7 @@
 package database
 
 import (
+	"context"
 	"io"
 
 	"github.com/data-preservation-programs/singularity/model"
@@ -18,13 +19,14 @@ func OpenInMemory() (*gorm.DB, io.Closer, error) {
 		return nil, nil, err
 	}
 
-	err = DoRetry(func() error { return model.DropAll(db) })
+	ctx := context.Background()
+	err = DoRetry(ctx, func() error { return model.DropAll(db) })
 	if err != nil {
 		logger.Error(err)
 		closer.Close()
 		return nil, nil, err
 	}
-	err = DoRetry(func() error { return model.AutoMigrate(db) })
+	err = DoRetry(ctx, func() error { return model.AutoMigrate(db) })
 	if err != nil {
 		logger.Error(err)
 		closer.Close()

--- a/database/util.go
+++ b/database/util.go
@@ -19,8 +19,8 @@ func retryOn(err error) bool {
 	return strings.Contains(err.Error(), "database is locked") || strings.Contains(err.Error(), "database table is locked")
 }
 
-func DoRetry(f func() error) error {
-	return retry.Do(f, retry.RetryIf(retryOn), retry.LastErrorOnly(true))
+func DoRetry(ctx context.Context, f func() error) error {
+	return retry.Do(f, retry.RetryIf(retryOn), retry.LastErrorOnly(true), retry.Context(ctx))
 }
 
 type databaseLogger struct {

--- a/handler/admin/init.go
+++ b/handler/admin/init.go
@@ -1,12 +1,14 @@
 package admin
 
 import (
+	"context"
+
 	"github.com/data-preservation-programs/singularity/model"
 	"gorm.io/gorm"
 )
 
-func InitHandler(db *gorm.DB) error {
-	return initHandler(db)
+func InitHandler(ctx context.Context, db *gorm.DB) error {
+	return initHandler(db.WithContext(ctx))
 }
 
 // @Summary Initialize the database

--- a/handler/admin/init_test.go
+++ b/handler/admin/init_test.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"testing"
 
 	"github.com/data-preservation-programs/singularity/database"
@@ -13,5 +14,5 @@ func TestInitHandler(t *testing.T) {
 	require.NoError(t, err)
 	defer closer.Close()
 	defer model.DropAll(db)
-	require.NoError(t, InitHandler(db))
+	require.NoError(t, InitHandler(context.Background(), db))
 }

--- a/handler/admin/reset.go
+++ b/handler/admin/reset.go
@@ -1,6 +1,8 @@
 package admin
 
 import (
+	"context"
+
 	"github.com/data-preservation-programs/singularity/model"
 	"gorm.io/gorm"
 )
@@ -25,6 +27,6 @@ func resetHandler(db *gorm.DB) error {
 	return nil
 }
 
-func ResetHandler(db *gorm.DB) error {
-	return resetHandler(db)
+func ResetHandler(ctx context.Context, db *gorm.DB) error {
+	return resetHandler(db.WithContext(ctx))
 }

--- a/handler/dataset/addpiece.go
+++ b/handler/dataset/addpiece.go
@@ -2,6 +2,7 @@ package dataset
 
 import (
 	"bufio"
+	"context"
 	"os"
 	"strconv"
 
@@ -24,11 +25,12 @@ type AddPieceRequest struct {
 }
 
 func AddPieceHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	datasetName string,
 	request AddPieceRequest,
 ) (*model.Car, error) {
-	return addPieceHandler(db, datasetName, request)
+	return addPieceHandler(ctx, db.WithContext(ctx), datasetName, request)
 }
 
 // @Summary Manually register a piece (CAR file) with the dataset for deal making purpose
@@ -42,6 +44,7 @@ func AddPieceHandler(
 // @Failure 500 {object} api.HTTPError
 // @Router /dataset/{datasetName}/piece [post]
 func addPieceHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	datasetName string,
 	request AddPieceRequest,
@@ -108,7 +111,7 @@ func addPieceHandler(
 		DatasetID: dataset.ID,
 	}
 
-	err = database.DoRetry(func() error { return db.Create(&mCar).Error })
+	err = database.DoRetry(ctx, func() error { return db.Create(&mCar).Error })
 	if err != nil {
 		return nil, err
 	}

--- a/handler/dataset/create_test.go
+++ b/handler/dataset/create_test.go
@@ -1,6 +1,7 @@
 package dataset
 
 import (
+	"context"
 	"testing"
 
 	"github.com/data-preservation-programs/singularity/database"
@@ -13,7 +14,7 @@ func TestCreateHandler_NoDatasetName(t *testing.T) {
 	require.NoError(t, err)
 	defer closer.Close()
 	defer model.DropAll(db)
-	_, err = CreateHandler(db, CreateRequest{})
+	_, err = CreateHandler(context.Background(), db, CreateRequest{})
 	require.ErrorContains(t, err, "name is required")
 }
 
@@ -22,7 +23,7 @@ func TestCreateHandler_MaxSizeNotValid(t *testing.T) {
 	require.NoError(t, err)
 	defer closer.Close()
 	defer model.DropAll(db)
-	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "not valid"})
+	_, err = CreateHandler(context.Background(), db, CreateRequest{Name: "test", MaxSizeStr: "not valid"})
 	require.ErrorContains(t, err, "invalid value for max-size")
 }
 
@@ -31,7 +32,7 @@ func TestCreateHandler_PieceSizeNotValid(t *testing.T) {
 	require.NoError(t, err)
 	defer closer.Close()
 	defer model.DropAll(db)
-	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", PieceSizeStr: "not valid"})
+	_, err = CreateHandler(context.Background(), db, CreateRequest{Name: "test", MaxSizeStr: "2GB", PieceSizeStr: "not valid"})
 	require.ErrorContains(t, err, "invalid value for piece-size")
 }
 
@@ -40,7 +41,7 @@ func TestCreateHandler_PieceSizeNotPowerOfTwo(t *testing.T) {
 	require.NoError(t, err)
 	defer closer.Close()
 	defer model.DropAll(db)
-	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", PieceSizeStr: "3GB"})
+	_, err = CreateHandler(context.Background(), db, CreateRequest{Name: "test", MaxSizeStr: "2GB", PieceSizeStr: "3GB"})
 	require.ErrorContains(t, err, "piece size must be a power of two")
 }
 
@@ -49,7 +50,7 @@ func TestCreateHandler_PieceSizeTooLarge(t *testing.T) {
 	require.NoError(t, err)
 	defer closer.Close()
 	defer model.DropAll(db)
-	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", PieceSizeStr: "128GiB"})
+	_, err = CreateHandler(context.Background(), db, CreateRequest{Name: "test", MaxSizeStr: "2GB", PieceSizeStr: "128GiB"})
 	require.ErrorContains(t, err, "piece size cannot be larger than 64 GiB")
 }
 
@@ -58,7 +59,7 @@ func TestCreateHandler_MaxSizeTooLarge(t *testing.T) {
 	require.NoError(t, err)
 	defer closer.Close()
 	defer model.DropAll(db)
-	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "63.9GiB"})
+	_, err = CreateHandler(context.Background(), db, CreateRequest{Name: "test", MaxSizeStr: "63.9GiB"})
 	require.ErrorContains(t, err, "max size needs to be reduced to leave space for padding")
 }
 
@@ -67,7 +68,7 @@ func TestCreateHandler_OutDirDoesNotExist(t *testing.T) {
 	require.NoError(t, err)
 	defer closer.Close()
 	defer model.DropAll(db)
-	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", OutputDirs: []string{"not exist"}})
+	_, err = CreateHandler(context.Background(), db, CreateRequest{Name: "test", MaxSizeStr: "2GB", OutputDirs: []string{"not exist"}})
 	require.ErrorContains(t, err, "output directory does not exist")
 }
 
@@ -76,7 +77,7 @@ func TestCreateHandler_RecipientsScriptCannotBeUsedTogether(t *testing.T) {
 	require.NoError(t, err)
 	defer closer.Close()
 	defer model.DropAll(db)
-	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", EncryptionRecipients: []string{"test"}, EncryptionScript: "test"})
+	_, err = CreateHandler(context.Background(), db, CreateRequest{Name: "test", MaxSizeStr: "2GB", EncryptionRecipients: []string{"test"}, EncryptionScript: "test"})
 	require.ErrorContains(t, err, "encryption recipients and script cannot be used together")
 }
 
@@ -85,7 +86,7 @@ func TestCreateHandler_EncryptionNeedsOutputDir(t *testing.T) {
 	require.NoError(t, err)
 	defer closer.Close()
 	defer model.DropAll(db)
-	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB", EncryptionRecipients: []string{"test"}})
+	_, err = CreateHandler(context.Background(), db, CreateRequest{Name: "test", MaxSizeStr: "2GB", EncryptionRecipients: []string{"test"}})
 	require.ErrorContains(t, err, "encryption is not compatible with inline preparation")
 }
 
@@ -94,7 +95,7 @@ func TestCreateHandler_Success(t *testing.T) {
 	require.NoError(t, err)
 	defer closer.Close()
 	defer model.DropAll(db)
-	_, err = CreateHandler(db, CreateRequest{Name: "test", MaxSizeStr: "2GB"})
+	_, err = CreateHandler(context.Background(), db, CreateRequest{Name: "test", MaxSizeStr: "2GB"})
 	require.NoError(t, err)
 	dataset := model.Dataset{}
 	db.Where("name = ?", "test").First(&dataset)

--- a/handler/dataset/list.go
+++ b/handler/dataset/list.go
@@ -1,6 +1,8 @@
 package dataset
 
 import (
+	"context"
+
 	"github.com/data-preservation-programs/singularity/model"
 	"gorm.io/gorm"
 )
@@ -24,7 +26,8 @@ func listHandler(
 }
 
 func ListHandler(
+	ctx context.Context,
 	db *gorm.DB,
 ) ([]model.Dataset, error) {
-	return listHandler(db)
+	return listHandler(db.WithContext(ctx))
 }

--- a/handler/dataset/listpieces.go
+++ b/handler/dataset/listpieces.go
@@ -1,6 +1,8 @@
 package dataset
 
 import (
+	"context"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
@@ -39,8 +41,9 @@ func listPiecesHandler(
 }
 
 func ListPiecesHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	datasetName string,
 ) ([]model.Car, error) {
-	return listPiecesHandler(db, datasetName)
+	return listPiecesHandler(db.WithContext(ctx), datasetName)
 }

--- a/handler/dataset/remove.go
+++ b/handler/dataset/remove.go
@@ -1,6 +1,8 @@
 package dataset
 
 import (
+	"context"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler"
 	"gorm.io/gorm"
@@ -15,6 +17,7 @@ import (
 // @Failure 500 {object} api.HTTPError
 // @Router /dataset/{datasetName} [delete]
 func removeHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	datasetName string,
 ) error {
@@ -22,7 +25,7 @@ func removeHandler(
 	if err != nil {
 		return handler.NewInvalidParameterErr("failed to find dataset: " + err.Error())
 	}
-	err = database.DoRetry(func() error { return db.Delete(&dataset).Error })
+	err = database.DoRetry(ctx, func() error { return db.Delete(&dataset).Error })
 	if err != nil {
 		return err
 	}
@@ -30,8 +33,9 @@ func removeHandler(
 }
 
 func RemoveHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	datasetName string,
 ) error {
-	return removeHandler(db, datasetName)
+	return removeHandler(ctx, db.WithContext(ctx), datasetName)
 }

--- a/handler/dataset/update.go
+++ b/handler/dataset/update.go
@@ -1,6 +1,7 @@
 package dataset
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -22,11 +23,12 @@ type UpdateRequest struct {
 }
 
 func UpdateHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	datasetName string,
 	request UpdateRequest,
 ) (*model.Dataset, error) {
-	return updateHandler(db, datasetName, request)
+	return updateHandler(ctx, db.WithContext(ctx), datasetName, request)
 }
 
 // @Summary Update a dataset
@@ -40,6 +42,7 @@ func UpdateHandler(
 // @Failure 500 {object} api.HTTPError
 // @Router /dataset/{datasetName} [patch]
 func updateHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	datasetName string,
 	request UpdateRequest,
@@ -59,7 +62,7 @@ func updateHandler(
 		return nil, err2
 	}
 
-	err = database.DoRetry(func() error { return db.Save(&dataset).Error })
+	err = database.DoRetry(ctx, func() error { return db.Save(&dataset).Error })
 	if err != nil {
 		return nil, err
 	}

--- a/handler/datasource/add.go
+++ b/handler/datasource/add.go
@@ -20,14 +20,13 @@ import (
 var ValidateSource = true
 
 func CreateDatasourceHandler(
-	db *gorm.DB,
 	ctx context.Context,
-	datasourceHandlerResolver datasource.HandlerResolver,
+	db *gorm.DB,
 	sourceType string,
 	datasetName string,
 	sourceParameters map[string]any,
 ) (*model.Source, error) {
-	return createDatasourceHandler(db, ctx, sourceType, datasetName, sourceParameters)
+	return createDatasourceHandler(ctx, db, sourceType, datasetName, sourceParameters)
 }
 
 // @Summary Add acd source for a dataset
@@ -41,8 +40,8 @@ func CreateDatasourceHandler(
 // @Param request body AcdRequest true "Request body"
 // @Router /source/acd/dataset/{datasetName} [post]
 func createDatasourceHandler(
-	db *gorm.DB,
 	ctx context.Context,
+	db *gorm.DB,
 	sourceType string,
 	datasetName string,
 	sourceParameters map[string]any,

--- a/handler/datasource/check.go
+++ b/handler/datasource/check.go
@@ -26,12 +26,12 @@ type Entry struct {
 }
 
 func CheckSourceHandler(
-	db *gorm.DB,
 	ctx context.Context,
+	db *gorm.DB,
 	id string,
 	request CheckSourceRequest,
 ) ([]Entry, error) {
-	return checkSourceHandler(db, ctx, id, request)
+	return checkSourceHandler(ctx, db.WithContext(ctx), id, request)
 }
 
 // @Summary Check the connection of the data source by listing a path
@@ -45,8 +45,8 @@ func CheckSourceHandler(
 // @Failure 500 {object} api.HTTPError
 // @Router /source/{id}/check [post]
 func checkSourceHandler(
-	db *gorm.DB,
 	ctx context.Context,
+	db *gorm.DB,
 	id string,
 	request CheckSourceRequest,
 ) ([]Entry, error) {

--- a/handler/datasource/chunk.go
+++ b/handler/datasource/chunk.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/data-preservation-programs/singularity/database"
@@ -16,11 +17,12 @@ type ChunkRequest struct {
 }
 
 func ChunkHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	sourceID string,
 	request ChunkRequest,
 ) (*model.Chunk, error) {
-	return chunkHandler(db, sourceID, request)
+	return chunkHandler(ctx, db.WithContext(ctx), sourceID, request)
 }
 
 // @Summary Create a chunk for the specified items
@@ -34,6 +36,7 @@ func ChunkHandler(
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /source/{id}/chunk [post]
 func chunkHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	sourceID string,
 	request ChunkRequest,
@@ -48,7 +51,7 @@ func chunkHandler(
 		PackingState: model.Ready,
 	}
 
-	err = database.DoRetry(func() error {
+	err = database.DoRetry(ctx, func() error {
 		return db.Transaction(
 			func(db *gorm.DB) error {
 				err := db.Create(&chunk).Error

--- a/handler/datasource/inspect/chunkdetail.go
+++ b/handler/datasource/inspect/chunkdetail.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/data-preservation-programs/singularity/handler"
@@ -11,10 +12,11 @@ import (
 )
 
 func GetSourceChunkDetailHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	id string,
 ) (*model.Chunk, error) {
-	return getSourceChunkDetailHandler(db, id)
+	return getSourceChunkDetailHandler(db.WithContext(ctx), id)
 }
 
 // @Summary Get detail of a specific chunk

--- a/handler/datasource/inspect/chunks.go
+++ b/handler/datasource/inspect/chunks.go
@@ -1,6 +1,8 @@
 package inspect
 
 import (
+	"context"
+
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/pkg/errors"
@@ -12,11 +14,12 @@ type GetSourceChunksRequest struct {
 }
 
 func GetSourceChunksHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	id uint32,
 	request GetSourceChunksRequest,
 ) ([]model.Chunk, error) {
-	return getSourceChunksHandler(db, id, request)
+	return getSourceChunksHandler(db.WithContext(ctx), id, request)
 }
 
 // @Summary Get all chunk details of a data source

--- a/handler/datasource/inspect/dags.go
+++ b/handler/datasource/inspect/dags.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/data-preservation-programs/singularity/handler"
@@ -10,10 +11,11 @@ import (
 )
 
 func GetDagsHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	id string,
 ) ([]model.Car, error) {
-	return getDagsHandler(db, id)
+	return getDagsHandler(db.WithContext(ctx), id)
 }
 
 // @Summary Get all dag details of a data source

--- a/handler/datasource/inspect/itemdetail.go
+++ b/handler/datasource/inspect/itemdetail.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/data-preservation-programs/singularity/handler"
@@ -10,10 +11,11 @@ import (
 )
 
 func GetSourceItemDetailHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	id string,
 ) (*model.Item, error) {
-	return getSourceItemDetailHandler(db, id)
+	return getSourceItemDetailHandler(db.WithContext(ctx), id)
 }
 
 // @Summary Get details about an item

--- a/handler/datasource/inspect/items.go
+++ b/handler/datasource/inspect/items.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/data-preservation-programs/singularity/handler"
@@ -10,10 +11,11 @@ import (
 )
 
 func GetSourceItemsHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	id string,
 ) ([]model.Item, error) {
-	return getSourceItemsHandler(db, id)
+	return getSourceItemsHandler(db.WithContext(ctx), id)
 }
 
 // @Summary Get all item details of a data source

--- a/handler/datasource/inspect/path.go
+++ b/handler/datasource/inspect/path.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"context"
 	"strconv"
 	"strings"
 
@@ -22,11 +23,12 @@ type GetPathRequest struct {
 }
 
 func GetPathHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	id string,
 	request GetPathRequest,
 ) (*DirDetail, error) {
-	return getPathHandler(db, id, request)
+	return getPathHandler(db.WithContext(ctx), id, request)
 }
 
 // @Summary Get all item details inside a data source path

--- a/handler/datasource/list.go
+++ b/handler/datasource/list.go
@@ -1,6 +1,8 @@
 package datasource
 
 import (
+	"context"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
@@ -8,9 +10,11 @@ import (
 )
 
 func ListSourcesByDatasetHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	datasetName string,
 ) ([]model.Source, error) {
+	db = db.WithContext(ctx)
 	var sources []model.Source
 	if datasetName == "" {
 		err := db.Find(&sources).Error
@@ -39,13 +43,15 @@ func ListSourcesByDatasetHandler(
 // @Failure 500 {object} api.HTTPError
 // @Router /source [get]
 func listSourceHandler(
+	ctx context.Context,
 	db *gorm.DB,
 ) ([]model.Source, error) {
-	return ListSourcesByDatasetHandler(db, "")
+	return ListSourcesByDatasetHandler(ctx, db, "")
 }
 
 func ListSourceHandler(
+	ctx context.Context,
 	db *gorm.DB,
 ) ([]model.Source, error) {
-	return listSourceHandler(db)
+	return listSourceHandler(ctx, db.WithContext(ctx))
 }

--- a/handler/datasource/pack.go
+++ b/handler/datasource/pack.go
@@ -84,7 +84,7 @@ func Pack(
 			return nil, errors.New("item part not found in result")
 		}
 		logger.Debugw("update item part CID", "itemPartID", itemPartID, "CID", itemPartCID.String())
-		err = database.DoRetry(func() error {
+		err = database.DoRetry(ctx, func() error {
 			return db.Model(&model.ItemPart{}).Where("id = ?", itemPartID).
 				Update("cid", model.CID(itemPartCID)).Error
 		})
@@ -93,7 +93,7 @@ func Pack(
 		}
 		logger.Debugw("update item CID", "itemID", itemPart.ItemID, "CID", itemPartCID.String())
 		if itemPart.Offset == 0 && itemPart.Length == itemPart.Item.Size {
-			err = database.DoRetry(func() error {
+			err = database.DoRetry(ctx, func() error {
 				return db.Model(&model.Item{}).Where("id = ?", itemPart.ItemID).
 					Update("cid", model.CID(itemPartCID)).Error
 			})
@@ -105,7 +105,7 @@ func Pack(
 
 	logger.Debugw("create car for finished chunk", "chunkID", chunk.ID)
 	var cars []model.Car
-	err = database.DoRetry(func() error {
+	err = database.DoRetry(ctx, func() error {
 		return db.Transaction(
 			func(db *gorm.DB) error {
 				for _, result := range result.CarResults {
@@ -142,7 +142,7 @@ func Pack(
 	}
 
 	logger.Debugw("update directory data", "chunkID", chunk.ID)
-	err = database.DoRetry(func() error {
+	err = database.DoRetry(ctx, func() error {
 		return db.Transaction(func(db *gorm.DB) error {
 			dirCache := make(map[uint64]*daggen.DirectoryData)
 			childrenCache := make(map[uint64][]uint64)

--- a/handler/datasource/remove.go
+++ b/handler/datasource/remove.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/data-preservation-programs/singularity/database"
@@ -18,6 +19,7 @@ import (
 // @Failure 500 {object} api.HTTPError
 // @Router /source/{id} [delete]
 func removeSourceHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	id string,
 ) error {
@@ -33,7 +35,7 @@ func removeSourceHandler(
 	if err != nil {
 		return err
 	}
-	err = database.DoRetry(func() error { return db.Delete(&source).Error })
+	err = database.DoRetry(ctx, func() error { return db.Delete(&source).Error })
 	if err != nil {
 		return err
 	}
@@ -41,8 +43,9 @@ func removeSourceHandler(
 }
 
 func RemoveSourceHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	id string,
 ) error {
-	return removeSourceHandler(db, id)
+	return removeSourceHandler(ctx, db.WithContext(ctx), id)
 }

--- a/handler/datasource/repack.go
+++ b/handler/datasource/repack.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/data-preservation-programs/singularity/database"
@@ -19,6 +20,7 @@ import (
 // @Failure 500 {object} api.HTTPError
 // @Router /source/{id}/repack [post]
 func repackHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	id string,
 	request RepackRequest,
@@ -51,7 +53,7 @@ func repackHandler(
 			return nil, err
 		}
 		if chunk.PackingState == model.Error || chunk.PackingState == model.Complete {
-			err = database.DoRetry(func() error {
+			err = database.DoRetry(ctx, func() error {
 				return db.Model(&chunk).Updates(map[string]any{
 					"packing_state": model.Ready,
 					"error_message": "",
@@ -96,9 +98,10 @@ type RepackRequest struct {
 }
 
 func RepackHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	id string,
 	request RepackRequest,
 ) ([]model.Chunk, error) {
-	return repackHandler(db, id, request)
+	return repackHandler(ctx, db.WithContext(ctx), id, request)
 }

--- a/handler/datasource/rescan.go
+++ b/handler/datasource/rescan.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/data-preservation-programs/singularity/database"
@@ -18,6 +19,7 @@ import (
 // @Failure 500 {object} api.HTTPError
 // @Router /source/{id}/rescan [post]
 func rescanSourceHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	id string,
 ) (*model.Source, error) {
@@ -32,7 +34,7 @@ func rescanSourceHandler(
 			return err
 		}
 		if source.ScanningState == model.Error || source.ScanningState == model.Complete {
-			return database.DoRetry(func() error {
+			return database.DoRetry(ctx, func() error {
 				return db.Model(&source).Updates(map[string]any{
 					"scanning_state":         model.Ready,
 					"last_scanned_timestamp": 0,
@@ -54,8 +56,9 @@ func rescanSourceHandler(
 }
 
 func RescanSourceHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	id string,
 ) (*model.Source, error) {
-	return rescanSourceHandler(db, id)
+	return rescanSourceHandler(ctx, db.WithContext(ctx), id)
 }

--- a/handler/datasource/summary.go
+++ b/handler/datasource/summary.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/data-preservation-programs/singularity/handler"
@@ -79,8 +80,9 @@ func getSourceStatusHandler(
 }
 
 func GetSourceStatusHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	id string,
 ) (*SourceStatus, error) {
-	return getSourceStatusHandler(db, id)
+	return getSourceStatusHandler(db.WithContext(ctx), id)
 }

--- a/handler/datasource/update.go
+++ b/handler/datasource/update.go
@@ -20,12 +20,12 @@ import (
 type Config map[string]any
 
 func UpdateSourceHandler(
-	db *gorm.DB,
 	ctx context.Context,
+	db *gorm.DB,
 	id string,
 	config Config,
 ) (*model.Source, error) {
-	return updateSourceHandler(db, ctx, id, config)
+	return updateSourceHandler(ctx, db.WithContext(ctx), id, config)
 }
 
 // @Summary Update the config options of a source
@@ -39,8 +39,8 @@ func UpdateSourceHandler(
 // @Failure 500 {object} api.HTTPError
 // @Router /source/{id} [patch]
 func updateSourceHandler(
-	db *gorm.DB,
 	ctx context.Context,
+	db *gorm.DB,
 	id string,
 	config Config,
 ) (*model.Source, error) {
@@ -118,7 +118,7 @@ func updateSourceHandler(
 		return nil, handler.InvalidParameterError{Err: err}
 	}
 
-	err = database.DoRetry(func() error {
+	err = database.DoRetry(ctx, func() error {
 		return db.Model(&source).Updates(map[string]any{
 			"metadata":              source.Metadata,
 			"scan_interval_seconds": source.ScanIntervalSeconds,

--- a/handler/deal/list.go
+++ b/handler/deal/list.go
@@ -1,6 +1,8 @@
 package deal
 
 import (
+	"context"
+
 	"github.com/data-preservation-programs/singularity/model"
 	"gorm.io/gorm"
 )
@@ -12,8 +14,8 @@ type ListDealRequest struct {
 	States    []string `json:"states"`    // state filter
 }
 
-func ListHandler(db *gorm.DB, request ListDealRequest) ([]model.Deal, error) {
-	return listHandler(db, request)
+func ListHandler(ctx context.Context, db *gorm.DB, request ListDealRequest) ([]model.Deal, error) {
+	return listHandler(db.WithContext(ctx), request)
 }
 
 // @Summary List all deals

--- a/handler/deal/schedule/create_test.go
+++ b/handler/deal/schedule/create_test.go
@@ -76,7 +76,7 @@ func TestCreateHandler_DatasetNotFound(t *testing.T) {
 	db, closer, err := database.OpenInMemory()
 	require.NoError(t, err)
 	defer closer.Close()
-	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), createRequest)
+	_, err = CreateHandler(context.Background(), db, getMockLotusClient(), createRequest)
 	require.ErrorContains(t, err, "dataset not found")
 }
 
@@ -87,7 +87,7 @@ func TestCreateHandler_InvalidStartDelay(t *testing.T) {
 	require.NoError(t, db.Create(&model.Dataset{Name: "test"}).Error)
 	badRequest := createRequest
 	badRequest.StartDelay = "1year"
-	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
+	_, err = CreateHandler(context.Background(), db, getMockLotusClient(), badRequest)
 	require.ErrorContains(t, err, "invalid start delay")
 }
 
@@ -98,7 +98,7 @@ func TestCreateHandler_InvalidDuration(t *testing.T) {
 	require.NoError(t, db.Create(&model.Dataset{Name: "test"}).Error)
 	badRequest := createRequest
 	badRequest.Duration = "1year"
-	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
+	_, err = CreateHandler(context.Background(), db, getMockLotusClient(), badRequest)
 	require.ErrorContains(t, err, "invalid duration")
 }
 
@@ -109,7 +109,7 @@ func TestCreateHandler_InvalidScheduleInterval(t *testing.T) {
 	require.NoError(t, db.Create(&model.Dataset{Name: "test"}).Error)
 	badRequest := createRequest
 	badRequest.ScheduleCron = "1year"
-	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
+	_, err = CreateHandler(context.Background(), db, getMockLotusClient(), badRequest)
 	require.ErrorContains(t, err, "invalid schedule cron")
 }
 
@@ -121,7 +121,7 @@ func TestCreateHandler_InvalidScheduleDealSize(t *testing.T) {
 	require.NoError(t, err)
 	badRequest := createRequest
 	badRequest.ScheduleDealSize = "One PB"
-	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
+	_, err = CreateHandler(context.Background(), db, getMockLotusClient(), badRequest)
 	require.ErrorContains(t, err, "invalid schedule deal size")
 }
 
@@ -133,7 +133,7 @@ func TestCreateHandler_InvalidTotalDealSize(t *testing.T) {
 	require.NoError(t, err)
 	badRequest := createRequest
 	badRequest.TotalDealSize = "One PB"
-	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
+	_, err = CreateHandler(context.Background(), db, getMockLotusClient(), badRequest)
 	require.ErrorContains(t, err, "invalid total deal size")
 }
 
@@ -145,7 +145,7 @@ func TestCreateHandler_InvalidPendingDealSize(t *testing.T) {
 	require.NoError(t, err)
 	badRequest := createRequest
 	badRequest.MaxPendingDealSize = "One PB"
-	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
+	_, err = CreateHandler(context.Background(), db, getMockLotusClient(), badRequest)
 	require.ErrorContains(t, err, "invalid pending deal size")
 }
 
@@ -157,7 +157,7 @@ func TestCreateHandler_InvalidAllowedPieceCID_NotCID(t *testing.T) {
 	require.NoError(t, err)
 	badRequest := createRequest
 	badRequest.AllowedPieceCIDs = []string{"not a cid"}
-	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
+	_, err = CreateHandler(context.Background(), db, getMockLotusClient(), badRequest)
 	require.ErrorContains(t, err, "it's not a CID")
 }
 
@@ -169,7 +169,7 @@ func TestCreateHandler_InvalidAllowedPieceCID_NotCommp(t *testing.T) {
 	require.NoError(t, err)
 	badRequest := createRequest
 	badRequest.AllowedPieceCIDs = []string{"bafybeiejlvvmfokp5c6q2eqgbfjeaokz3nqho5c7yy3ov527vsatgsqfma"}
-	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), badRequest)
+	_, err = CreateHandler(context.Background(), db, getMockLotusClient(), badRequest)
 	require.ErrorContains(t, err, "it's not a commp")
 }
 
@@ -179,7 +179,7 @@ func TestCreateHandler_NoAssociatedWallet(t *testing.T) {
 	defer closer.Close()
 	err = db.Create(&model.Dataset{Name: "test"}).Error
 	require.NoError(t, err)
-	_, err = CreateHandler(db, context.Background(), getMockLotusClient(), createRequest)
+	_, err = CreateHandler(context.Background(), db, getMockLotusClient(), createRequest)
 	require.ErrorContains(t, err, "no wallet")
 }
 
@@ -196,7 +196,7 @@ func TestCreateHandler_InvalidProvider(t *testing.T) {
 	lotusClient := new(MockRPCClient)
 	lotusClient.On("CallFor", mock.Anything, mock.Anything, "Filecoin.StateLookupID", mock.Anything).
 		Return(errors.New("Some provider error"))
-	_, err = CreateHandler(db, context.Background(), lotusClient, createRequest)
+	_, err = CreateHandler(context.Background(), db, lotusClient, createRequest)
 	require.ErrorContains(t, err, "Some provider error")
 }
 
@@ -210,7 +210,7 @@ func TestCreateHandler_Success(t *testing.T) {
 	require.NoError(t, err)
 	err = db.Create(&model.WalletAssignment{WalletID: "f01", DatasetID: 1}).Error
 	require.NoError(t, err)
-	schedule, err := CreateHandler(db, context.Background(), getMockLotusClient(), createRequest)
+	schedule, err := CreateHandler(context.Background(), db, getMockLotusClient(), createRequest)
 	require.NoError(t, err)
 	require.NotNil(t, schedule)
 }

--- a/handler/deal/schedule/list.go
+++ b/handler/deal/schedule/list.go
@@ -1,6 +1,8 @@
 package schedule
 
 import (
+	"context"
+
 	"github.com/data-preservation-programs/singularity/model"
 	"gorm.io/gorm"
 )
@@ -25,7 +27,8 @@ func listHandler(
 }
 
 func ListHandler(
+	ctx context.Context,
 	db *gorm.DB,
 ) ([]model.Schedule, error) {
-	return listHandler(db)
+	return listHandler(db.WithContext(ctx))
 }

--- a/handler/deal/send-manual.go
+++ b/handler/deal/send-manual.go
@@ -48,12 +48,12 @@ func argToDuration(s string) (time.Duration, error) {
 }
 
 func SendManualHandler(
-	db *gorm.DB,
 	ctx context.Context,
+	db *gorm.DB,
 	dealMaker replication.DealMaker,
 	request Proposal,
 ) (*model.Deal, error) {
-	return sendManualHandler(db, ctx, dealMaker, request)
+	return sendManualHandler(ctx, db.WithContext(ctx), dealMaker, request)
 }
 
 // @Summary Send a manual deal proposal
@@ -67,8 +67,8 @@ func SendManualHandler(
 // @Failure 500 {object} api.HTTPError
 // @Router /send_deal [post]
 func sendManualHandler(
-	db *gorm.DB,
 	ctx context.Context,
+	db *gorm.DB,
 	dealMaker replication.DealMaker,
 	request Proposal,
 ) (*model.Deal, error) {

--- a/handler/deal/send-manual_test.go
+++ b/handler/deal/send-manual_test.go
@@ -52,7 +52,7 @@ func TestSendManualHandler_WalletNotFound(t *testing.T) {
 
 	mockDealMaker := new(MockDealMaker)
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return(&model.Deal{}, nil)
-	_, err = SendManualHandler(db, ctx, mockDealMaker, proposal)
+	_, err = SendManualHandler(ctx, db, mockDealMaker, proposal)
 	require.ErrorContains(t, err, "client address not found")
 }
 
@@ -73,7 +73,7 @@ func TestSendManualHandler_InvalidPieceCID(t *testing.T) {
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return(&model.Deal{}, nil)
 	badProposal := proposal
 	badProposal.PieceCID = "bad"
-	_, err = SendManualHandler(db, ctx, mockDealMaker, badProposal)
+	_, err = SendManualHandler(ctx, db, mockDealMaker, badProposal)
 	require.ErrorContains(t, err, "invalid piece CID")
 }
 
@@ -94,7 +94,7 @@ func TestSendManualHandler_InvalidPieceCID_NOTCOMMP(t *testing.T) {
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return(&model.Deal{}, nil)
 	badProposal := proposal
 	badProposal.PieceCID = proposal.RootCID
-	_, err = SendManualHandler(db, ctx, mockDealMaker, badProposal)
+	_, err = SendManualHandler(ctx, db, mockDealMaker, badProposal)
 	require.ErrorContains(t, err, "piece CID must be commp")
 }
 
@@ -115,7 +115,7 @@ func TestSendManualHandler_InvalidPieceSize(t *testing.T) {
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return(&model.Deal{}, nil)
 	badProposal := proposal
 	badProposal.PieceSize = "aaa"
-	_, err = SendManualHandler(db, ctx, mockDealMaker, badProposal)
+	_, err = SendManualHandler(ctx, db, mockDealMaker, badProposal)
 	require.ErrorContains(t, err, "invalid piece size")
 }
 
@@ -136,7 +136,7 @@ func TestSendManualHandler_InvalidPieceSize_NotPowerOfTwo(t *testing.T) {
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return(&model.Deal{}, nil)
 	badProposal := proposal
 	badProposal.PieceSize = "31GiB"
-	_, err = SendManualHandler(db, ctx, mockDealMaker, badProposal)
+	_, err = SendManualHandler(ctx, db, mockDealMaker, badProposal)
 	require.ErrorContains(t, err, "piece size must be a power of 2")
 }
 
@@ -157,7 +157,7 @@ func TestSendManualHandler_InvalidRootCID(t *testing.T) {
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return(&model.Deal{}, nil)
 	badProposal := proposal
 	badProposal.RootCID = "xxxx"
-	_, err = SendManualHandler(db, ctx, mockDealMaker, badProposal)
+	_, err = SendManualHandler(ctx, db, mockDealMaker, badProposal)
 	require.ErrorContains(t, err, "invalid root CID")
 }
 
@@ -178,7 +178,7 @@ func TestSendManualHandler_InvalidDuration(t *testing.T) {
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return(&model.Deal{}, nil)
 	badProposal := proposal
 	badProposal.Duration = "xxxx"
-	_, err = SendManualHandler(db, ctx, mockDealMaker, badProposal)
+	_, err = SendManualHandler(ctx, db, mockDealMaker, badProposal)
 	require.ErrorContains(t, err, "invalid duration")
 }
 
@@ -199,7 +199,7 @@ func TestSendManualHandler_InvalidStartDelay(t *testing.T) {
 	mockDealMaker.On("MakeDeal", ctx, wallet, mock.Anything, mock.Anything).Return(&model.Deal{}, nil)
 	badProposal := proposal
 	badProposal.StartDelay = "xxxx"
-	_, err = SendManualHandler(db, ctx, mockDealMaker, badProposal)
+	_, err = SendManualHandler(ctx, db, mockDealMaker, badProposal)
 	require.ErrorContains(t, err, "invalid start delay")
 }
 
@@ -230,7 +230,7 @@ func TestSendManualHandler(t *testing.T) {
 		PricePerGB:      proposal.PricePerGB,
 		PricePerGBEpoch: proposal.PricePerGBEpoch,
 	}).Return(&model.Deal{}, nil)
-	resp, err := SendManualHandler(db, ctx, mockDealMaker, proposal)
+	resp, err := SendManualHandler(ctx, db, mockDealMaker, proposal)
 	mockDealMaker.AssertExpectations(t)
 	require.NoError(t, err)
 	require.NotNil(t, resp)

--- a/handler/wallet/addremote.go
+++ b/handler/wallet/addremote.go
@@ -18,12 +18,12 @@ type AddRemoteRequest struct {
 }
 
 func AddRemoteHandler(
-	db *gorm.DB,
 	ctx context.Context,
+	db *gorm.DB,
 	lotusClient jsonrpc.RPCClient,
 	request AddRemoteRequest,
 ) (*model.Wallet, error) {
-	return addRemoteHandler(db, ctx, lotusClient, request)
+	return addRemoteHandler(ctx, db.WithContext(ctx), lotusClient, request)
 }
 
 // @Summary Add a remote wallet
@@ -36,8 +36,8 @@ func AddRemoteHandler(
 // @Failure 500 {object} api.HTTPError
 // @Router /wallet/remote [post]
 func addRemoteHandler(
-	db *gorm.DB,
 	ctx context.Context,
+	db *gorm.DB,
 	lotusClient jsonrpc.RPCClient,
 	request AddRemoteRequest,
 ) (*model.Wallet, error) {
@@ -67,7 +67,7 @@ func addRemoteHandler(
 		RemotePeer: request.RemotePeer,
 	}
 
-	err = database.DoRetry(func() error { return db.Create(&wallet).Error })
+	err = database.DoRetry(ctx, func() error { return db.Create(&wallet).Error })
 	if err != nil {
 		return nil, err
 	}

--- a/handler/wallet/addwallet.go
+++ b/handler/wallet/addwallet.go
@@ -1,6 +1,8 @@
 package wallet
 
 import (
+	"context"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
@@ -8,11 +10,12 @@ import (
 )
 
 func AddWalletHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	datasetName string,
 	wallet string,
 ) (*model.WalletAssignment, error) {
-	return addWalletHandler(db, datasetName, wallet)
+	return addWalletHandler(ctx, db.WithContext(ctx), datasetName, wallet)
 }
 
 // @Summary Associate a new wallet with a dataset
@@ -26,6 +29,7 @@ func AddWalletHandler(
 // @Failure 500 {object} api.HTTPError
 // @Router /dataset/{datasetName}/wallet/{wallet} [post]
 func addWalletHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	datasetName string,
 	wallet string,
@@ -54,7 +58,7 @@ func addWalletHandler(
 		WalletID:  w.ID,
 	}
 
-	err = database.DoRetry(func() error {
+	err = database.DoRetry(ctx, func() error {
 		return db.Create(&a).Error
 	})
 

--- a/handler/wallet/list.go
+++ b/handler/wallet/list.go
@@ -1,14 +1,17 @@
 package wallet
 
 import (
+	"context"
+
 	"github.com/data-preservation-programs/singularity/model"
 	"gorm.io/gorm"
 )
 
 func ListHandler(
+	ctx context.Context,
 	db *gorm.DB,
 ) ([]model.Wallet, error) {
-	return listHandler(db)
+	return listHandler(db.WithContext(ctx))
 }
 
 // @Summary List all imported wallets

--- a/handler/wallet/listwallet.go
+++ b/handler/wallet/listwallet.go
@@ -1,6 +1,8 @@
 package wallet
 
 import (
+	"context"
+
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/pkg/errors"
@@ -8,10 +10,11 @@ import (
 )
 
 func ListWalletHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	datasetName string,
 ) ([]model.Wallet, error) {
-	return listWalletHandler(db, datasetName)
+	return listWalletHandler(db.WithContext(ctx), datasetName)
 }
 
 // @Summary List all wallets of a dataset.

--- a/handler/wallet/remove.go
+++ b/handler/wallet/remove.go
@@ -1,16 +1,19 @@
 package wallet
 
 import (
+	"context"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/model"
 	"gorm.io/gorm"
 )
 
 func RemoveHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	address string,
 ) error {
-	return removeHandler(db, address)
+	return removeHandler(ctx, db.WithContext(ctx), address)
 }
 
 // @Summary Remove a wallet
@@ -21,10 +24,11 @@ func RemoveHandler(
 // @Failure 500 {object} api.HTTPError
 // @Router /wallet/{address} [delete]
 func removeHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	address string,
 ) error {
-	err := database.DoRetry(func() error { return db.Where("address = ? OR id = ?", address, address).Delete(&model.Wallet{}).Error })
+	err := database.DoRetry(ctx, func() error { return db.Where("address = ? OR id = ?", address, address).Delete(&model.Wallet{}).Error })
 	if err != nil {
 		return err
 	}

--- a/handler/wallet/removewallet.go
+++ b/handler/wallet/removewallet.go
@@ -1,6 +1,8 @@
 package wallet
 
 import (
+	"context"
+
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
@@ -8,11 +10,12 @@ import (
 )
 
 func RemoveWalletHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	datasetName string,
 	wallet string,
 ) error {
-	return removeWalletHandler(db, datasetName, wallet)
+	return removeWalletHandler(ctx, db.WithContext(ctx), datasetName, wallet)
 }
 
 // @Summary Remove an associated wallet from a dataset
@@ -24,6 +27,7 @@ func RemoveWalletHandler(
 // @Failure 500 {object} api.HTTPError
 // @Router /dataset/{datasetName}/wallet/{wallet} [delete]
 func removeWalletHandler(
+	ctx context.Context,
 	db *gorm.DB,
 	datasetName string,
 	wallet string,
@@ -47,7 +51,7 @@ func removeWalletHandler(
 		return handler.NewInvalidParameterErr("failed to find wallet: " + err.Error())
 	}
 
-	err = database.DoRetry(func() error {
+	err = database.DoRetry(ctx, func() error {
 		return db.Where("dataset_id = ? AND wallet_id = ?", dataset.ID, w.ID).Delete(&model.WalletAssignment{}).Error
 	})
 

--- a/migrate/migrate-dataset.go
+++ b/migrate/migrate-dataset.go
@@ -31,7 +31,7 @@ func migrateDataset(ctx context.Context, mg *mongo.Client, db *gorm.DB, scanning
 	if err != nil {
 		log.Printf("[Warning] Output directory %s does not exist\n", scanning.OutDir)
 	}
-	ds, err := dataset.CreateHandler(db, dataset.CreateRequest{
+	ds, err := dataset.CreateHandler(ctx, db, dataset.CreateRequest{
 		Name:                 scanning.Name,
 		MaxSizeStr:           fmt.Sprintf("%d", scanning.MaxSize),
 		OutputDirs:           nil,
@@ -61,7 +61,7 @@ func migrateDataset(ctx context.Context, mg *mongo.Client, db *gorm.DB, scanning
 		"rescanInterval":    "0",
 		"scanningState":     "complete",
 	}
-	src, err := datasource.CreateDatasourceHandler(db, ctx, nil, sourceType, ds.Name, metadata)
+	src, err := datasource.CreateDatasourceHandler(ctx, db, sourceType, ds.Name, metadata)
 	if err != nil {
 		return errors.Wrap(err, "failed to create datasource")
 	}
@@ -222,7 +222,7 @@ func migrateDataset(ctx context.Context, mg *mongo.Client, db *gorm.DB, scanning
 						item.CID = model.CID(root.Cid())
 					}
 				}
-				err = datasource.EnsureParentDirectories(db, &item, rootDirectoryID, directoryCache)
+				err = datasource.EnsureParentDirectories(ctx, db, &item, rootDirectoryID, directoryCache)
 				if err != nil {
 					return errors.Wrap(err, "failed to ensure parent directories")
 				}

--- a/migrate/migrate-dataset_test.go
+++ b/migrate/migrate-dataset_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/model"
+	"github.com/ipfs/boxo/util"
 	"github.com/ipfs/go-cid"
-	util "github.com/ipfs/go-ipfs-util"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 	"go.mongodb.org/mongo-driver/bson/primitive"

--- a/service/contentprovider/bitswap.go
+++ b/service/contentprovider/bitswap.go
@@ -14,8 +14,8 @@ import (
 )
 
 type BitswapServer struct {
-	db   *gorm.DB
-	host host.Host
+	dbNoContext *gorm.DB
+	host        host.Host
 }
 
 func (BitswapServer) Name() string {
@@ -29,7 +29,7 @@ func (s BitswapServer) Start(ctx context.Context) ([]service.Done, service.Fail,
 	}
 
 	net := bsnetwork.NewFromIpfsHost(s.host, nilRouter)
-	bs := &store.ItemReferenceBlockStore{DB: s.db, HandlerResolver: datasource.DefaultHandlerResolver{}}
+	bs := &store.ItemReferenceBlockStore{DBNoContext: s.dbNoContext, HandlerResolver: datasource.DefaultHandlerResolver{}}
 	bsserver := server.New(ctx, net, bs)
 	net.Start(bsserver)
 	done := make(chan struct{})

--- a/service/contentprovider/bitswap_test.go
+++ b/service/contentprovider/bitswap_test.go
@@ -17,8 +17,8 @@ func TestBitswapServer(t *testing.T) {
 	h, err := util.InitHost(nil)
 	require.NoError(t, err)
 	s := BitswapServer{
-		db:   db,
-		host: h,
+		dbNoContext: db,
+		host:        h,
 	}
 	require.Equal(t, "Bitswap", s.Name())
 	ctx, cancel := context.WithCancel(context.Background())

--- a/service/contentprovider/contentprovider.go
+++ b/service/contentprovider/contentprovider.go
@@ -42,9 +42,9 @@ func NewService(db *gorm.DB, config Config) (*Service, error) {
 
 	if config.HTTP.Enable {
 		s.servers = append(s.servers, &HTTPServer{
-			bind:     config.HTTP.Bind,
-			db:       db,
-			resolver: &datasource.DefaultHandlerResolver{},
+			bind:        config.HTTP.Bind,
+			dbNoContext: db,
+			resolver:    &datasource.DefaultHandlerResolver{},
 		})
 	}
 
@@ -87,8 +87,8 @@ func NewService(db *gorm.DB, config Config) (*Service, error) {
 		}
 		logger.Info("peerID: " + h.ID().String())
 		s.servers = append(s.servers, &BitswapServer{
-			host: h,
-			db:   db,
+			host:        h,
+			dbNoContext: db,
 		})
 	}
 	return s, nil

--- a/service/contentprovider/http_test.go
+++ b/service/contentprovider/http_test.go
@@ -26,9 +26,9 @@ func TestHTTPServerStart(t *testing.T) {
 	require.NoError(t, err)
 	defer closer.Close()
 	s := HTTPServer{
-		db:       db,
-		bind:     "127.0.0.1:65432",
-		resolver: &datasource.DefaultHandlerResolver{},
+		dbNoContext: db,
+		bind:        "127.0.0.1:65432",
+		resolver:    &datasource.DefaultHandlerResolver{},
 	}
 	require.Equal(t, "HTTPServer", s.Name())
 	ctx, cancel := context.WithCancel(context.Background())
@@ -51,9 +51,9 @@ func TestHTTPServerHandler(t *testing.T) {
 	defer closer.Close()
 	e := echo.New()
 	s := HTTPServer{
-		db:       db,
-		bind:     ":0",
-		resolver: &datasource.DefaultHandlerResolver{},
+		dbNoContext: db,
+		bind:        ":0",
+		resolver:    &datasource.DefaultHandlerResolver{},
 	}
 
 	pieceCID := cid.NewCidV1(cid.FilCommitmentSealed, util.Hash([]byte("test")))

--- a/service/datasetworker/datasetworker_test.go
+++ b/service/datasetworker/datasetworker_test.go
@@ -110,7 +110,7 @@ func TestDatasetWorkerThread_pack(t *testing.T) {
 	defer closer.Close()
 	thread := Thread{
 		id:                        uuid.New(),
-		db:                        db,
+		dbNoContext:               db,
 		logger:                    logger.With("key", "value"),
 		datasourceHandlerResolver: datasource.DefaultHandlerResolver{},
 		config: Config{
@@ -236,7 +236,7 @@ func TestDatasetWorkerThread_scan(t *testing.T) {
 	defer closer.Close()
 	thread := Thread{
 		id:                        uuid.New(),
-		db:                        db,
+		dbNoContext:               db,
 		logger:                    logger.With("key", "value"),
 		datasourceHandlerResolver: datasource.DefaultHandlerResolver{},
 		config: Config{
@@ -291,7 +291,7 @@ func TestDatasetWorkerThread_findPackWork(t *testing.T) {
 	defer closer.Close()
 	thread := Thread{
 		id:                        uuid.New(),
-		db:                        db,
+		dbNoContext:               db,
 		logger:                    logger.With("key", "value"),
 		datasourceHandlerResolver: datasource.DefaultHandlerResolver{},
 		config: Config{
@@ -374,7 +374,7 @@ func TestDatasetWorkerThread_findPackWork(t *testing.T) {
 			require.NoError(t, err)
 		}
 		require.NoError(t, err)
-		ck, err := thread.findPackWork()
+		ck, err := thread.findPackWork(context.Background())
 		require.NoError(t, err)
 		if shouldBeFound {
 			require.NotNil(t, ck)
@@ -396,7 +396,7 @@ func TestDatasetWorkerThread_findScanWork(t *testing.T) {
 	defer closer.Close()
 	thread := Thread{
 		id:                        uuid.New(),
-		db:                        db,
+		dbNoContext:               db,
 		logger:                    logger.With("key", "value"),
 		datasourceHandlerResolver: datasource.DefaultHandlerResolver{},
 		config: Config{
@@ -468,7 +468,7 @@ func TestDatasetWorkerThread_findScanWork(t *testing.T) {
 		}
 		err = db.Create(&root).Error
 		require.NoError(t, err)
-		src, err := thread.findScanWork()
+		src, err := thread.findScanWork(context.Background())
 		require.NoError(t, err)
 		if shouldBeFound {
 			require.NotNil(t, src)

--- a/service/datasetworker/find.go
+++ b/service/datasetworker/find.go
@@ -1,6 +1,7 @@
 package datasetworker
 
 import (
+	"context"
 	"time"
 
 	"github.com/data-preservation-programs/singularity/database"
@@ -8,15 +9,15 @@ import (
 	"gorm.io/gorm"
 )
 
-func (w *Thread) findDagWork() (*model.Source, error) {
+func (w *Thread) findDagWork(ctx context.Context) (*model.Source, error) {
 	if !w.config.EnableDag {
 		return nil, nil
 	}
 	w.logger.Debugw("finding dag work")
 	var sources []model.Source
 
-	err := database.DoRetry(func() error {
-		return w.db.Transaction(func(db *gorm.DB) error {
+	err := database.DoRetry(ctx, func() error {
+		return w.dbNoContext.Transaction(func(db *gorm.DB) error {
 			// First, find the id of the record to update
 			err := db.
 				Where("dag_gen_state = ? OR (dag_gen_state = ? AND dag_gen_worker_id is null)",
@@ -50,7 +51,7 @@ func (w *Thread) findDagWork() (*model.Source, error) {
 		return nil, nil
 	}
 
-	err = w.db.Model(&sources[0]).Association("Dataset").Find(&sources[0].Dataset)
+	err = w.dbNoContext.Model(&sources[0]).Association("Dataset").Find(&sources[0].Dataset)
 	if err != nil {
 		return nil, err
 	}
@@ -58,15 +59,15 @@ func (w *Thread) findDagWork() (*model.Source, error) {
 	return &sources[0], nil
 }
 
-func (w *Thread) findPackWork() (*model.Chunk, error) {
+func (w *Thread) findPackWork(ctx context.Context) (*model.Chunk, error) {
 	if !w.config.EnablePack {
 		return nil, nil
 	}
 	w.logger.Debugw("finding pack work")
 	var chunks []model.Chunk
 
-	err := database.DoRetry(func() error {
-		return w.db.Transaction(func(db *gorm.DB) error {
+	err := database.DoRetry(ctx, func() error {
+		return w.dbNoContext.Transaction(func(db *gorm.DB) error {
 			// First, find the id of the record to update
 			err := db.
 				Where("packing_state = ? OR (packing_state = ? AND packing_worker_id is null)", model.Ready, model.Processing).
@@ -100,14 +101,14 @@ func (w *Thread) findPackWork() (*model.Chunk, error) {
 	}
 
 	var src model.Source
-	err = w.db.Joins("Dataset").Where("sources.id = ?", chunks[0].SourceID).First(&src).Error
+	err = w.dbNoContext.Joins("Dataset").Where("sources.id = ?", chunks[0].SourceID).First(&src).Error
 	if err != nil {
 		return nil, err
 	}
 	chunks[0].Source = &src
 
 	var itemParts []model.ItemPart
-	err = w.db.Joins("Item").Where("item_parts.chunk_id = ?", chunks[0].ID).Order("item_parts.id asc").Find(&itemParts).Error
+	err = w.dbNoContext.Joins("Item").Where("item_parts.chunk_id = ?", chunks[0].ID).Order("item_parts.id asc").Find(&itemParts).Error
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +117,7 @@ func (w *Thread) findPackWork() (*model.Chunk, error) {
 	return &chunks[0], nil
 }
 
-func (w *Thread) findScanWork() (*model.Source, error) {
+func (w *Thread) findScanWork(ctx context.Context) (*model.Source, error) {
 	if !w.config.EnableScan {
 		return nil, nil
 	}
@@ -124,9 +125,9 @@ func (w *Thread) findScanWork() (*model.Source, error) {
 	var sources []model.Source
 	// Find all ready sources or sources that is being processed but does not have a worker id,
 	// or all source that is complete but needs rescanning
-	err := database.DoRetry(func() error {
-		return w.db.Transaction(func(db *gorm.DB) error {
-			err := w.db.
+	err := database.DoRetry(ctx, func() error {
+		return w.dbNoContext.Transaction(func(db *gorm.DB) error {
+			err := w.dbNoContext.
 				Where(
 					"(scanning_state = ? OR (scanning_state = ? AND scanning_worker_id is null)) OR "+
 						"(scanning_state = ? AND scan_interval_seconds > 0 AND last_scanned_timestamp + scan_interval_seconds < ?)",
@@ -163,7 +164,7 @@ func (w *Thread) findScanWork() (*model.Source, error) {
 		return nil, nil
 	}
 
-	err = w.db.Model(&sources[0]).Association("Dataset").Find(&sources[0].Dataset)
+	err = w.dbNoContext.Model(&sources[0]).Association("Dataset").Find(&sources[0].Dataset)
 	if err != nil {
 		return nil, err
 	}

--- a/service/datasetworker/pack.go
+++ b/service/datasetworker/pack.go
@@ -10,7 +10,7 @@ import (
 func (w *Thread) pack(
 	ctx context.Context, chunk model.Chunk,
 ) error {
-	_, err := datasource.Pack(ctx, w.db, chunk, w.datasourceHandlerResolver)
+	_, err := datasource.Pack(ctx, w.dbNoContext, chunk, w.datasourceHandlerResolver)
 	if err != nil {
 		return err
 	}

--- a/store/item_reference_test.go
+++ b/store/item_reference_test.go
@@ -23,7 +23,7 @@ func TestItemReferenceBlockStore_Has(t *testing.T) {
 	defer closer.Close()
 
 	store := ItemReferenceBlockStore{
-		DB:              db,
+		DBNoContext:     db,
 		HandlerResolver: &datasource.DefaultHandlerResolver{},
 	}
 
@@ -63,7 +63,7 @@ func TestItemReferenceBlockStore_GetSize(t *testing.T) {
 	defer closer.Close()
 
 	store := ItemReferenceBlockStore{
-		DB:              db,
+		DBNoContext:     db,
 		HandlerResolver: &datasource.DefaultHandlerResolver{},
 	}
 	ctx := context.Background()
@@ -89,7 +89,7 @@ func TestItemReferenceBlockStore_Get_RawBlock(t *testing.T) {
 	defer closer.Close()
 
 	store := ItemReferenceBlockStore{
-		DB:              db,
+		DBNoContext:     db,
 		HandlerResolver: &datasource.DefaultHandlerResolver{},
 	}
 
@@ -117,7 +117,7 @@ func TestItemReferenceBlockStore_Get_ItemBlock(t *testing.T) {
 	defer closer.Close()
 
 	store := ItemReferenceBlockStore{
-		DB:              db,
+		DBNoContext:     db,
 		HandlerResolver: &datasource.DefaultHandlerResolver{},
 	}
 


### PR DESCRIPTION
- [x] database.DoRetry now have a context argument
- [x] All cli/api handlers now have a context argument
- [x] Renamed internal "db" field in different services to "dbNoContext" to capture places where context is not correctly set
- [x] Switch position of context function argument to always be the first one