### PR TITLE
Allow perpetual cron schedules

### DIFF
--- a/client/swagger/models/model_schedule.go
+++ b/client/swagger/models/model_schedule.go
@@ -69,6 +69,9 @@ type ModelSchedule struct {
 	// schedule cron
 	ScheduleCron string `json:"scheduleCron,omitempty"`
 
+	// schedule cron perpetual
+	ScheduleCronPerpetual bool `json:"scheduleCronPerpetual,omitempty"`
+
 	// schedule deal number
 	ScheduleDealNumber int64 `json:"scheduleDealNumber,omitempty"`
 

--- a/client/swagger/models/schedule_create_request.go
+++ b/client/swagger/models/schedule_create_request.go
@@ -59,6 +59,9 @@ type ScheduleCreateRequest struct {
 	// Schedule cron patter
 	ScheduleCron string `json:"scheduleCron,omitempty"`
 
+	// Whether a cron schedule should run in definitely
+	ScheduleCronPerpetual bool `json:"scheduleCronPerpetual,omitempty"`
+
 	// Number of deals per scheduled time
 	ScheduleDealNumber int64 `json:"scheduleDealNumber,omitempty"`
 

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -10390,6 +10390,9 @@ const docTemplate = `{
                 "scheduleCron": {
                     "type": "string"
                 },
+                "scheduleCronPerpetual": {
+                    "type": "boolean"
+                },
                 "scheduleDealNumber": {
                     "type": "integer"
                 },
@@ -10623,6 +10626,10 @@ const docTemplate = `{
                 "scheduleCron": {
                     "description": "Schedule cron patter",
                     "type": "string"
+                },
+                "scheduleCronPerpetual": {
+                    "description": "Whether a cron schedule should run in definitely",
+                    "type": "boolean"
                 },
                 "scheduleDealNumber": {
                     "description": "Number of deals per scheduled time",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -10383,6 +10383,9 @@
                 "scheduleCron": {
                     "type": "string"
                 },
+                "scheduleCronPerpetual": {
+                    "type": "boolean"
+                },
                 "scheduleDealNumber": {
                     "type": "integer"
                 },
@@ -10616,6 +10619,10 @@
                 "scheduleCron": {
                     "description": "Schedule cron patter",
                     "type": "string"
+                },
+                "scheduleCronPerpetual": {
+                    "description": "Whether a cron schedule should run in definitely",
+                    "type": "boolean"
                 },
                 "scheduleDealNumber": {
                     "description": "Number of deals per scheduled time",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -5068,6 +5068,8 @@ definitions:
         type: string
       scheduleCron:
         type: string
+      scheduleCronPerpetual:
+        type: boolean
       scheduleDealNumber:
         type: integer
       scheduleDealSize:
@@ -5237,6 +5239,9 @@ definitions:
       scheduleCron:
         description: Schedule cron patter
         type: string
+      scheduleCronPerpetual:
+        description: Whether a cron schedule should run in definitely
+        type: boolean
       scheduleDealNumber:
         description: Number of deals per scheduled time
         type: integer

--- a/handler/deal/schedule/create.go
+++ b/handler/deal/schedule/create.go
@@ -19,26 +19,27 @@ import (
 
 //nolint:lll
 type CreateRequest struct {
-	DatasetName          string   `json:"datasetName"          validation:"required"`  // Dataset name
-	Provider             string   `json:"provider"             validation:"required"`  // Provider
-	HTTPHeaders          []string `json:"httpHeaders"`                                 // http headers to be passed with the request (i.e. key=value)
-	URLTemplate          string   `json:"urlTemplate"`                                 // URL template with PIECE_CID placeholder for boost to fetch the CAR file, i.e. http://127.0.0.1/piece/{PIECE_CID}.car
-	PricePerGBEpoch      float64  `default:"0"                 json:"pricePerGbEpoch"` // Price in FIL per GiB per epoch
-	PricePerGB           float64  `default:"0"                 json:"pricePerGb"`      // Price in FIL  per GiB
-	PricePerDeal         float64  `default:"0"                 json:"pricePerDeal"`    // Price in FIL per deal
-	Verified             bool     `default:"true"              json:"verified"`        // Whether the deal should be verified
-	IPNI                 bool     `default:"true"              json:"ipni"`            // Whether the deal should be IPNI
-	KeepUnsealed         bool     `default:"true"              json:"keepUnsealed"`    // Whether the deal should be kept unsealed
-	StartDelay           string   `default:"72h"               json:"startDelay"`      // Deal start delay in epoch or in duration format, i.e. 1000, 72h
-	Duration             string   `default:"12840h"            json:"duration"`        // Duration in epoch or in duration format, i.e. 1500000, 2400h
-	ScheduleCron         string   `json:"scheduleCron"`                                // Schedule cron patter
-	ScheduleDealNumber   int      `json:"scheduleDealNumber"`                          // Number of deals per scheduled time
-	TotalDealNumber      int      `json:"totalDealNumber"`                             // Total number of deals
-	ScheduleDealSize     string   `json:"scheduleDealSize"`                            // Size of deals per schedule trigger in human readable format, i.e. 100 TiB
-	TotalDealSize        string   `json:"totalDealSize"`                               // Total size of deals in human readable format, i.e. 100 TiB
-	Notes                string   `json:"notes"`                                       // Notes
-	MaxPendingDealSize   string   `json:"maxPendingDealSize"`                          // Max pending deal size in human readable format, i.e. 100 TiB
-	MaxPendingDealNumber int      `json:"maxPendingDealNumber"`                        // Max pending deal number
+	DatasetName           string   `json:"datasetName"          validation:"required"`  // Dataset name
+	Provider              string   `json:"provider"             validation:"required"`  // Provider
+	HTTPHeaders           []string `json:"httpHeaders"`                                 // http headers to be passed with the request (i.e. key=value)
+	URLTemplate           string   `json:"urlTemplate"`                                 // URL template with PIECE_CID placeholder for boost to fetch the CAR file, i.e. http://127.0.0.1/piece/{PIECE_CID}.car
+	PricePerGBEpoch       float64  `default:"0"                 json:"pricePerGbEpoch"` // Price in FIL per GiB per epoch
+	PricePerGB            float64  `default:"0"                 json:"pricePerGb"`      // Price in FIL  per GiB
+	PricePerDeal          float64  `default:"0"                 json:"pricePerDeal"`    // Price in FIL per deal
+	Verified              bool     `default:"true"              json:"verified"`        // Whether the deal should be verified
+	IPNI                  bool     `default:"true"              json:"ipni"`            // Whether the deal should be IPNI
+	KeepUnsealed          bool     `default:"true"              json:"keepUnsealed"`    // Whether the deal should be kept unsealed
+	StartDelay            string   `default:"72h"               json:"startDelay"`      // Deal start delay in epoch or in duration format, i.e. 1000, 72h
+	Duration              string   `default:"12840h"            json:"duration"`        // Duration in epoch or in duration format, i.e. 1500000, 2400h
+	ScheduleCron          string   `json:"scheduleCron"`                                // Schedule cron patter
+	ScheduleCronPerpetual bool     `json:"scheduleCronPerpetual"`                       // Whether a cron schedule should run in definitely
+	ScheduleDealNumber    int      `json:"scheduleDealNumber"`                          // Number of deals per scheduled time
+	TotalDealNumber       int      `json:"totalDealNumber"`                             // Total number of deals
+	ScheduleDealSize      string   `json:"scheduleDealSize"`                            // Size of deals per schedule trigger in human readable format, i.e. 100 TiB
+	TotalDealSize         string   `json:"totalDealSize"`                               // Total size of deals in human readable format, i.e. 100 TiB
+	Notes                 string   `json:"notes"`                                       // Notes
+	MaxPendingDealSize    string   `json:"maxPendingDealSize"`                          // Max pending deal size in human readable format, i.e. 100 TiB
+	MaxPendingDealNumber  int      `json:"maxPendingDealNumber"`                        // Max pending deal number
 	//nolint:tagliatelle
 	AllowedPieceCIDs []string `json:"allowedPieceCids"` // Allowed piece CIDs in this schedule
 }
@@ -160,28 +161,29 @@ func createHandler(
 	}
 
 	schedule := model.Schedule{
-		DatasetID:            dataset.ID,
-		URLTemplate:          request.URLTemplate,
-		HTTPHeaders:          request.HTTPHeaders,
-		Provider:             request.Provider,
-		TotalDealNumber:      request.TotalDealNumber,
-		TotalDealSize:        int64(totalDealSize),
-		Verified:             request.Verified,
-		KeepUnsealed:         request.KeepUnsealed,
-		AnnounceToIPNI:       request.IPNI,
-		StartDelay:           startDelay,
-		Duration:             duration,
-		State:                model.ScheduleActive,
-		ScheduleDealNumber:   request.ScheduleDealNumber,
-		ScheduleDealSize:     int64(scheduleDealSize),
-		MaxPendingDealNumber: request.MaxPendingDealNumber,
-		MaxPendingDealSize:   int64(pendingDealSize),
-		Notes:                request.Notes,
-		AllowedPieceCIDs:     request.AllowedPieceCIDs,
-		ScheduleCron:         scheduleCron,
-		PricePerGBEpoch:      request.PricePerGBEpoch,
-		PricePerGB:           request.PricePerGB,
-		PricePerDeal:         request.PricePerDeal,
+		DatasetID:             dataset.ID,
+		URLTemplate:           request.URLTemplate,
+		HTTPHeaders:           request.HTTPHeaders,
+		Provider:              request.Provider,
+		TotalDealNumber:       request.TotalDealNumber,
+		TotalDealSize:         int64(totalDealSize),
+		Verified:              request.Verified,
+		KeepUnsealed:          request.KeepUnsealed,
+		AnnounceToIPNI:        request.IPNI,
+		StartDelay:            startDelay,
+		Duration:              duration,
+		State:                 model.ScheduleActive,
+		ScheduleDealNumber:    request.ScheduleDealNumber,
+		ScheduleDealSize:      int64(scheduleDealSize),
+		MaxPendingDealNumber:  request.MaxPendingDealNumber,
+		MaxPendingDealSize:    int64(pendingDealSize),
+		Notes:                 request.Notes,
+		AllowedPieceCIDs:      request.AllowedPieceCIDs,
+		ScheduleCron:          scheduleCron,
+		ScheduleCronPerpetual: request.ScheduleCronPerpetual,
+		PricePerGBEpoch:       request.PricePerGBEpoch,
+		PricePerGB:            request.PricePerGB,
+		PricePerDeal:          request.PricePerDeal,
 	}
 
 	if err := database.DoRetry(ctx, func() error {

--- a/model/replication.go
+++ b/model/replication.go
@@ -81,33 +81,34 @@ func (d Deal) Key() string {
 }
 
 type Schedule struct {
-	ID                   uint32        `gorm:"primaryKey"                                       json:"id"`
-	CreatedAt            time.Time     `json:"createdAt"`
-	UpdatedAt            time.Time     `json:"updatedAt"`
-	DatasetID            uint32        `json:"datasetId"`
-	Dataset              *Dataset      `gorm:"foreignKey:DatasetID;constraint:OnDelete:CASCADE" json:"dataset,omitempty"        swaggerignore:"true"`
-	URLTemplate          string        `json:"urlTemplate"`
-	HTTPHeaders          StringSlice   `gorm:"type:JSON"                                        json:"httpHeaders"`
-	Provider             string        `json:"provider"`
-	PricePerGBEpoch      float64       `json:"pricePerGbEpoch"`
-	PricePerGB           float64       `json:"pricePerGb"`
-	PricePerDeal         float64       `json:"pricePerDeal"`
-	TotalDealNumber      int           `json:"totalDealNumber"`
-	TotalDealSize        int64         `json:"totalDealSize"`
-	Verified             bool          `json:"verified"`
-	KeepUnsealed         bool          `json:"keepUnsealed"`
-	AnnounceToIPNI       bool          `json:"announceToIpni"`
-	StartDelay           time.Duration `json:"startDelay"                                       swaggertype:"primitive,integer"`
-	Duration             time.Duration `json:"duration"                                         swaggertype:"primitive,integer"`
-	State                ScheduleState `gorm:"index"                                            json:"state"`
-	ScheduleCron         string        `json:"scheduleCron"`
-	ScheduleDealNumber   int           `json:"scheduleDealNumber"`
-	ScheduleDealSize     int64         `json:"scheduleDealSize"`
-	MaxPendingDealNumber int           `json:"maxPendingDealNumber"`
-	MaxPendingDealSize   int64         `json:"maxPendingDealSize"`
-	Notes                string        `json:"notes"`
-	ErrorMessage         string        `json:"errorMessage"`
-	AllowedPieceCIDs     StringSlice   `gorm:"type:JSON"                                        json:"allowedPieceCids"`
+	ID                    uint32        `gorm:"primaryKey"                                       json:"id"`
+	CreatedAt             time.Time     `json:"createdAt"`
+	UpdatedAt             time.Time     `json:"updatedAt"`
+	DatasetID             uint32        `json:"datasetId"`
+	Dataset               *Dataset      `gorm:"foreignKey:DatasetID;constraint:OnDelete:CASCADE" json:"dataset,omitempty"        swaggerignore:"true"`
+	URLTemplate           string        `json:"urlTemplate"`
+	HTTPHeaders           StringSlice   `gorm:"type:JSON"                                        json:"httpHeaders"`
+	Provider              string        `json:"provider"`
+	PricePerGBEpoch       float64       `json:"pricePerGbEpoch"`
+	PricePerGB            float64       `json:"pricePerGb"`
+	PricePerDeal          float64       `json:"pricePerDeal"`
+	TotalDealNumber       int           `json:"totalDealNumber"`
+	TotalDealSize         int64         `json:"totalDealSize"`
+	Verified              bool          `json:"verified"`
+	KeepUnsealed          bool          `json:"keepUnsealed"`
+	AnnounceToIPNI        bool          `json:"announceToIpni"`
+	StartDelay            time.Duration `json:"startDelay"                                       swaggertype:"primitive,integer"`
+	Duration              time.Duration `json:"duration"                                         swaggertype:"primitive,integer"`
+	State                 ScheduleState `gorm:"index"                                            json:"state"`
+	ScheduleCron          string        `json:"scheduleCron"`
+	ScheduleCronPerpetual bool          `json:"scheduleCronPerpetual"`
+	ScheduleDealNumber    int           `json:"scheduleDealNumber"`
+	ScheduleDealSize      int64         `json:"scheduleDealSize"`
+	MaxPendingDealNumber  int           `json:"maxPendingDealNumber"`
+	MaxPendingDealSize    int64         `json:"maxPendingDealSize"`
+	Notes                 string        `json:"notes"`
+	ErrorMessage          string        `json:"errorMessage"`
+	AllowedPieceCIDs      StringSlice   `gorm:"type:JSON"                                        json:"allowedPieceCids"`
 }
 
 type Wallet struct {

--- a/service/dealpusher/dealpusher.go
+++ b/service/dealpusher/dealpusher.go
@@ -295,6 +295,10 @@ func (d *DealPusher) runSchedule(ctx context.Context, schedule *model.Schedule) 
 						})).First(&car).Error
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				Logger.Infow("no more pieces to send deal", "schedule_id", schedule.ID)
+				// we're out of deals to schedule, but if we're running a perpetual cron, we simply put things on hold till next cron
+				if schedule.ScheduleCron != "" && schedule.ScheduleCronPerpetual {
+					return "", nil
+				}
 				return model.ScheduleCompleted, nil
 			}
 			if err != nil {


### PR DESCRIPTION
# Goals

Allow cron schedules to keep running when they run out of deals

# Implementation

- add attribute to the model
- add ability to set attribute on CreateSchedule 
- when jobs run out of deals, if they are cron and set to perpetual, they don't get marked complete