### PR TITLE
Correct space utilization for large folder dag

### DIFF
--- a/cmd/api_test.go
+++ b/cmd/api_test.go
@@ -286,6 +286,6 @@ func TestBasicDataPrep(t *testing.T) {
 		require.Len(t, listPiecesResp.Payload, 1)
 		require.Len(t, listPiecesResp.Payload[0].Pieces, 2)
 		require.Equal(t, "baga6ea4seaqoahdvfwkrp64ecsxbjvyuqcwpz3o7ctxrjanlv2x4u2cq2qjf2ji", listPiecesResp.Payload[0].Pieces[0].PieceCid)
-		require.Equal(t, "baga6ea4seaqikgg6djdjtgro2pwsipxkjo754gwykmyglrv5yhjkgqi23dtqubq", listPiecesResp.Payload[0].Pieces[1].PieceCid)
+		require.Equal(t, "baga6ea4seaqbkouoyih2elxfrztq3gr23rpvgpx5e3fnud2rhvvzf4b7tneeyki", listPiecesResp.Payload[0].Pieces[1].PieceCid)
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/ipfs/go-ipfs-routing v0.3.0
 	github.com/ipfs/go-ipld-cbor v0.0.6
 	github.com/ipfs/go-ipld-format v0.5.0
+	github.com/ipfs/go-ipld-legacy v0.2.1
 	github.com/ipfs/go-libipfs v0.7.0
 	github.com/ipfs/go-log v1.0.5
 	github.com/ipfs/go-log/v2 v2.5.1
@@ -43,6 +44,8 @@ require (
 	github.com/ipfs/go-unixfs v0.4.5
 	github.com/ipld/go-car v0.6.1
 	github.com/ipld/go-car/v2 v2.10.2-0.20230622090957-499d0c909d33
+	github.com/ipld/go-codec-dagpb v1.6.0
+	github.com/ipld/go-ipld-prime v0.20.0
 	github.com/jellydator/ttlcache/v3 v3.0.1
 	github.com/joho/godotenv v1.5.1
 	github.com/jsign/go-filsigner v0.4.1
@@ -170,12 +173,9 @@ require (
 	github.com/ipfs/go-ipfs-exchange-interface v0.2.0 // indirect
 	github.com/ipfs/go-ipfs-pq v0.0.3 // indirect
 	github.com/ipfs/go-ipfs-util v0.0.3 // indirect
-	github.com/ipfs/go-ipld-legacy v0.2.1 // indirect
 	github.com/ipfs/go-metrics-interface v0.0.1 // indirect
 	github.com/ipfs/go-peertaskqueue v0.8.1 // indirect
 	github.com/ipfs/go-verifcid v0.0.2 // indirect
-	github.com/ipld/go-codec-dagpb v1.6.0 // indirect
-	github.com/ipld/go-ipld-prime v0.20.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/pgx/v5 v5.3.0 // indirect

--- a/handler/tool/extractcar.go
+++ b/handler/tool/extractcar.go
@@ -108,7 +108,7 @@ func (m multiBlockstore) HashOnRead(enabled bool) {
 //
 // Note:
 //
-//	The function only supports CAR files with CIDs of type Raw or DagProtobuf.
+//	The function only supports CAR files with CIDs of type raw or DagProtobuf.
 //	It recursively walks the input directory and gathers all .car files.
 //	For each CAR file, it reads the content and extracts the data for the given CID, then writes the extracted
 //	content to the specified output directory or file. If no CAR files are found in the input directory,

--- a/model/basetypes.go
+++ b/model/basetypes.go
@@ -37,8 +37,8 @@ type ClientConfig struct {
 	DisableHTTP2            *bool             `cbor:"11,keyasint,omitempty" json:"disableHttp2,omitempty"`                                            // Disable HTTP/2 in the transport
 	DisableHTTPKeepAlives   *bool             `cbor:"12,keyasint,omitempty" json:"disableHttpKeepAlives,omitempty"`                                   // Disable HTTP keep-alives and use each connection once.
 	RetryMaxCount           *int              `cbor:"13,keyasint,omitempty" json:"retryMaxCount,omitempty"`                                           // Maximum number of retries. Default is 10 retries.
-	RetryDelay              *time.Duration    `cbor:"14,keyasint,omitempty" json:"retryDelay,omitempty" swaggertype:"primitive,integer"`              // Delay between retries. Default is 1s.
-	RetryBackoff            *time.Duration    `cbor:"15,keyasint,omitempty" json:"retryBackoff,omitempty" swaggertype:"primitive,integer"`            // Constant backoff between retries. Default is 1s.
+	RetryDelay              *time.Duration    `cbor:"14,keyasint,omitempty" json:"retryDelay,omitempty"              swaggertype:"primitive,integer"` // Delay between retries. Default is 1s.
+	RetryBackoff            *time.Duration    `cbor:"15,keyasint,omitempty" json:"retryBackoff,omitempty"            swaggertype:"primitive,integer"` // Constant backoff between retries. Default is 1s.
 	RetryBackoffExponential *float64          `cbor:"16,keyasint,omitempty" json:"retryBackoffExponential,omitempty"`                                 // Exponential backoff between retries. Default is 1.0.
 }
 

--- a/pack/daggen/dagserv.go
+++ b/pack/daggen/dagserv.go
@@ -1,0 +1,127 @@
+package daggen
+
+import (
+	"context"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	format "github.com/ipfs/go-ipld-format"
+	legacy "github.com/ipfs/go-ipld-legacy"
+	"github.com/ipfs/go-merkledag"
+	dagpb "github.com/ipld/go-codec-dagpb"
+	_ "github.com/ipld/go-ipld-prime/codec/raw"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+)
+
+var ipldLegacyDecoder *legacy.Decoder
+
+// TODO: Don't require global registries
+func init() {
+	d := legacy.NewDecoder()
+	d.RegisterCodec(cid.DagProtobuf, dagpb.Type.PBNode, merkledag.ProtoNodeConverter)
+	d.RegisterCodec(cid.Raw, basicnode.Prototype.Bytes, merkledag.RawNodeConverter)
+	ipldLegacyDecoder = d
+}
+
+type blockData struct {
+	raw     []byte
+	dummy   bool
+	size    uint32
+	visited bool
+}
+
+// RecordedDagService is a DAGService that records all blocks that are used.
+// This struct is only meant to be used internally which achieves
+// * Tracks the blocks that are used
+// * Directly supports DummyNode
+type RecordedDagService struct {
+	blockstore map[cid.Cid]blockData
+}
+
+type DagServEntry struct {
+	_         struct{} `cbor:",toarray"`
+	Cid       cid.Cid
+	Data      []byte
+	DummySize int32
+}
+
+var _ format.DAGService = &RecordedDagService{}
+
+func NewRecordedDagService() *RecordedDagService {
+	return &RecordedDagService{
+		blockstore: make(map[cid.Cid]blockData),
+	}
+}
+
+func (r *RecordedDagService) ResetVisited() {
+	for c, data := range r.blockstore {
+		data.visited = false
+		r.blockstore[c] = data
+	}
+}
+
+func (r *RecordedDagService) Get(ctx context.Context, c cid.Cid) (format.Node, error) {
+	if data, ok := r.blockstore[c]; ok {
+		if !data.visited {
+			data.visited = true
+			r.blockstore[c] = data
+		}
+		if data.dummy {
+			return NewDummyNode(uint64(data.size), c), nil
+		}
+		blk, _ := blocks.NewBlockWithCid(data.raw, c)
+		return ipldLegacyDecoder.DecodeNode(ctx, blk)
+	}
+	return nil, format.ErrNotFound{Cid: c}
+}
+
+func (r *RecordedDagService) Visit(ctx context.Context, c cid.Cid) {
+	if data, ok := r.blockstore[c]; ok {
+		if !data.visited {
+			data.visited = true
+			r.blockstore[c] = data
+		}
+	}
+}
+
+func (r *RecordedDagService) Add(ctx context.Context, node format.Node) error {
+	dummy, ok := node.(*DummyNode)
+	if ok {
+		r.blockstore[dummy.cid] = blockData{
+			size:  uint32(dummy.size),
+			dummy: true,
+		}
+		return nil
+	}
+	r.blockstore[node.Cid()] = blockData{
+		raw: node.RawData(),
+	}
+	return nil
+}
+
+func (r *RecordedDagService) GetMany(ctx context.Context, cids []cid.Cid) <-chan *format.NodeOption {
+	resultChan := make(chan *format.NodeOption, len(cids))
+	go func() {
+		defer close(resultChan)
+		for _, c := range cids {
+			node, err := r.Get(ctx, c)
+			resultChan <- &format.NodeOption{
+				Node: node,
+				Err:  err,
+			}
+		}
+	}()
+	return resultChan
+}
+
+func (r *RecordedDagService) AddMany(ctx context.Context, nodes []format.Node) error {
+	panic("implement me")
+}
+
+func (r *RecordedDagService) Remove(ctx context.Context, c cid.Cid) error {
+	panic("implement me")
+}
+
+func (r *RecordedDagService) RemoveMany(ctx context.Context, cids []cid.Cid) error {
+	panic("implement me")
+}

--- a/pack/daggen/dagserv_test.go
+++ b/pack/daggen/dagserv_test.go
@@ -1,0 +1,62 @@
+package daggen
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ipfs/boxo/util"
+	"github.com/ipfs/go-cid"
+	format "github.com/ipfs/go-ipld-format"
+	"github.com/ipfs/go-merkledag"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordedDagService(t *testing.T) {
+	s := NewRecordedDagService()
+	c1 := cid.NewCidV1(cid.Raw, util.Hash([]byte("")))
+	c2 := cid.NewCidV1(cid.Raw, util.Hash([]byte("123")))
+	c3 := cid.NewCidV1(cid.Raw, util.Hash([]byte("hello")))
+	c4 := cid.NewCidV1(cid.Raw, util.Hash([]byte("not exist")))
+	dummy1 := NewDummyNode(0, c1)
+	dummy2 := NewDummyNode(3, c2)
+	node3 := merkledag.NewRawNode([]byte("hello"))
+	err := s.Add(context.TODO(), dummy1)
+	require.NoError(t, err)
+	err = s.Add(context.TODO(), dummy2)
+	require.NoError(t, err)
+	err = s.Add(context.TODO(), node3)
+	require.NoError(t, err)
+
+	node1, err := s.Get(context.TODO(), c1)
+	require.NoError(t, err)
+	require.Equal(t, dummy1, node1)
+
+	node2, err := s.Get(context.TODO(), c2)
+	require.NoError(t, err)
+	require.Equal(t, dummy2, node2)
+
+	node4, err := s.Get(context.TODO(), c3)
+	require.NoError(t, err)
+	require.Equal(t, node3.RawData(), node4.RawData())
+
+	_, err = s.Get(context.TODO(), c4)
+	require.ErrorIs(t, err, format.ErrNotFound{})
+
+	for _, v := range s.blockstore {
+		require.True(t, v.visited)
+	}
+
+	s.ResetVisited()
+
+	for _, v := range s.blockstore {
+		require.False(t, v.visited)
+	}
+
+	for c := range s.blockstore {
+		s.Visit(context.TODO(), c)
+	}
+
+	for _, v := range s.blockstore {
+		require.True(t, v.visited)
+	}
+}

--- a/pack/daggen/directory.go
+++ b/pack/daggen/directory.go
@@ -1,29 +1,23 @@
 package daggen
 
 import (
-	"bufio"
 	"bytes"
 	"context"
-	"io"
 
 	"github.com/cockroachdb/errors"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/pack/packutil"
+	"github.com/fxamacker/cbor/v2"
 	blocks "github.com/ipfs/go-block-format"
-	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-ipfs-blockstore"
 	format "github.com/ipfs/go-ipld-format"
 	"github.com/ipfs/go-merkledag"
 	uio "github.com/ipfs/go-unixfs/io"
-	"github.com/ipld/go-car"
-	"github.com/ipld/go-car/util"
 	"github.com/klauspost/compress/zstd"
 )
 
-var encoder, _ = zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
-var decoder, _ = zstd.NewReader(nil, zstd.WithDecoderConcurrency(0))
+var compressor, _ = zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
+var decompressor, _ = zstd.NewReader(nil, zstd.WithDecoderConcurrency(0))
 
 type DirectoryDetail struct {
 	Dir  *model.Directory
@@ -133,10 +127,11 @@ func (t DirectoryTree) Resolve(ctx context.Context, dirID model.DirectoryID) (*f
 //   - nodeDirty : A flag indicating whether the cached node representation is potentially outdated
 //     and needs to be refreshed from the internal directory representation.
 type DirectoryData struct {
-	dir       uio.Directory
-	bstore    blockstore.Blockstore
-	node      format.Node
-	nodeDirty bool
+	dir        uio.Directory
+	dagServ    *RecordedDagService
+	node       format.Node
+	nodeDirty  bool
+	additional map[cid.Cid][]byte
 }
 
 // Node retrieves the format.Node representation of the current DirectoryData.
@@ -174,15 +169,14 @@ func (d *DirectoryData) Node() (format.Node, error) {
 //
 //   - DirectoryData : A new DirectoryData instance with the initialized directory, blockstore, and a dirty node flag set to true.
 func NewDirectoryData() DirectoryData {
-	ds := datastore.NewMapDatastore()
-	bs := blockstore.NewBlockstore(ds, blockstore.WriteThrough())
-	dagServ := merkledag.NewDAGService(blockservice.New(bs, nil))
+	dagServ := NewRecordedDagService()
 	dir := uio.NewDirectory(dagServ)
 	dir.SetCidBuilder(merkledag.V1CidPrefix())
 	return DirectoryData{
-		dir:       dir,
-		bstore:    bs,
-		nodeDirty: true,
+		dir:        dir,
+		nodeDirty:  true,
+		dagServ:    dagServ,
+		additional: make(map[cid.Cid][]byte),
 	}
 }
 
@@ -201,7 +195,10 @@ func NewDirectoryData() DirectoryData {
 //
 //	error  : An error is returned if adding the child to the directory fails, otherwise it returns nil.
 func (d *DirectoryData) AddFile(ctx context.Context, name string, c cid.Cid, length uint64) error {
-	return d.dir.AddChild(ctx, name, NewDummyNode(length, c))
+	d.nodeDirty = true
+	node := NewDummyNode(length, c)
+	_ = d.dagServ.Add(ctx, node)
+	return d.dir.AddChild(ctx, name, node)
 }
 
 // AddFileFromLinks constructs a new file from a set of links and adds it to the directory.
@@ -230,10 +227,8 @@ func (d *DirectoryData) AddFileFromLinks(ctx context.Context, name string, links
 	if err != nil {
 		return cid.Undef, errors.WithStack(err)
 	}
-	err = d.bstore.PutMany(ctx, blks)
-	if err != nil {
-		return cid.Undef, errors.WithStack(err)
-	}
+	d.AddBlocks(ctx, blks)
+	d.nodeDirty = true
 	return node.Cid(), nil
 }
 
@@ -248,8 +243,18 @@ func (d *DirectoryData) AddFileFromLinks(ctx context.Context, name string, links
 //
 // This function is a wrapper that delegates the block adding task to the blockstore instance
 // associated with the DirectoryData instance.
-func (d *DirectoryData) AddBlocks(ctx context.Context, blks []blocks.Block) error {
-	return d.bstore.PutMany(ctx, blks)
+func (d *DirectoryData) AddBlocks(ctx context.Context, blks []blocks.Block) {
+	for _, blk := range blks {
+		d.additional[blk.Cid()] = blk.RawData()
+	}
+}
+
+type directoryData struct {
+	_          struct{} `cbor:",toarray"`
+	Root       cid.Cid
+	Dummies    map[cid.Cid]uint32
+	Reals      map[cid.Cid][]byte
+	Additional map[cid.Cid][]byte
 }
 
 // MarshalBinary serializes the current state of the DirectoryData object into a binary format.
@@ -277,75 +282,83 @@ func (d *DirectoryData) MarshalBinary(ctx context.Context) ([]byte, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	_, err = packutil.WriteCarHeader(buf, newNode.Cid())
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	err = d.bstore.Put(ctx, newNode)
+	_ = d.dagServ.Add(ctx, newNode)
+
+	// Reconstruct the directory from dagServ and figure out the visited blocks
+	d.dagServ.ResetVisited()
+	d.dagServ.Visit(ctx, newNode.Cid())
+	d.dir, err = uio.NewDirectoryFromNode(d.dagServ, newNode)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	ch, err := d.bstore.AllKeysChan(ctx)
+	err = d.dir.ForEachLink(ctx, func(link *format.Link) error {
+		if link.Cid.String() == "bafybeibgzuxcjfvdxbq2kl253cnijejdxiqvblfumr65mxa77oarctf6ri" {
+			panic("here")
+		}
+		d.dagServ.Visit(ctx, link.Cid)
+		return nil
+	})
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	for k := range ch {
-		data, err := d.bstore.Get(ctx, k)
-		if err != nil {
-			return nil, errors.WithStack(err)
+
+	data := directoryData{
+		Dummies:    make(map[cid.Cid]uint32),
+		Reals:      make(map[cid.Cid][]byte),
+		Additional: d.additional,
+		Root:       newNode.Cid(),
+	}
+
+	for c, d := range d.dagServ.blockstore {
+		if !d.visited {
+			continue
 		}
-		_, err = packutil.WriteCarBlock(buf, data)
-		if err != nil {
-			return nil, errors.WithStack(err)
+		if d.dummy {
+			data.Dummies[c] = d.size
+		} else {
+			data.Reals[c] = d.raw
 		}
 	}
-	return encoder.EncodeAll(buf.Bytes(), make([]byte, 0, len(buf.Bytes()))), nil
+	encoder := cbor.NewEncoder(buf)
+	err = encoder.Encode(data)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return compressor.EncodeAll(buf.Bytes(), make([]byte, 0, len(buf.Bytes()))), nil
 }
 
-// UnmarshalToBlocks deserializes binary data into a set of blocks and a root content identifier (CID).
-// This function:
-//  1. Decodes the input binary data.
-//  2. Reads the CAR (Content Addressable Archives) header from the decoded data to obtain the root CID.
-//  3. Iteratively reads CAR blocks from the data and constructs block objects from them.
-//
-// Parameters:
-//
-//   - data : Binary data representing a serialized set of blocks and a root CID.
-//
-// Returns:
-//
-//   - cid.Cid     : The root CID extracted from the CAR header, or an undefined CID if an error occurs.
-//   - []blocks.Block : Slice of blocks.Block objects reconstructed from the input data, or nil if an error occurs.
-//   - error       : An error is returned if decoding the input data, reading the CAR header, or reading CAR blocks fails.
-//     Otherwise, it returns nil.
-func UnmarshalToBlocks(data []byte) (cid.Cid, []blocks.Block, error) {
-	if len(data) == 0 {
-		return cid.Undef, nil, nil
+func UnmarshalToBlocks(in []byte) ([]blocks.Block, error) {
+	if len(in) == 0 {
+		return nil, nil
 	}
-	decoded, err := decoder.DecodeAll(data, nil)
+
+	decompressed, err := decompressor.DecodeAll(in, nil)
 	if err != nil {
-		return cid.Undef, nil, errors.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
-	reader := bufio.NewReader(bytes.NewReader(decoded))
-	ch, err := car.ReadHeader(reader)
+	decoder, err := cbor.DecOptions{
+		MaxMapPairs: 2147483647,
+	}.DecMode()
 	if err != nil {
-		return cid.Undef, nil, errors.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
-	dirCID := ch.Roots[0]
-	var blks []blocks.Block
-	for {
-		c, data, err := util.ReadNode(reader)
-		if err != nil && !errors.Is(err, io.EOF) {
-			return cid.Undef, nil, errors.WithStack(err)
-		}
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		blk, _ := blocks.NewBlockWithCid(data, c)
+	var data directoryData
+	err = decoder.Unmarshal(decompressed, &data)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	blks := make([]blocks.Block, 0, len(data.Reals)+len(data.Additional))
+	for c, d := range data.Reals {
+		blk, _ := blocks.NewBlockWithCid(d, c)
 		blks = append(blks, blk)
 	}
-	return dirCID, blks, nil
+	for c, d := range data.Additional {
+		blk, _ := blocks.NewBlockWithCid(d, c)
+		blks = append(blks, blk)
+	}
+	return blks, nil
 }
 
 // UnmarshalBinary deserializes binary data into the current DirectoryData object.
@@ -367,44 +380,64 @@ func UnmarshalToBlocks(data []byte) (cid.Cid, []blocks.Block, error) {
 //   - error : An error is returned if unmarshalling the data, putting blocks into blockstore,
 //     retrieving the root directory node, or creating a new directory from the node fails.
 //     Otherwise, it returns nil.
-func (d *DirectoryData) UnmarshalBinary(ctx context.Context, data []byte) error {
-	ds := datastore.NewMapDatastore()
-	bs := blockstore.NewBlockstore(ds, blockstore.WriteThrough())
-	bs.HashOnRead(false)
-	dagServ := merkledag.NewDAGService(blockservice.New(bs, nil))
-	if len(data) == 0 {
+func (d *DirectoryData) UnmarshalBinary(ctx context.Context, in []byte) error {
+	dagServ := NewRecordedDagService()
+	if len(in) == 0 {
 		dir := uio.NewDirectory(dagServ)
 		dir.SetCidBuilder(merkledag.V1CidPrefix())
 		*d = DirectoryData{
-			dir:       dir,
-			bstore:    bs,
-			nodeDirty: true,
+			dir:        dir,
+			nodeDirty:  true,
+			dagServ:    dagServ,
+			additional: make(map[cid.Cid][]byte),
 		}
 		return nil
 	}
 
-	dirCID, blks, err := UnmarshalToBlocks(data)
+	var data directoryData
+
+	decompressed, err := decompressor.DecodeAll(in, nil)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	err = bs.PutMany(ctx, blks)
+	decoder, err := cbor.DecOptions{
+		MaxMapPairs: 2147483647,
+	}.DecMode()
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	dirNode, err := dagServ.Get(ctx, dirCID)
+	err = decoder.Unmarshal(decompressed, &data)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	dir, err := uio.NewDirectoryFromNode(dagServ, dirNode)
+
+	for c, d := range data.Dummies {
+		dagServ.blockstore[c] = blockData{
+			dummy: true,
+			size:  d,
+		}
+	}
+	for c, d := range data.Reals {
+		dagServ.blockstore[c] = blockData{
+			raw: d,
+		}
+	}
+
+	root, err := dagServ.Get(ctx, data.Root)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	dir, err := uio.NewDirectoryFromNode(dagServ, root)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 	dir.SetCidBuilder(merkledag.V1CidPrefix())
 	*d = DirectoryData{
-		dir:       dir,
-		bstore:    bs,
-		node:      nil,
-		nodeDirty: true,
+		dir:        dir,
+		node:       root,
+		nodeDirty:  false,
+		dagServ:    dagServ,
+		additional: data.Additional,
 	}
 	return nil
 }

--- a/pack/daggen/directory_test.go
+++ b/pack/daggen/directory_test.go
@@ -15,6 +15,110 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func benchmarkMarshal(i int, size int, b *testing.B) {
+	b.Helper()
+	dirData := NewDirectoryData()
+	for j := 0; j < i; j++ {
+		err := dirData.AddFile(context.Background(), strconv.Itoa(j), cid.NewCidV1(cid.Raw, util.Hash([]byte(strconv.Itoa(j)))), 4)
+		require.NoError(b, err)
+	}
+	for n := 0; n < b.N; n++ {
+		out, err := dirData.MarshalBinary(context.Background())
+		require.NoError(b, err)
+		require.LessOrEqual(b, len(out), size)
+		err = dirData.UnmarshalBinary(context.Background(), out)
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkMarshal_0(b *testing.B) {
+	benchmarkMarshal(0, 69, b)
+}
+
+func BenchmarkMarshal_1(b *testing.B) {
+	benchmarkMarshal(1, 120, b)
+}
+
+func BenchmarkMarshal_100(b *testing.B) {
+	benchmarkMarshal(100, 4200, b)
+}
+
+func BenchmarkMarshal_10000(b *testing.B) {
+	benchmarkMarshal(10000, 500000, b)
+}
+
+func BenchmarkMarshal_1000000(b *testing.B) {
+	benchmarkMarshal(1000000, 85000000, b)
+}
+
+func TestDataSize_HAMTDirectory(t *testing.T) {
+	ctx := context.Background()
+	oldShardingSize := io.HAMTShardingSize
+	defer func() {
+		io.HAMTShardingSize = oldShardingSize
+	}()
+	io.HAMTShardingSize = int(units.KiB)
+
+	initial := []byte{}
+	dirData := &DirectoryData{}
+	err := dirData.UnmarshalBinary(ctx, initial)
+	require.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		err = dirData.AddFile(ctx, strconv.Itoa(i), cid.NewCidV1(cid.Raw, util.Hash([]byte(strconv.Itoa(i)))), 4)
+		require.NoError(t, err)
+	}
+	initial, err = dirData.MarshalBinary(ctx)
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(initial), 5500)
+
+	for i := 0; i < 10; i++ {
+		dirData := &DirectoryData{}
+		err := dirData.UnmarshalBinary(ctx, initial)
+		require.NoError(t, err)
+		initial, err = dirData.MarshalBinary(ctx)
+		require.NoError(t, err)
+	}
+	require.LessOrEqual(t, len(initial), 5500)
+}
+
+func TestDataSize_BasicDirectory(t *testing.T) {
+	ctx := context.Background()
+
+	var initial []byte
+	for i := 0; i < 100; i++ {
+		dirData := &DirectoryData{}
+		err := dirData.UnmarshalBinary(ctx, initial)
+		require.NoError(t, err)
+		err = dirData.AddFile(ctx, strconv.Itoa(i), cid.NewCidV1(cid.Raw, util.Hash([]byte(strconv.Itoa(i)))), 4)
+		require.NoError(t, err)
+		initial, err = dirData.MarshalBinary(ctx)
+		require.NoError(t, err)
+	}
+
+	require.LessOrEqual(t, len(initial), 4200)
+
+	initial = []byte{}
+	dirData := &DirectoryData{}
+	err := dirData.UnmarshalBinary(ctx, initial)
+	require.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		err = dirData.AddFile(ctx, strconv.Itoa(i), cid.NewCidV1(cid.Raw, util.Hash([]byte(strconv.Itoa(i)))), 4)
+		require.NoError(t, err)
+	}
+	initial, err = dirData.MarshalBinary(ctx)
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(initial), 9000)
+
+	for i := 0; i < 100; i++ {
+		dirData := &DirectoryData{}
+		err := dirData.UnmarshalBinary(ctx, initial)
+		require.NoError(t, err)
+		initial, err = dirData.MarshalBinary(ctx)
+		require.NoError(t, err)
+	}
+	require.LessOrEqual(t, len(initial), 9000)
+}
+
 func TestMarshalling(t *testing.T) {
 	ctx := context.Background()
 	oldShardingSize := io.HAMTShardingSize

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -273,10 +273,7 @@ func Pack(
 								return errors.Wrap(err, "failed to add file to directory")
 							}
 							if blks, ok := splitFileBlks[file.ID]; ok {
-								err = dirDetail.Data.AddBlocks(ctx, blks)
-								if err != nil {
-									return errors.Wrap(err, "failed to add blocks to directory")
-								}
+								dirDetail.Data.AddBlocks(ctx, blks)
 							}
 						}
 

--- a/service/datasetworker/daggen.go
+++ b/service/datasetworker/daggen.go
@@ -99,7 +99,7 @@ func (d *DagGenerator) Read(p []byte) (int, error) {
 		return 0, errors.WithStack(err)
 	}
 	d.dirCIDs[dir.ID] = dir.CID
-	_, blks, err := daggen.UnmarshalToBlocks(dir.Data)
+	blks, err := daggen.UnmarshalToBlocks(dir.Data)
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to unmarshall directory %d to blocks", dir.ID)
 	}


### PR DESCRIPTION
Below correction is done when handling directory data marshal and unmarshalling
* Created a custom implementation of DagServ to track which blocks are used when iterating through all children of a directory. This is because when we keep adding new items to the directory, the HAMT directory may end up adding blocks to DagServ without deleting blocks that is no longer used.
* When marshalling to byte array, we will reset all blocks to be unvisited and iterate through all children of the directory so we know which blocks are needed to reconstruct the current directory
  * Since some blocks are cached internally in HAMTDirectory, we have to initialize the directory from DagServ first

resolves #249 
