### PR TITLE
Build containers for both archs in single job

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -22,8 +22,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - linux/amd64
-          - linux/arm64
+          - linux/amd64,linux/arm64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Use a single build step to build for both architectures. Context:
 investigating images overriding each other on ghcr.