### PR TITLE
Allow configuration of scanning intervals

### DIFF
--- a/cmd/run/datasetworker.go
+++ b/cmd/run/datasetworker.go
@@ -1,6 +1,8 @@
 package run
 
 import (
+	"time"
+
 	"github.com/cockroachdb/errors"
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/service/datasetworker"
@@ -41,6 +43,16 @@ var DatasetWorkerCmd = &cli.Command{
 			Usage: "Exit the worker when there is any error",
 			Value: false,
 		},
+		&cli.DurationFlag{
+			Name:  "min-interval",
+			Usage: "How often to scan storages (minimum)",
+			Value: 5 * time.Second,
+		},
+		&cli.DurationFlag{
+			Name:  "max-interval",
+			Usage: "How often to scan storages (maximum)",
+			Value: 160 * time.Second,
+		},
 	},
 	Action: func(c *cli.Context) error {
 		db, closer, err := database.OpenFromCLI(c)
@@ -57,6 +69,8 @@ var DatasetWorkerCmd = &cli.Command{
 				EnableDag:      c.Bool("enable-dag"),
 				ExitOnComplete: c.Bool("exit-on-complete"),
 				ExitOnError:    c.Bool("exit-on-error"),
+				MinInterval:    c.Duration("min-interval"),
+				MaxInterval:    c.Duration("max-interval"),
 			})
 		err = worker.Run(c.Context)
 		if err != nil {

--- a/cmd/run/datasetworker.go
+++ b/cmd/run/datasetworker.go
@@ -45,7 +45,7 @@ var DatasetWorkerCmd = &cli.Command{
 		},
 		&cli.DurationFlag{
 			Name:  "min-interval",
-			Usage: "How often to scan storages (minimum)",
+			Usage: "How often to check for new jobs (minimum)",
 			Value: 5 * time.Second,
 		},
 		&cli.DurationFlag{

--- a/cmd/run/datasetworker.go
+++ b/cmd/run/datasetworker.go
@@ -50,7 +50,7 @@ var DatasetWorkerCmd = &cli.Command{
 		},
 		&cli.DurationFlag{
 			Name:  "max-interval",
-			Usage: "How often to scan storages (maximum)",
+			Usage: "How often to check for new jobs (maximum)",
 			Value: 160 * time.Second,
 		},
 	},

--- a/docs/en/cli-reference/run/dataset-worker.md
+++ b/docs/en/cli-reference/run/dataset-worker.md
@@ -15,7 +15,7 @@ OPTIONS:
    --enable-dag          Enable dag generation of datasets that maintains the directory structure of datasets (default: true)
    --exit-on-complete    Exit the worker when there is no more work to do (default: false)
    --exit-on-error       Exit the worker when there is any error (default: false)
-   --min-interval value  How often to scan storages (minimum) (default: 5s)
+   --min-interval value  How often to check for new jobs (minimum) (default: 5s)
    --max-interval value  How often to scan storages (maximum) (default: 2m40s)
    --help, -h            show help
 ```

--- a/docs/en/cli-reference/run/dataset-worker.md
+++ b/docs/en/cli-reference/run/dataset-worker.md
@@ -16,7 +16,7 @@ OPTIONS:
    --exit-on-complete    Exit the worker when there is no more work to do (default: false)
    --exit-on-error       Exit the worker when there is any error (default: false)
    --min-interval value  How often to check for new jobs (minimum) (default: 5s)
-   --max-interval value  How often to scan storages (maximum) (default: 2m40s)
+   --max-interval value  How often to check for new jobs (maximum) (default: 2m40s)
    --help, -h            show help
 ```
 {% endcode %}

--- a/docs/en/cli-reference/run/dataset-worker.md
+++ b/docs/en/cli-reference/run/dataset-worker.md
@@ -9,12 +9,14 @@ USAGE:
    singularity run dataset-worker [command options] [arguments...]
 
 OPTIONS:
-   --concurrency value  Number of concurrent workers to run (default: 1)
-   --enable-scan        Enable scanning of datasets (default: true)
-   --enable-pack        Enable packing of datasets that calculates CIDs and packs them into CAR files (default: true)
-   --enable-dag         Enable dag generation of datasets that maintains the directory structure of datasets (default: true)
-   --exit-on-complete   Exit the worker when there is no more work to do (default: false)
-   --exit-on-error      Exit the worker when there is any error (default: false)
-   --help, -h           show help
+   --concurrency value   Number of concurrent workers to run (default: 1)
+   --enable-scan         Enable scanning of datasets (default: true)
+   --enable-pack         Enable packing of datasets that calculates CIDs and packs them into CAR files (default: true)
+   --enable-dag          Enable dag generation of datasets that maintains the directory structure of datasets (default: true)
+   --exit-on-complete    Exit the worker when there is no more work to do (default: false)
+   --exit-on-error       Exit the worker when there is any error (default: false)
+   --min-interval value  How often to scan storages (minimum) (default: 5s)
+   --max-interval value  How often to scan storages (maximum) (default: 2m40s)
+   --help, -h            show help
 ```
 {% endcode %}


### PR DESCRIPTION
# Goals

Users may want to configure scanning time bounds on the dataset worker. In particular, this is useful in test to speed up the worker.