### PR TITLE
Create aliases for all database model IDs

### DIFF
--- a/cmd/dataprep_test.go
+++ b/cmd/dataprep_test.go
@@ -272,7 +272,7 @@ func TestDataPreparationAddPieceHandler(t *testing.T) {
 			PieceSize:     100,
 			RootCID:       model.CID{},
 			FileSize:      100,
-			StorageID:     ptr.Of(uint32(1)),
+			StorageID:     ptr.Of(model.StorageID(1)),
 			StoragePath:   "test1.car",
 			PreparationID: 1,
 		}, nil)
@@ -293,8 +293,8 @@ func TestDataPreparationListPiecesHandler(t *testing.T) {
 
 		mockHandler.On("ListPiecesHandler", mock.Anything, mock.Anything, mock.Anything).Return([]dataprep.PieceList{
 			{
-				SourceStorageID: ptr.Of(uint32(1)),
-				AttachmentID:    ptr.Of(uint32(1)),
+				SourceStorageID: ptr.Of(model.StorageID(1)),
+				AttachmentID:    ptr.Of(model.SourceAttachmentID(1)),
 				SourceStorage: &model.Storage{
 					ID:        1,
 					Name:      "local",
@@ -309,7 +309,7 @@ func TestDataPreparationListPiecesHandler(t *testing.T) {
 					PieceCID:      model.CID(testutil.TestCid),
 					PieceSize:     100,
 					FileSize:      200,
-					StorageID:     ptr.Of(uint32(1)),
+					StorageID:     ptr.Of(model.StorageID(1)),
 					StoragePath:   "test1.car",
 					PreparationID: 1,
 				}, {
@@ -318,7 +318,7 @@ func TestDataPreparationListPiecesHandler(t *testing.T) {
 					PieceCID:      model.CID(testutil.TestCid),
 					PieceSize:     300,
 					FileSize:      400,
-					StorageID:     ptr.Of(uint32(1)),
+					StorageID:     ptr.Of(model.StorageID(1)),
 					StoragePath:   "test2.car",
 					PreparationID: 1,
 				}},
@@ -330,7 +330,7 @@ func TestDataPreparationListPiecesHandler(t *testing.T) {
 					PieceCID:      model.CID(testutil.TestCid),
 					PieceSize:     500,
 					FileSize:      600,
-					StorageID:     ptr.Of(uint32(1)),
+					StorageID:     ptr.Of(model.StorageID(1)),
 					StoragePath:   "test3.car",
 					PreparationID: 1,
 				}, {
@@ -339,7 +339,7 @@ func TestDataPreparationListPiecesHandler(t *testing.T) {
 					PieceCID:      model.CID(testutil.TestCid),
 					PieceSize:     700,
 					FileSize:      800,
-					StorageID:     ptr.Of(uint32(1)),
+					StorageID:     ptr.Of(model.StorageID(1)),
 					StoragePath:   "test4.car",
 					PreparationID: 1,
 				}},

--- a/cmd/deal_test.go
+++ b/cmd/deal_test.go
@@ -76,7 +76,7 @@ func TestListDealHandler(t *testing.T) {
 				SectorStartEpoch: 1500,
 				Price:            "0",
 				Verified:         true,
-				ScheduleID:       ptr.Of(uint32(5)),
+				ScheduleID:       ptr.Of(model.ScheduleID(5)),
 				ClientID:         "client_id",
 			},
 			{
@@ -94,7 +94,7 @@ func TestListDealHandler(t *testing.T) {
 				SectorStartEpoch: 1600,
 				Price:            "0",
 				Verified:         false,
-				ScheduleID:       ptr.Of(uint32(5)),
+				ScheduleID:       ptr.Of(model.ScheduleID(5)),
 				ClientID:         "client_id",
 			},
 		}, nil)

--- a/cmd/job_test.go
+++ b/cmd/job_test.go
@@ -162,8 +162,8 @@ func TestDataPreparationGetStatusHandler(t *testing.T) {
 
 		mockHandler.On("GetStatusHandler", mock.Anything, mock.Anything, mock.Anything).Return([]job.SourceStatus{
 			{
-				AttachmentID:    ptr.Of(uint32(1)),
-				SourceStorageID: ptr.Of(uint32(1)),
+				AttachmentID:    ptr.Of(model.SourceAttachmentID(1)),
+				SourceStorageID: ptr.Of(model.StorageID(1)),
 				SourceStorage: &model.Storage{
 					ID:        1,
 					Name:      "source",

--- a/handler/dataprep/explore.go
+++ b/handler/dataprep/explore.go
@@ -26,11 +26,11 @@ type ExploreResult struct {
 }
 
 type Version struct {
-	ID           uint64    `json:"id"`
-	CID          string    `json:"cid"`
-	Hash         string    `json:"hash"`
-	Size         int64     `json:"size"`
-	LastModified time.Time `json:"lastModified" table:"format:2006-01-02 15:04:05"`
+	ID           model.FileID `json:"id"`
+	CID          string       `json:"cid"`
+	Hash         string       `json:"hash"`
+	Size         int64        `json:"size"`
+	LastModified time.Time    `json:"lastModified" table:"format:2006-01-02 15:04:05"`
 }
 
 // ExploreHandler fetches directory entries (files and sub-directories) associated with a specific preparation

--- a/handler/dataprep/explore_test.go
+++ b/handler/dataprep/explore_test.go
@@ -45,12 +45,12 @@ func TestExploreHandler(t *testing.T) {
 					},
 					{
 						AttachmentID: 1,
-						ParentID:     ptr.Of(uint64(1)),
+						ParentID:     ptr.Of(model.DirectoryID(1)),
 						Name:         "sub1",
 					},
 					{
 						AttachmentID: 1,
-						ParentID:     ptr.Of(uint64(2)),
+						ParentID:     ptr.Of(model.DirectoryID(2)),
 						Name:         "sub2",
 					},
 				}).Error
@@ -62,7 +62,7 @@ func TestExploreHandler(t *testing.T) {
 						Size:             100,
 						LastModifiedNano: 100,
 						AttachmentID:     1,
-						DirectoryID:      ptr.Of(uint64(2)),
+						DirectoryID:      ptr.Of(model.DirectoryID(2)),
 					},
 					{
 						Path:             "sub1/test2.tst",
@@ -70,7 +70,7 @@ func TestExploreHandler(t *testing.T) {
 						Size:             100,
 						LastModifiedNano: 100,
 						AttachmentID:     1,
-						DirectoryID:      ptr.Of(uint64(2)),
+						DirectoryID:      ptr.Of(model.DirectoryID(2)),
 					},
 					{
 						Path:             "sub1/test1.tst",
@@ -78,7 +78,7 @@ func TestExploreHandler(t *testing.T) {
 						Size:             200,
 						LastModifiedNano: 200,
 						AttachmentID:     1,
-						DirectoryID:      ptr.Of(uint64(2)),
+						DirectoryID:      ptr.Of(model.DirectoryID(2)),
 					},
 				}).Error
 				require.NoError(t, err)

--- a/handler/dataprep/piece.go
+++ b/handler/dataprep/piece.go
@@ -25,10 +25,10 @@ type AddPieceRequest struct {
 }
 
 type PieceList struct {
-	AttachmentID    *uint32        `json:"attachmentId"`
-	SourceStorageID *uint32        `json:"storageId"`
-	SourceStorage   *model.Storage `json:"source"       table:"expand"`
-	Pieces          []model.Car    `json:"pieces"       table:"expand"`
+	AttachmentID    *model.SourceAttachmentID `json:"attachmentId"`
+	SourceStorageID *model.StorageID          `json:"storageId"`
+	SourceStorage   *model.Storage            `json:"source"       table:"expand"`
+	Pieces          []model.Car               `json:"pieces"       table:"expand"`
 }
 
 // ListPiecesHandler retrieves the list of pieces associated with a particular preparation and its source attachments.

--- a/handler/dataprep/piece_test.go
+++ b/handler/dataprep/piece_test.go
@@ -25,7 +25,7 @@ func TestListPiecesHandler(t *testing.T) {
 				}).Error
 				require.NoError(t, err)
 				err = db.Create([]model.Car{{
-					AttachmentID:  ptr.Of(uint32(1)),
+					AttachmentID:  ptr.Of(model.SourceAttachmentID(1)),
 					PreparationID: 1,
 				}, {
 					PreparationID: 1,

--- a/handler/file/deals_test.go
+++ b/handler/file/deals_test.go
@@ -35,7 +35,7 @@ func TestGetFileDealsHandler(t *testing.T) {
 		err := db.Create(&file).Error
 		require.NoError(t, err)
 		car := model.Car{
-			JobID:         ptr.Of(uint64(1)),
+			JobID:         ptr.Of(model.JobID(1)),
 			PieceCID:      model.CID(testutil.TestCid),
 			PreparationID: 1,
 		}

--- a/handler/file/prepare_test.go
+++ b/handler/file/prepare_test.go
@@ -56,7 +56,7 @@ func TestPrepareToPackFileHandler(t *testing.T) {
 		file2 := model.File{
 			Size:         900000,
 			AttachmentID: 1,
-			DirectoryID:  ptr.Of(uint64(1)),
+			DirectoryID:  ptr.Of(model.DirectoryID(1)),
 			FileRanges: []model.FileRange{{
 				Offset: 0,
 				Length: 900000,

--- a/handler/file/push.go
+++ b/handler/file/push.go
@@ -66,7 +66,7 @@ func (DefaultHandler) PushFileHandler(
 		return nil, errors.Wrapf(handlererror.ErrInvalidParameter, "file '%s' is not an object", fileInfo.Path)
 	}
 
-	file, fileRanges, err := push.PushFile(ctx, db, obj, attachment, map[string]uint64{})
+	file, fileRanges, err := push.PushFile(ctx, db, obj, attachment, map[string]model.DirectoryID{})
 
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/handler/job/pack.go
+++ b/handler/job/pack.go
@@ -54,7 +54,7 @@ func (DefaultHandler) StartPackHandler(
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			var jobIDs []uint64
+			var jobIDs []model.JobID
 			for i, job := range jobs {
 				jobIDs = append(jobIDs, job.ID)
 				jobs[i].State = model.Ready
@@ -161,7 +161,7 @@ func (DefaultHandler) PausePackHandler(
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			var jobIDs []uint64
+			var jobIDs []model.JobID
 			for i, job := range jobs {
 				jobIDs = append(jobIDs, job.ID)
 				jobs[i].State = model.Paused

--- a/handler/job/status.go
+++ b/handler/job/status.go
@@ -11,11 +11,11 @@ import (
 )
 
 type SourceStatus struct {
-	AttachmentID    *uint32         `json:"attachmentId"`
-	SourceStorageID *uint32         `json:"storageId"`
-	SourceStorage   *model.Storage  `json:"source"       table:"expand;header:Source Storage"`
-	OutputStorages  []model.Storage `json:"output"       table:"expand;header:Output Storages"`
-	Jobs            []model.Job     `json:"jobs"         table:"expand"`
+	AttachmentID    *model.SourceAttachmentID `json:"attachmentId"`
+	SourceStorageID *model.StorageID          `json:"storageId"`
+	SourceStorage   *model.Storage            `json:"source"       table:"expand;header:Source Storage"`
+	OutputStorages  []model.Storage           `json:"output"       table:"expand;header:Output Storages"`
+	Jobs            []model.Job               `json:"jobs"         table:"expand"`
 }
 
 // GetStatusHandler fetches and returns the current status of a specific Preparation.

--- a/migrate/migrate-dataset.go
+++ b/migrate/migrate-dataset.go
@@ -78,7 +78,7 @@ func migrateDataset(ctx context.Context, mg *mongo.Client, db *gorm.DB, scanning
 		return errors.Wrap(err, "failed to query mongo for generation requests")
 	}
 
-	directoryCache := map[string]uint64{}
+	directoryCache := map[string]model.DirectoryID{}
 	directoryCache[""] = rootDir.ID
 	directoryCache["."] = rootDir.ID
 	var lastFile model.File

--- a/model/preparation.go
+++ b/model/preparation.go
@@ -23,15 +23,17 @@ type Global struct {
 	Value string `json:"value"`
 }
 
+type PreparationID uint32
+
 // Preparation is a data preparation definition that can attach multiple source storages and up to one output storage.
 type Preparation struct {
-	ID                uint32    `gorm:"primaryKey"        json:"id"`
-	Name              string    `gorm:"unique"            json:"name"`
-	CreatedAt         time.Time `json:"createdAt"         table:"verbose;format:2006-01-02 15:04:05"`
-	UpdatedAt         time.Time `json:"updatedAt"         table:"verbose;format:2006-01-02 15:04:05"`
-	DeleteAfterExport bool      `json:"deleteAfterExport"` // DeleteAfterExport is a flag that indicates whether the source files should be deleted after export.
-	MaxSize           int64     `json:"maxSize"`
-	PieceSize         int64     `json:"pieceSize"`
+	ID                PreparationID `gorm:"primaryKey"        json:"id"`
+	Name              string        `gorm:"unique"            json:"name"`
+	CreatedAt         time.Time     `json:"createdAt"         table:"verbose;format:2006-01-02 15:04:05"`
+	UpdatedAt         time.Time     `json:"updatedAt"         table:"verbose;format:2006-01-02 15:04:05"`
+	DeleteAfterExport bool          `json:"deleteAfterExport"` // DeleteAfterExport is a flag that indicates whether the source files should be deleted after export.
+	MaxSize           int64         `json:"maxSize"`
+	PieceSize         int64         `json:"pieceSize"`
 
 	// Associations
 	Wallets        []Wallet  `gorm:"many2many:wallet_assignments"                             json:"wallets,omitempty"        swaggerignore:"true"                   table:"expand"`
@@ -54,9 +56,11 @@ func (s *Preparation) FindByIDOrName(db *gorm.DB, name string, preloads ...strin
 	}
 }
 
+type StorageID uint32
+
 // Storage is a storage system definition that can be used as either source or output of a Preparation.
 type Storage struct {
-	ID        uint32    `gorm:"primaryKey" json:"id"`
+	ID        StorageID `gorm:"primaryKey" json:"id"`
 	Name      string    `gorm:"unique"     json:"name"`
 	CreatedAt time.Time `json:"createdAt"  table:"verbose;format:2006-01-02 15:04:05"`
 	UpdatedAt time.Time `json:"updatedAt"  table:"verbose;format:2006-01-02 15:04:05"`
@@ -86,16 +90,18 @@ func (s *Storage) FindByIDOrName(db *gorm.DB, name string, preloads ...string) e
 	}
 }
 
+type SourceAttachmentID uint32
+
 // SourceAttachment is a link between a Preparation and a Storage that is used as a source.
 type SourceAttachment struct {
-	ID uint32 `gorm:"primaryKey" json:"id"`
+	ID SourceAttachmentID `gorm:"primaryKey" json:"id"`
 
 	// Associations
-	PreparationID   uint32       `gorm:"uniqueIndex:prep_source"                              json:"preparationId"`
-	Preparation     *Preparation `gorm:"foreignKey:PreparationID;constraint:OnDelete:CASCADE" json:"preparation,omitempty" swaggerignore:"true"`
-	StorageID       uint32       `gorm:"uniqueIndex:prep_source"                              json:"storageId"`
-	Storage         *Storage     `gorm:"foreignKey:StorageID;constraint:OnDelete:CASCADE"     json:"storage,omitempty"     swaggerignore:"true"`
-	LastScannedPath string       `json:"lastScannedPath"`
+	PreparationID   PreparationID `gorm:"uniqueIndex:prep_source"                              json:"preparationId"`
+	Preparation     *Preparation  `gorm:"foreignKey:PreparationID;constraint:OnDelete:CASCADE" json:"preparation,omitempty" swaggerignore:"true"`
+	StorageID       StorageID     `gorm:"uniqueIndex:prep_source"                              json:"storageId"`
+	Storage         *Storage      `gorm:"foreignKey:StorageID;constraint:OnDelete:CASCADE"     json:"storage,omitempty"     swaggerignore:"true"`
+	LastScannedPath string        `json:"lastScannedPath"`
 }
 
 func (s *SourceAttachment) FindByPreparationAndSource(db *gorm.DB, preparation string, source string) error {
@@ -128,46 +134,52 @@ func (s *SourceAttachment) RootDirectoryCID(ctx context.Context, db *gorm.DB) (c
 	return cid.Cid(root.CID), errors.WithStack(err)
 }
 
-func (s *SourceAttachment) RootDirectoryID(ctx context.Context, db *gorm.DB) (uint64, error) {
+func (s *SourceAttachment) RootDirectoryID(ctx context.Context, db *gorm.DB) (DirectoryID, error) {
 	db = db.WithContext(ctx)
 	var root Directory
 	err := db.Select("id").Where("attachment_id = ? AND parent_id is null", s.ID).First(&root).Error
 	return root.ID, errors.WithStack(err)
 }
 
+type OutputAttachmentID uint32
+
 // OutputAttachment is a link between a Preparation and a Storage that is used as an output.
 type OutputAttachment struct {
-	ID uint32 `gorm:"primaryKey" json:"id"`
+	ID OutputAttachmentID `gorm:"primaryKey" json:"id"`
 
 	// Associations
-	PreparationID uint32       `gorm:"uniqueIndex:prep_output"                              json:"preparationId"`
-	Preparation   *Preparation `gorm:"foreignKey:PreparationID;constraint:OnDelete:CASCADE" json:"preparation,omitempty" swaggerignore:"true"`
-	StorageID     uint32       `gorm:"uniqueIndex:prep_output"                              json:"storageId"`
-	Storage       *Storage     `gorm:"foreignKey:StorageID;constraint:OnDelete:CASCADE"     json:"storage,omitempty"     swaggerignore:"true"`
+	PreparationID PreparationID `gorm:"uniqueIndex:prep_output"                              json:"preparationId"`
+	Preparation   *Preparation  `gorm:"foreignKey:PreparationID;constraint:OnDelete:CASCADE" json:"preparation,omitempty" swaggerignore:"true"`
+	StorageID     StorageID     `gorm:"uniqueIndex:prep_output"                              json:"storageId"`
+	Storage       *Storage      `gorm:"foreignKey:StorageID;constraint:OnDelete:CASCADE"     json:"storage,omitempty"     swaggerignore:"true"`
 }
+
+type JobID uint64
 
 // Job is a job that is executed by a worker.
 // The composite index on Type and State is used to find jobs that are ready to be executed.
 type Job struct {
-	ID              uint64   `gorm:"primaryKey"           json:"id"`
+	ID              JobID    `gorm:"primaryKey"           json:"id"`
 	Type            JobType  `gorm:"index:job_type_state" json:"type"`
 	State           JobState `gorm:"index:job_type_state" json:"state"`
 	ErrorMessage    string   `json:"errorMessage"`
 	ErrorStackTrace string   `json:"errorStackTrace"      table:"verbose"`
 
 	// Associations
-	WorkerID     *string           `gorm:"size:63"                                                        json:"workerId,omitempty"`
-	Worker       *Worker           `gorm:"foreignKey:WorkerID;references:ID;constraint:OnDelete:SET NULL" json:"worker,omitempty"     swaggerignore:"true" table:"verbose;expand"`
-	AttachmentID uint32            `json:"attachmentId"                                                   table:"verbose"`
-	Attachment   *SourceAttachment `gorm:"foreignKey:AttachmentID;constraint:OnDelete:CASCADE"            json:"attachment,omitempty" swaggerignore:"true" table:"expand"`
-	FileRanges   []FileRange       `gorm:"foreignKey:JobID;constraint:OnDelete:SET NULL"                  json:"fileRanges,omitempty" swaggerignore:"true" table:"-"`
+	WorkerID     *string            `gorm:"size:63"                                                        json:"workerId,omitempty"`
+	Worker       *Worker            `gorm:"foreignKey:WorkerID;references:ID;constraint:OnDelete:SET NULL" json:"worker,omitempty"     swaggerignore:"true" table:"verbose;expand"`
+	AttachmentID SourceAttachmentID `json:"attachmentId"                                                   table:"verbose"`
+	Attachment   *SourceAttachment  `gorm:"foreignKey:AttachmentID;constraint:OnDelete:CASCADE"            json:"attachment,omitempty" swaggerignore:"true" table:"expand"`
+	FileRanges   []FileRange        `gorm:"foreignKey:JobID;constraint:OnDelete:SET NULL"                  json:"fileRanges,omitempty" swaggerignore:"true" table:"-"`
 }
+
+type FileID uint64
 
 // File makes a reference to the source storage file, e.g., a local file.
 // The index on Path is used as part of scanning to find existing file and add new versions.
 // The index on DirectoryID is used to find all files in a directory.
 type File struct {
-	ID               uint64 `gorm:"primaryKey"                     json:"id"`
+	ID               FileID `gorm:"primaryKey"                     json:"id"`
 	CID              CID    `gorm:"column:cid;type:bytes;size:255" json:"cid"  swaggertype:"string"` // CID is the CID of the file.
 	Path             string `gorm:"index"                          json:"path"`                      // Path is the relative path to the file inside the storage.
 	Hash             string `json:"hash"`                                                            // Hash is the hash of the file.
@@ -175,11 +187,11 @@ type File struct {
 	LastModifiedNano int64  `json:"lastModifiedNano"`
 
 	// Associations
-	AttachmentID uint32            `json:"attachmentId"`
-	Attachment   *SourceAttachment `gorm:"foreignKey:AttachmentID;constraint:OnDelete:CASCADE" json:"attachment,omitempty" swaggerignore:"true"`
-	DirectoryID  *uint64           `gorm:"index"                                               json:"directoryId"`
-	Directory    *Directory        `gorm:"foreignKey:DirectoryID;constraint:OnDelete:CASCADE"  json:"directory,omitempty"  swaggerignore:"true"`
-	FileRanges   []FileRange       `gorm:"constraint:OnDelete:CASCADE"                         json:"fileRanges,omitempty"`
+	AttachmentID SourceAttachmentID `json:"attachmentId"`
+	Attachment   *SourceAttachment  `gorm:"foreignKey:AttachmentID;constraint:OnDelete:CASCADE" json:"attachment,omitempty" swaggerignore:"true"`
+	DirectoryID  *DirectoryID       `gorm:"index"                                               json:"directoryId"`
+	Directory    *Directory         `gorm:"foreignKey:DirectoryID;constraint:OnDelete:CASCADE"  json:"directory,omitempty"  swaggerignore:"true"`
+	FileRanges   []FileRange        `gorm:"constraint:OnDelete:CASCADE"                         json:"fileRanges,omitempty"`
 
 	// For Cbor marshalling
 	_ struct{} `cbor:",toarray"                                                  json:"-"                    swaggerignore:"true"`
@@ -189,65 +201,73 @@ func (i File) FileName() string {
 	return i.Path[strings.LastIndex(i.Path, "/")+1:]
 }
 
+type DirectoryID uint64
+
 // Directory is a link between parent and child directories.
 // The index on AttachmentID and ParentID is used to find all root directories, as well as all directories in a directory.
 type Directory struct {
-	ID       uint64 `gorm:"primaryKey"            json:"id"`
-	CID      CID    `gorm:"column:cid;type:bytes" json:"cid" swaggertype:"string"` // CID is the CID of the directory.
-	Data     []byte `gorm:"column:data"           json:"-"   swaggerignore:"true"` // Data is the serialized directory data.
-	Name     string `json:"name"`                                                  // Name is the name of the directory.
-	Exported bool   `json:"exported"`                                              // Exported is a flag that indicates whether the directory has been exported to the DAG.
+	ID       DirectoryID `gorm:"primaryKey"            json:"id"`
+	CID      CID         `gorm:"column:cid;type:bytes" json:"cid" swaggertype:"string"` // CID is the CID of the directory.
+	Data     []byte      `gorm:"column:data"           json:"-"   swaggerignore:"true"` // Data is the serialized directory data.
+	Name     string      `json:"name"`                                                  // Name is the name of the directory.
+	Exported bool        `json:"exported"`                                              // Exported is a flag that indicates whether the directory has been exported to the DAG.
 
 	// Associations
-	AttachmentID uint32            `gorm:"index:directory_source_parent"                       json:"attachmentId"`
-	Attachment   *SourceAttachment `gorm:"foreignKey:AttachmentID;constraint:OnDelete:CASCADE" json:"attachment,omitempty" swaggerignore:"true"`
-	ParentID     *uint64           `gorm:"index:directory_source_parent"                       json:"parentId"`
-	Parent       *Directory        `gorm:"foreignKey:ParentID;constraint:OnDelete:CASCADE"     json:"parent,omitempty"     swaggerignore:"true"`
+	AttachmentID SourceAttachmentID `gorm:"index:directory_source_parent"                       json:"attachmentId"`
+	Attachment   *SourceAttachment  `gorm:"foreignKey:AttachmentID;constraint:OnDelete:CASCADE" json:"attachment,omitempty" swaggerignore:"true"`
+	ParentID     *DirectoryID       `gorm:"index:directory_source_parent"                       json:"parentId"`
+	Parent       *Directory         `gorm:"foreignKey:ParentID;constraint:OnDelete:CASCADE"     json:"parent,omitempty"     swaggerignore:"true"`
 }
+
+type FileRangeID uint64
 
 // FileRange is a range of bytes inside File.
 // The index on FileID is used to find all FileRange in a file.
 // The index on JobID is used to find all FileRange in a job.
 type FileRange struct {
-	ID     uint64 `gorm:"primaryKey"            json:"id"`
-	Offset int64  `json:"offset"`                                                // Offset is the offset of the range inside the file.
-	Length int64  `json:"length"`                                                // Length is the length of the range in bytes.
-	CID    CID    `gorm:"column:cid;type:bytes" json:"cid" swaggertype:"string"` // CID is the CID of the range.
+	ID     FileRangeID `gorm:"primaryKey"            json:"id"`
+	Offset int64       `json:"offset"`                                                // Offset is the offset of the range inside the file.
+	Length int64       `json:"length"`                                                // Length is the length of the range in bytes.
+	CID    CID         `gorm:"column:cid;type:bytes" json:"cid" swaggertype:"string"` // CID is the CID of the range.
 
 	// Associations
-	JobID  *uint64 `gorm:"index"                                         json:"jobId"`
-	Job    *Job    `gorm:"foreignKey:JobID;constraint:OnDelete:SET NULL" json:"job,omitempty"  swaggerignore:"true"`
-	FileID uint64  `gorm:"index"                                         json:"fileId"`
-	File   *File   `gorm:"foreignKey:FileID;constraint:OnDelete:CASCADE" json:"file,omitempty" swaggerignore:"true"`
+	JobID  *JobID `gorm:"index"                                         json:"jobId"`
+	Job    *Job   `gorm:"foreignKey:JobID;constraint:OnDelete:SET NULL" json:"job,omitempty"  swaggerignore:"true"`
+	FileID FileID `gorm:"index"                                         json:"fileId"`
+	File   *File  `gorm:"foreignKey:FileID;constraint:OnDelete:CASCADE" json:"file,omitempty" swaggerignore:"true"`
 }
+
+type CarID uint32
 
 // Car makes a reference to a CAR file that has been potentially exported to the disk.
 // In the case of inline preparation, the path may be empty so the Car should be constructed
 // on the fly using CarBlock.
 // The index on PieceCID is to find all CARs that can matches the PieceCID
 type Car struct {
-	ID          uint32    `gorm:"primaryKey"                                        json:"id"                                  table:"verbose"`
-	CreatedAt   time.Time `json:"createdAt"                                         table:"verbose;format:2006-01-02 15:04:05"`
-	PieceCID    CID       `gorm:"column:piece_cid;index;type:bytes;size:255"        json:"pieceCid"                            swaggertype:"string"`
-	PieceSize   int64     `json:"pieceSize"`
-	RootCID     CID       `gorm:"column:root_cid;type:bytes"                        json:"rootCid"                             swaggertype:"string"`
-	FileSize    int64     `json:"fileSize"`
-	StorageID   *uint32   `json:"storageId"                                         table:"verbose"`
-	Storage     *Storage  `gorm:"foreignKey:StorageID;constraint:OnDelete:SET NULL" json:"storage,omitempty"                   swaggerignore:"true" table:"expand"`
-	StoragePath string    `json:"storagePath"` // StoragePath is the path to the CAR file inside the storage. If the StorageID is nil but StoragePath is not empty, it means the CAR file is stored at the local absolute path.
-	NumOfFiles  int64     `json:"numOfFiles"                                        table:"verbose"`
+	ID          CarID      `gorm:"primaryKey"                                        json:"id"                                  table:"verbose"`
+	CreatedAt   time.Time  `json:"createdAt"                                         table:"verbose;format:2006-01-02 15:04:05"`
+	PieceCID    CID        `gorm:"column:piece_cid;index;type:bytes;size:255"        json:"pieceCid"                            swaggertype:"string"`
+	PieceSize   int64      `json:"pieceSize"`
+	RootCID     CID        `gorm:"column:root_cid;type:bytes"                        json:"rootCid"                             swaggertype:"string"`
+	FileSize    int64      `json:"fileSize"`
+	StorageID   *StorageID `json:"storageId"                                         table:"verbose"`
+	Storage     *Storage   `gorm:"foreignKey:StorageID;constraint:OnDelete:SET NULL" json:"storage,omitempty"                   swaggerignore:"true" table:"expand"`
+	StoragePath string     `json:"storagePath"` // StoragePath is the path to the CAR file inside the storage. If the StorageID is nil but StoragePath is not empty, it means the CAR file is stored at the local absolute path.
+	NumOfFiles  int64      `json:"numOfFiles"                                        table:"verbose"`
 
 	// Association
-	PreparationID uint32            `json:"preparationId"                                        table:"-"`
-	Preparation   *Preparation      `gorm:"foreignKey:PreparationID;constraint:OnDelete:CASCADE" json:"preparation,omitempty" swaggerignore:"true" table:"-"`
-	AttachmentID  *uint32           `json:"attachmentId"                                         table:"-"`
-	Attachment    *SourceAttachment `gorm:"foreignKey:AttachmentID;constraint:OnDelete:CASCADE"  json:"attachment,omitempty"  swaggerignore:"true" table:"-"`
-	JobID         *uint64           `json:"jobId,omitempty"                                      table:"-"`
-	Job           *Job              `gorm:"foreignKey:JobID;constraint:OnDelete:SET NULL"        json:"job,omitempty"         swaggerignore:"true" table:"-"`
+	PreparationID PreparationID       `json:"preparationId"                                        table:"-"`
+	Preparation   *Preparation        `gorm:"foreignKey:PreparationID;constraint:OnDelete:CASCADE" json:"preparation,omitempty" swaggerignore:"true" table:"-"`
+	AttachmentID  *SourceAttachmentID `json:"attachmentId"                                         table:"-"`
+	Attachment    *SourceAttachment   `gorm:"foreignKey:AttachmentID;constraint:OnDelete:CASCADE"  json:"attachment,omitempty"  swaggerignore:"true" table:"-"`
+	JobID         *JobID              `json:"jobId,omitempty"                                      table:"-"`
+	Job           *Job                `gorm:"foreignKey:JobID;constraint:OnDelete:SET NULL"        json:"job,omitempty"         swaggerignore:"true" table:"-"`
 
 	// For Cbor marshalling
 	_ struct{} `cbor:",toarray"                                                  json:"-"                    swaggerignore:"true"`
 }
+
+type CarBlockID uint64
 
 // CarBlock tells us the CIDs of all blocks inside a Car and the offset of those blocks.
 // From this table we can determine how to get the block by CID from a Car.
@@ -256,21 +276,21 @@ type Car struct {
 // The index on CarID is used to find all blocks in a Car.
 // The index on CID is used to find a specific block with CID.
 type CarBlock struct {
-	ID             uint64 `gorm:"primaryKey"                           json:"id"`
-	CID            CID    `gorm:"index;column:cid;type:bytes;size:255" json:"cid" swaggertype:"string"` // CID is the CID of the block.
-	CarOffset      int64  `json:"carOffset"`                                                            // Offset of the block in the Car
-	CarBlockLength int32  `json:"carBlockLength"`                                                       // Length of the block in the Car, including varint, CID and raw block
-	Varint         []byte `json:"varint"`                                                               // Varint is the varint that represents the length of the block and the CID.
-	RawBlock       []byte `json:"rawBlock"`                                                             // Raw block
-	FileOffset     int64  `json:"fileOffset"`                                                           // Offset of the block in the File
+	ID             CarBlockID `gorm:"primaryKey"                           json:"id"`
+	CID            CID        `gorm:"index;column:cid;type:bytes;size:255" json:"cid" swaggertype:"string"` // CID is the CID of the block.
+	CarOffset      int64      `json:"carOffset"`                                                            // Offset of the block in the Car
+	CarBlockLength int32      `json:"carBlockLength"`                                                       // Length of the block in the Car, including varint, CID and raw block
+	Varint         []byte     `json:"varint"`                                                               // Varint is the varint that represents the length of the block and the CID.
+	RawBlock       []byte     `json:"rawBlock"`                                                             // Raw block
+	FileOffset     int64      `json:"fileOffset"`                                                           // Offset of the block in the File
 
 	// Internal Caching
 	blockLength int32 // Block length in bytes
 
 	// Associations
-	CarID  uint32  `gorm:"index"                                         json:"carId"`
+	CarID  CarID   `gorm:"index"                                         json:"carId"`
 	Car    *Car    `gorm:"foreignKey:CarID;constraint:OnDelete:CASCADE"  json:"car,omitempty"  swaggerignore:"true"`
-	FileID *uint64 `json:"fileId"`
+	FileID *FileID `json:"fileId"`
 	File   *File   `gorm:"foreignKey:FileID;constraint:OnDelete:CASCADE" json:"file,omitempty" swaggerignore:"true"`
 
 	// For Cbor marshalling

--- a/pack/assembler.go
+++ b/pack/assembler.go
@@ -26,7 +26,7 @@ var ErrFileModified = errors.New("file has been modified")
 type Assembler struct {
 	rootCID cid.Cid
 	// objects represents a map of object IDs to their corresponding fs.Object representations.
-	objects map[uint64]fs.Object
+	objects map[model.FileID]fs.Object
 	// ctx provides the context for the assembler's operations.
 	ctx context.Context
 	// reader is the storage system reader used to read file data.
@@ -73,7 +73,7 @@ func NewAssembler(ctx context.Context, reader storagesystem.Reader,
 		reader:     reader,
 		fileRanges: fileRanges,
 		buf:        make([]byte, packutil.ChunkSize),
-		objects:    make(map[uint64]fs.Object),
+		objects:    make(map[model.FileID]fs.Object),
 	}
 }
 

--- a/pack/assembler_test.go
+++ b/pack/assembler_test.go
@@ -52,12 +52,12 @@ func TestAssembler(t *testing.T) {
 		stat, err := os.Stat(filepath.Join(tmp, filename))
 		require.NoError(t, err)
 		allFileRanges = append(allFileRanges, model.FileRange{
-			ID:     uint64(size),
+			ID:     model.FileRangeID(size),
 			Offset: 0,
 			Length: int64(size),
-			FileID: uint64(size),
+			FileID: model.FileID(size),
 			File: &model.File{
-				ID:               uint64(size),
+				ID:               model.FileID(size),
 				Path:             filename,
 				Size:             int64(size),
 				LastModifiedNano: stat.ModTime().UnixNano(),
@@ -66,7 +66,7 @@ func TestAssembler(t *testing.T) {
 
 	for size, expected := range sizes {
 		fileRange, err := underscore.Find(allFileRanges, func(fileRange model.FileRange) bool {
-			return fileRange.ID == uint64(size)
+			return fileRange.ID == model.FileRangeID(size)
 		})
 		require.NoError(t, err)
 		t.Run(fmt.Sprintf("single size=%d", size), func(t *testing.T) {

--- a/pack/daggen/directory.go
+++ b/pack/daggen/directory.go
@@ -31,27 +31,27 @@ type DirectoryDetail struct {
 }
 
 type DirectoryTree struct {
-	cache         map[uint64]*DirectoryDetail
-	childrenCache map[uint64][]uint64 // This is known children for this pack only
+	cache         map[model.DirectoryID]*DirectoryDetail
+	childrenCache map[model.DirectoryID][]model.DirectoryID // This is known children for this pack only
 }
 
 func NewDirectoryTree() DirectoryTree {
 	return DirectoryTree{
-		cache:         make(map[uint64]*DirectoryDetail),
-		childrenCache: make(map[uint64][]uint64),
+		cache:         make(map[model.DirectoryID]*DirectoryDetail),
+		childrenCache: make(map[model.DirectoryID][]model.DirectoryID),
 	}
 }
 
-func (t DirectoryTree) Cache() map[uint64]*DirectoryDetail {
+func (t DirectoryTree) Cache() map[model.DirectoryID]*DirectoryDetail {
 	return t.cache
 }
 
-func (t DirectoryTree) Has(dirID uint64) bool {
+func (t DirectoryTree) Has(dirID model.DirectoryID) bool {
 	_, ok := t.cache[dirID]
 	return ok
 }
 
-func (t DirectoryTree) Get(dirID uint64) *DirectoryDetail {
+func (t DirectoryTree) Get(dirID model.DirectoryID) *DirectoryDetail {
 	return t.cache[dirID]
 }
 
@@ -89,7 +89,7 @@ func (t DirectoryTree) Add(ctx context.Context, dir *model.Directory) error {
 // Returns:
 //   - *format.Link: A link that points to the root of the IPLD structure for the directory.
 //   - error: The error encountered during the operation, if any.
-func (t DirectoryTree) Resolve(ctx context.Context, dirID uint64) (*format.Link, error) {
+func (t DirectoryTree) Resolve(ctx context.Context, dirID model.DirectoryID) (*format.Link, error) {
 	detail, ok := t.cache[dirID]
 	if !ok {
 		return nil, errors.Errorf("no directory detail for dir %d", dirID)

--- a/pack/daggen/directory_test.go
+++ b/pack/daggen/directory_test.go
@@ -87,17 +87,17 @@ func TestResolveDirectoryTree(t *testing.T) {
 	ctx := context.Background()
 	root := NewDirectoryData()
 	dir := NewDirectoryData()
-	cache := map[uint64]*DirectoryDetail{
+	cache := map[model.DirectoryID]*DirectoryDetail{
 		1: {
 			Dir:  &model.Directory{ID: 1},
 			Data: &root,
 		},
 		2: {
-			Dir:  &model.Directory{ID: 2, Name: "name", ParentID: ptr.Of(uint64(1))},
+			Dir:  &model.Directory{ID: 2, Name: "name", ParentID: ptr.Of(model.DirectoryID(1))},
 			Data: &dir,
 		},
 	}
-	children := map[uint64][]uint64{
+	children := map[model.DirectoryID][]model.DirectoryID{
 		1: {2},
 	}
 	err := root.AddFile(ctx, "test", cid.NewCidV1(cid.Raw, util.Hash([]byte("test"))), 4)

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -148,9 +148,9 @@ func Pack(
 	}
 
 	// Update all FileRange and file CID that are not split
-	splitFileIDs := make(map[uint64]model.File)
+	splitFileIDs := make(map[model.FileID]model.File)
 	var updatedFiles []model.File
-	splitFileBlks := make(map[uint64][]blocks.Block)
+	splitFileBlks := make(map[model.FileID][]blocks.Block)
 	for _, fileRange := range job.FileRanges {
 		err = database.DoRetry(ctx, func() error {
 			return db.Model(&model.FileRange{}).Where("id = ?", fileRange.ID).
@@ -244,7 +244,7 @@ func Pack(
 		return db.Transaction(func(db *gorm.DB) error {
 			var err error
 			tree := daggen.NewDirectoryTree()
-			var rootDirID uint64
+			var rootDirID model.DirectoryID
 			for _, file := range updatedFiles {
 				dirID := file.DirectoryID
 				for {

--- a/pack/pack_test.go
+++ b/pack/pack_test.go
@@ -103,7 +103,7 @@ func TestAssembleCar(t *testing.T) {
 							Size:             stat.Size(),
 							LastModifiedNano: stat.ModTime().UnixNano(),
 							AttachmentID:     1,
-							DirectoryID:      ptr.Of(uint64(1)),
+							DirectoryID:      ptr.Of(model.DirectoryID(1)),
 						},
 					},
 				},

--- a/pack/push/filerangeset.go
+++ b/pack/push/filerangeset.go
@@ -51,8 +51,8 @@ func (r *FileRangeSet) Reset() {
 	r.carSize = int64(carHeaderSize)
 }
 
-func (r *FileRangeSet) FileRangeIDs() []uint64 {
-	return underscore.Map(r.fileRanges, func(fileRange model.FileRange) uint64 {
+func (r *FileRangeSet) FileRangeIDs() []model.FileRangeID {
+	return underscore.Map(r.fileRanges, func(fileRange model.FileRange) model.FileRangeID {
 		return fileRange.ID
 	})
 }

--- a/pack/push/pushfile.go
+++ b/pack/push/pushfile.go
@@ -51,7 +51,7 @@ func PushFile(
 	db *gorm.DB,
 	obj fs.ObjectInfo,
 	attachment model.SourceAttachment,
-	directoryCache map[string]uint64) (*model.File, []model.FileRange, error) {
+	directoryCache map[string]model.DirectoryID) (*model.File, []model.FileRange, error) {
 	logger.Debugw("pushing file", "file", obj.Remote(), "preparation", attachment.PreparationID, "storage", attachment.StorageID)
 	db = db.WithContext(ctx)
 	splitSize := MaxSizeToSplitSize(attachment.Preparation.MaxSize)
@@ -138,8 +138,8 @@ func PushFile(
 func EnsureParentDirectories(
 	ctx context.Context,
 	db *gorm.DB,
-	file *model.File, rootDirID uint64,
-	directoryCache map[string]uint64) error {
+	file *model.File, rootDirID model.DirectoryID,
+	directoryCache map[string]model.DirectoryID) error {
 	if file.DirectoryID != nil {
 		return nil
 	}
@@ -178,8 +178,8 @@ func EnsureParentDirectories(
 func CreatePackJob(
 	ctx context.Context,
 	db *gorm.DB,
-	attachmentID uint32,
-	fileRangeIDs []uint64,
+	attachmentID model.SourceAttachmentID,
+	fileRangeIDs []model.FileRangeID,
 ) (*model.Job, error) {
 	db = db.WithContext(ctx)
 	job := model.Job{

--- a/pack/push/pushfile_test.go
+++ b/pack/push/pushfile_test.go
@@ -47,7 +47,7 @@ func TestMaxSizeToSplitSize(t *testing.T) {
 
 func TestPushFile(t *testing.T) {
 	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
-		cache := map[string]uint64{"": 1, ".": 1}
+		cache := map[string]model.DirectoryID{"": 1, ".": 1}
 		attachment := model.SourceAttachment{
 			Preparation: &model.Preparation{
 				MaxSize: 16,
@@ -89,7 +89,7 @@ func TestPushFile(t *testing.T) {
 
 func TestEnsureParentDirectories(t *testing.T) {
 	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
-		cache := map[string]uint64{}
+		cache := map[string]model.DirectoryID{}
 		attachment := model.SourceAttachment{
 			Preparation: &model.Preparation{},
 			Storage:     &model.Storage{},
@@ -145,7 +145,7 @@ func TestCreatePackJob(t *testing.T) {
 		}
 		err = db.Create(&fileRanges).Error
 		require.NoError(t, err)
-		job, err := CreatePackJob(ctx, db, attachment.ID, []uint64{1})
+		job, err := CreatePackJob(ctx, db, attachment.ID, []model.FileRangeID{1})
 		require.NoError(t, err)
 		require.Equal(t, attachment.ID, job.AttachmentID)
 	})

--- a/scan/prepare.go
+++ b/scan/prepare.go
@@ -15,7 +15,7 @@ import (
 func NextAvailablePackJob(
 	ctx context.Context,
 	db *gorm.DB,
-	attachmentID uint32,
+	attachmentID model.SourceAttachmentID,
 ) (*model.Job, error) {
 	var packJob model.Job
 	err := database.DoRetry(ctx, func() error {
@@ -65,9 +65,9 @@ func PrepareToPackFileRanges(
 func UpdatePackJob(
 	ctx context.Context,
 	db *gorm.DB,
-	packJobID uint64,
+	packJobID model.JobID,
 	state model.JobState,
-	fileRangeIDs []uint64,
+	fileRangeIDs []model.FileRangeID,
 ) error {
 	return database.DoRetry(ctx, func() error {
 		return db.Transaction(
@@ -111,7 +111,7 @@ func PrepareSource(ctx context.Context, db *gorm.DB, attachment model.SourceAtta
 func markPackJobsReady(
 	ctx context.Context,
 	db *gorm.DB,
-	attachmentID uint32,
+	attachmentID model.SourceAttachmentID,
 ) error {
 	return database.DoRetry(ctx, func() error {
 		return db.Model(&model.Job{}).Where("attachment_id = ? AND state = ?", attachmentID, model.Created).Update("state", model.Ready).Error

--- a/scan/scan.go
+++ b/scan/scan.go
@@ -17,7 +17,7 @@ var logger = log.Logger("scan")
 
 func Scan(ctx context.Context, db *gorm.DB, attachment model.SourceAttachment) error {
 	db = db.WithContext(ctx)
-	directoryCache := make(map[string]uint64)
+	directoryCache := make(map[string]model.DirectoryID)
 	var remaining = push.NewFileRangeSet()
 	var remainingFileRanges []model.FileRange
 	err := db.Joins("File").
@@ -87,7 +87,7 @@ func Scan(ctx context.Context, db *gorm.DB, attachment model.SourceAttachment) e
 func createPackJob(
 	ctx context.Context,
 	db *gorm.DB,
-	attachmentID uint32,
+	attachmentID model.SourceAttachmentID,
 	remaining *push.FileRangeSet,
 ) error {
 	job, err := push.CreatePackJob(ctx, db, attachmentID, remaining.FileRangeIDs())
@@ -102,7 +102,7 @@ func createPackJob(
 func addFileRangesAndCreatePackJob(
 	ctx context.Context,
 	db *gorm.DB,
-	attachmentID uint32,
+	attachmentID model.SourceAttachmentID,
 	remaining *push.FileRangeSet,
 	maxSize int64,
 	fileRanges ...model.FileRange) error {

--- a/service/contentprovider/http.go
+++ b/service/contentprovider/http.go
@@ -134,11 +134,11 @@ func getPieceMetadata(ctx context.Context, db *gorm.DB, car model.Car) (*PieceMe
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	storageIDSet := make(map[uint32]struct{})
+	storageIDSet := make(map[model.StorageID]struct{})
 	for _, file := range files {
 		storageIDSet[file.Attachment.StorageID] = struct{}{}
 	}
-	var storageIDs []uint32
+	var storageIDs []model.StorageID
 	for storageID := range storageIDSet {
 		storageIDs = append(storageIDs, storageID)
 	}

--- a/service/datasetworker/daggen.go
+++ b/service/datasetworker/daggen.go
@@ -24,10 +24,10 @@ import (
 type DagGenerator struct {
 	ctx          context.Context
 	db           *gorm.DB
-	attachmentID uint32
+	attachmentID model.SourceAttachmentID
 	rows         *sql.Rows
 	root         cid.Cid
-	dirCIDs      map[uint64]model.CID
+	dirCIDs      map[model.DirectoryID]model.CID
 	buffer       io.Reader
 	done         bool
 	carBlocks    []model.CarBlock
@@ -114,13 +114,13 @@ func (d *DagGenerator) Close() error {
 	return nil
 }
 
-func NewDagGenerator(ctx context.Context, db *gorm.DB, attachmentID uint32, root cid.Cid) *DagGenerator {
+func NewDagGenerator(ctx context.Context, db *gorm.DB, attachmentID model.SourceAttachmentID, root cid.Cid) *DagGenerator {
 	return &DagGenerator{
 		ctx:          ctx,
 		db:           db,
 		attachmentID: attachmentID,
 		root:         root,
-		dirCIDs:      make(map[uint64]model.CID),
+		dirCIDs:      make(map[model.DirectoryID]model.CID),
 	}
 }
 

--- a/service/datasetworker/daggen_test.go
+++ b/service/datasetworker/daggen_test.go
@@ -53,7 +53,7 @@ func TestExportDag(t *testing.T) {
 
 		dirs := []model.Directory{
 			{AttachmentID: 1, Data: dir1Data, CID: model.CID(packutil.EmptyFileCid)},
-			{AttachmentID: 1, Data: dir2Data, CID: model.CID(packutil.EmptyFileCid), ParentID: ptr.Of(uint64(1)), Name: "sub"},
+			{AttachmentID: 1, Data: dir2Data, CID: model.CID(packutil.EmptyFileCid), ParentID: ptr.Of(model.DirectoryID(1)), Name: "sub"},
 		}
 		err = thread.dbNoContext.Create(&dirs).Error
 		require.NoError(t, err)
@@ -117,7 +117,7 @@ func TestExportDag_WithOutputStorage(t *testing.T) {
 
 		dirs := []model.Directory{
 			{AttachmentID: 1, Data: dir1Data, CID: model.CID(packutil.EmptyFileCid)},
-			{AttachmentID: 1, Data: dir2Data, CID: model.CID(packutil.EmptyFileCid), ParentID: ptr.Of(uint64(1)), Name: "sub"},
+			{AttachmentID: 1, Data: dir2Data, CID: model.CID(packutil.EmptyFileCid), ParentID: ptr.Of(model.DirectoryID(1)), Name: "sub"},
 		}
 		err = thread.dbNoContext.Create(&dirs).Error
 		require.NoError(t, err)

--- a/service/datasetworker/datasetworker.go
+++ b/service/datasetworker/datasetworker.go
@@ -174,7 +174,7 @@ func (w Worker) Name() string {
 	return "Preparation Worker Main"
 }
 
-func (w *Thread) handleWorkComplete(ctx context.Context, jobID uint64) error {
+func (w *Thread) handleWorkComplete(ctx context.Context, jobID model.JobID) error {
 	return database.DoRetry(ctx, func() error {
 		return w.dbNoContext.WithContext(ctx).Model(&model.Job{}).Where("id = ?", jobID).Updates(map[string]any{
 			"worker_id":         nil,
@@ -185,7 +185,7 @@ func (w *Thread) handleWorkComplete(ctx context.Context, jobID uint64) error {
 	})
 }
 
-func (w *Thread) handleWorkError(ctx context.Context, jobID uint64, err error) error {
+func (w *Thread) handleWorkError(ctx context.Context, jobID model.JobID, err error) error {
 	updates := make(map[string]any)
 	updates["worker_id"] = nil
 	// Reset the state to ready if the context was canceled

--- a/service/datasetworker/find_test.go
+++ b/service/datasetworker/find_test.go
@@ -47,7 +47,7 @@ func TestFindPackWork(t *testing.T) {
 		}).Error
 		require.NoError(t, err)
 		err = db.Create(&model.FileRange{
-			JobID: ptr.Of(uint64(1)),
+			JobID: ptr.Of(model.JobID(1)),
 			File: &model.File{
 				AttachmentID: 1,
 			},

--- a/service/dealpusher/dealpusher_test.go
+++ b/service/dealpusher/dealpusher_test.go
@@ -133,7 +133,7 @@ func TestDealMakerService_FailtoSend(t *testing.T) {
 		}
 		err = db.Create([]model.Car{
 			{
-				AttachmentID:  ptr.Of(uint32(1)),
+				AttachmentID:  ptr.Of(model.SourceAttachmentID(1)),
 				PreparationID: 1,
 				PieceCID:      pieceCIDs[0],
 				PieceSize:     1024,
@@ -189,19 +189,19 @@ func TestDealMakerService_Cron(t *testing.T) {
 
 		err = db.Create([]model.Car{
 			{
-				AttachmentID:  ptr.Of(uint32(1)),
+				AttachmentID:  ptr.Of(model.SourceAttachmentID(1)),
 				PreparationID: 1,
 				PieceCID:      model.CID(calculateCommp(t, generateRandomBytes(1000), 1024)),
 				PieceSize:     1024,
 			},
 			{
-				AttachmentID:  ptr.Of(uint32(1)),
+				AttachmentID:  ptr.Of(model.SourceAttachmentID(1)),
 				PreparationID: 1,
 				PieceCID:      model.CID(calculateCommp(t, generateRandomBytes(1000), 1024)),
 				PieceSize:     1024,
 			},
 			{
-				AttachmentID:  ptr.Of(uint32(1)),
+				AttachmentID:  ptr.Of(model.SourceAttachmentID(1)),
 				PreparationID: 1,
 				PieceCID:      model.CID(calculateCommp(t, generateRandomBytes(1000), 1024)),
 				PieceSize:     1024,
@@ -290,35 +290,35 @@ func TestDealMakerService_ScheduleWithConstraints(t *testing.T) {
 		}
 		err = db.Create([]model.Car{
 			{
-				AttachmentID:  ptr.Of(uint32(1)),
+				AttachmentID:  ptr.Of(model.SourceAttachmentID(1)),
 				PreparationID: 1,
 				PieceCID:      pieceCIDs[0],
 				PieceSize:     1024,
 				StoragePath:   "0",
 			},
 			{
-				AttachmentID:  ptr.Of(uint32(1)),
+				AttachmentID:  ptr.Of(model.SourceAttachmentID(1)),
 				PreparationID: 1,
 				PieceCID:      pieceCIDs[1],
 				PieceSize:     1024,
 				StoragePath:   "1",
 			},
 			{
-				AttachmentID:  ptr.Of(uint32(1)),
+				AttachmentID:  ptr.Of(model.SourceAttachmentID(1)),
 				PreparationID: 1,
 				PieceCID:      pieceCIDs[2],
 				PieceSize:     2048,
 				StoragePath:   "2",
 			},
 			{
-				AttachmentID:  ptr.Of(uint32(1)),
+				AttachmentID:  ptr.Of(model.SourceAttachmentID(1)),
 				PreparationID: 1,
 				PieceCID:      pieceCIDs[3],
 				PieceSize:     1024,
 				StoragePath:   "3",
 			},
 			{
-				AttachmentID:  ptr.Of(uint32(1)),
+				AttachmentID:  ptr.Of(model.SourceAttachmentID(1)),
 				PreparationID: 1,
 				PieceCID:      pieceCIDs[4],
 				PieceSize:     1024,
@@ -401,35 +401,35 @@ func TestDealMakerService_NewScheduleOneOff(t *testing.T) {
 		}
 		err = db.Create([]model.Car{
 			{
-				AttachmentID:  ptr.Of(uint32(1)),
+				AttachmentID:  ptr.Of(model.SourceAttachmentID(1)),
 				PreparationID: 1,
 				PieceCID:      pieceCIDs[0],
 				PieceSize:     1024,
 				StoragePath:   "0",
 			},
 			{
-				AttachmentID:  ptr.Of(uint32(1)),
+				AttachmentID:  ptr.Of(model.SourceAttachmentID(1)),
 				PreparationID: 1,
 				PieceCID:      pieceCIDs[1],
 				PieceSize:     1024,
 				StoragePath:   "1",
 			},
 			{
-				AttachmentID:  ptr.Of(uint32(1)),
+				AttachmentID:  ptr.Of(model.SourceAttachmentID(1)),
 				PreparationID: 1,
 				PieceCID:      pieceCIDs[2],
 				PieceSize:     1024,
 				StoragePath:   "2",
 			},
 			{
-				AttachmentID:  ptr.Of(uint32(1)),
+				AttachmentID:  ptr.Of(model.SourceAttachmentID(1)),
 				PreparationID: 1,
 				PieceCID:      pieceCIDs[3],
 				PieceSize:     1024,
 				StoragePath:   "3",
 			},
 			{
-				AttachmentID:  ptr.Of(uint32(1)),
+				AttachmentID:  ptr.Of(model.SourceAttachmentID(1)),
 				PreparationID: 1,
 				PieceCID:      pieceCIDs[4],
 				PieceSize:     1024,

--- a/service/dealtracker/dealtracker.go
+++ b/service/dealtracker/dealtracker.go
@@ -344,7 +344,7 @@ type KnownDeal struct {
 	State model.DealState
 }
 type UnknownDeal struct {
-	ID         uint64
+	ID         model.DealID
 	ClientID   string
 	Provider   string
 	PieceCID   model.CID

--- a/storagesystem/util.go
+++ b/storagesystem/util.go
@@ -80,13 +80,13 @@ var ErrStorageNotAvailable = errors.New("storage not available")
 var freeSpaceWarningThreshold = 0.05
 var freeSpaceErrorThreshold = 0.01
 
-func GetRandomOutputWriter(ctx context.Context, storages []model.Storage) (*uint32, Writer, error) {
+func GetRandomOutputWriter(ctx context.Context, storages []model.Storage) (*model.StorageID, Writer, error) {
 	if len(storages) == 0 {
 		return nil, nil, nil
 	}
 
 	var handlersWithWeight []struct {
-		id      uint32
+		id      model.StorageID
 		handler Writer
 		weight  float64
 	}
@@ -108,7 +108,7 @@ func GetRandomOutputWriter(ctx context.Context, storages []model.Storage) (*uint
 				continue
 			}
 			handlersWithWeight = append(handlersWithWeight, struct {
-				id      uint32
+				id      model.StorageID
 				handler Writer
 				weight  float64
 			}{
@@ -126,7 +126,7 @@ func GetRandomOutputWriter(ctx context.Context, storages []model.Storage) (*uint
 		}
 
 		handlersWithWeight = append(handlersWithWeight, struct {
-			id      uint32
+			id      model.StorageID
 			handler Writer
 			weight  float64
 		}{

--- a/store/item_reference_test.go
+++ b/store/item_reference_test.go
@@ -135,7 +135,7 @@ func TestFileReferenceBlockStore_Get_FileBlock(t *testing.T) {
 
 		err = db.Create(&model.CarBlock{
 			Car: &model.Car{
-				AttachmentID:  ptr.Of(uint32(1)),
+				AttachmentID:  ptr.Of(model.SourceAttachmentID(1)),
 				PreparationID: 1,
 			},
 			CID: model.CID(cidValue),

--- a/store/piece_store.go
+++ b/store/piece_store.go
@@ -48,11 +48,11 @@ type PieceReader struct {
 	ctx        context.Context
 	fileSize   int64
 	header     []byte
-	handlerMap map[uint32]storagesystem.Handler
+	handlerMap map[model.StorageID]storagesystem.Handler
 	carBlocks  []model.CarBlock
-	files      map[uint64]model.File
+	files      map[model.FileID]model.File
 	reader     io.ReadCloser
-	readerFor  uint64
+	readerFor  model.FileID
 	pos        int64
 	blockIndex int
 }
@@ -154,8 +154,8 @@ func NewPieceReader(
 	*PieceReader,
 	error,
 ) {
-	filesMap := make(map[uint64]model.File)
-	storageIDs := make(map[uint32]struct{})
+	filesMap := make(map[model.FileID]model.File)
+	storageIDs := make(map[model.StorageID]struct{})
 	for _, storage := range storages {
 		storageIDs[storage.ID] = struct{}{}
 	}
@@ -210,7 +210,7 @@ func NewPieceReader(
 		}
 	}
 
-	handlerMap := make(map[uint32]storagesystem.Handler)
+	handlerMap := make(map[model.StorageID]storagesystem.Handler)
 	for _, s := range storages {
 		handler, err := storagesystem.NewRCloneHandler(ctx, s)
 		if err != nil {

--- a/store/piece_store_test.go
+++ b/store/piece_store_test.go
@@ -39,7 +39,7 @@ func TestPieceReader_FileChanged(t *testing.T) {
 			CarOffset:      59,
 			CarBlockLength: 57,
 			Varint:         []byte{56},
-			FileID:         ptr.Of(uint64(1)),
+			FileID:         ptr.Of(model.FileID(1)),
 			CID:            model.CID(cidValue),
 		},
 	}
@@ -93,7 +93,7 @@ func TestPieceReader_LargeFile(t *testing.T) {
 			CarOffset:      59,
 			CarBlockLength: int32(size - 59),
 			Varint:         varint.ToUvarint(36 + 1024*1024),
-			FileID:         ptr.Of(uint64(1)),
+			FileID:         ptr.Of(model.FileID(1)),
 			CID:            model.CID(cidValue),
 		},
 	}
@@ -143,21 +143,21 @@ func TestPieceReader_ReadSeek(t *testing.T) {
 			CarOffset:      59,
 			CarBlockLength: 57,
 			Varint:         []byte{56},
-			FileID:         ptr.Of(uint64(1)),
+			FileID:         ptr.Of(model.FileID(1)),
 			CID:            model.CID(cidValue),
 		},
 		{
 			CarOffset:      116,
 			CarBlockLength: 57,
 			Varint:         []byte{56},
-			FileID:         ptr.Of(uint64(2)),
+			FileID:         ptr.Of(model.FileID(2)),
 			CID:            model.CID(cidValue),
 		},
 		{
 			CarOffset:      173,
 			CarBlockLength: 57,
 			Varint:         []byte{56},
-			FileID:         ptr.Of(uint64(3)),
+			FileID:         ptr.Of(model.FileID(3)),
 			CID:            model.CID(cidValue),
 		},
 		{
@@ -400,7 +400,7 @@ func TestNewPieceReader_InvalidConstruction(t *testing.T) {
 					CarOffset:      59,
 					CarBlockLength: 57,
 					Varint:         []byte{56},
-					FileID:         ptr.Of(uint64(100)),
+					FileID:         ptr.Of(model.FileID(100)),
 				},
 			},
 			files: []model.File{{


### PR DESCRIPTION
This PR creates type aliases for IDs of all database models so that it will be easier for future refactor (i.e. switch from uint32 to uint64)

resolves #226 