### PR TITLE
Use consistent id type across handlers

### DIFF
--- a/client/lib/client.go
+++ b/client/lib/client.go
@@ -67,7 +67,7 @@ func (c *Client) GetFile(ctx context.Context, id uint64) (*model.File, error) {
 }
 
 func (c *Client) GetFileDeals(ctx context.Context, id uint64) ([]model.Deal, error) {
-	return inspect.GetFileDealsHandler(c.db.WithContext(ctx), id)
+	return inspect.GetFileDealsHandler(c.db.WithContext(ctx), strconv.FormatUint(id, 10))
 }
 
 func (c *Client) PushFile(ctx context.Context, sourceID uint32, fileInfo dshandler.FileInfo) (*model.File, error) {

--- a/handler/datasource/inspect/itemdeals.go
+++ b/handler/datasource/inspect/itemdeals.go
@@ -1,13 +1,16 @@
 package inspect
 
 import (
+	"strconv"
+
+	"github.com/data-preservation-programs/singularity/handler"
 	"github.com/data-preservation-programs/singularity/model"
 	"gorm.io/gorm"
 )
 
 func GetFileDealsHandler(
 	db *gorm.DB,
-	id uint64,
+	id string,
 ) ([]model.Deal, error) {
 	return getFileDealsHandler(db, id)
 }
@@ -22,15 +25,19 @@ func GetFileDealsHandler(
 // @Router /file/{id}/deals [get]
 func getFileDealsHandler(
 	db *gorm.DB,
-	id uint64,
+	id string,
 ) ([]model.Deal, error) {
+	fileID, err := strconv.Atoi(id)
+	if err != nil {
+		return nil, handler.NewInvalidParameterErr("invalid file id")
+	}
 	var deals []model.Deal
 	query := db.
 		Model(&model.FileRange{}).
 		Select("deals.*").
 		Joins("JOIN cars ON file_ranges.pack_job_id = cars.pack_job_id").
 		Joins("JOIN deals ON cars.piece_cid = deals.piece_cid").
-		Where("file_ranges.file_id = ?", id)
+		Where("file_ranges.file_id = ?", fileID)
 	if err := query.Find(&deals).Error; err != nil {
 		return nil, err
 	}

--- a/handler/datasource/inspect/itemdeals_test.go
+++ b/handler/datasource/inspect/itemdeals_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path"
+	"strconv"
 	"testing"
 
 	"github.com/data-preservation-programs/singularity/database"
@@ -83,11 +84,11 @@ func TestFileDeals(t *testing.T) {
 	}
 
 	// Test file deals
-	deals, err := inspect.GetFileDealsHandler(db.WithContext(ctx), fileA.ID)
+	deals, err := inspect.GetFileDealsHandler(db.WithContext(ctx), strconv.FormatUint(fileA.ID, 10))
 	require.NoError(t, err)
 	require.Len(t, deals, 1)
 
-	deals, err = inspect.GetFileDealsHandler(db.WithContext(ctx), fileB.ID)
+	deals, err = inspect.GetFileDealsHandler(db.WithContext(ctx), strconv.FormatUint(fileB.ID, 10))
 	require.NoError(t, err)
 	require.Len(t, deals, 1)
 }


### PR DESCRIPTION
Investigating `Invalid handler function signature` on hitting `/api/file/{id}/deals` via the hand-rolled HTTP Client library. The parameter types across get source file and get source file deals is inconsistent. consistently use string.