### PR TITLE
Fix version file not matching latest release

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.3.0"
+  "version": "v0.3.1"
 }


### PR DESCRIPTION
There seem to have been some manual releases which leaves version file inconsistent with what the latest release is.