### PR TITLE
Mark jobs as pack jobs

### DIFF
--- a/handler/file/prepare_test.go
+++ b/handler/file/prepare_test.go
@@ -69,6 +69,8 @@ func TestPrepareToPackFileHandler(t *testing.T) {
 		err = db.Find(&jobs).Error
 		require.NoError(t, err)
 		require.Len(t, jobs, 2)
+		require.Equal(t, model.Pack, jobs[0].Type)
+		require.Equal(t, model.Pack, jobs[1].Type)
 		require.Equal(t, model.Ready, jobs[0].State)
 		require.Equal(t, model.Created, jobs[1].State)
 	})

--- a/scan/prepare.go
+++ b/scan/prepare.go
@@ -19,7 +19,7 @@ func NextAvailablePackJob(
 ) (*model.Job, error) {
 	var packJob model.Job
 	err := database.DoRetry(ctx, func() error {
-		return db.Where(model.Job{AttachmentID: attachmentID, State: model.Created}).Preload("FileRanges").FirstOrCreate(&packJob).Error
+		return db.Where(model.Job{AttachmentID: attachmentID, State: model.Created, Type: model.Pack}).Preload("FileRanges").FirstOrCreate(&packJob).Error
 	})
 	return &packJob, errors.WithStack(err)
 }


### PR DESCRIPTION
pack jobs are not getting marked as pack jobs when using the prepare API, meaning they don't get picked up by the packing phase. Seems to have appeared during the refactor.