### PR TITLE
Remove temporary CAR file if packing failed

### DIFF
--- a/pack/pack.go
+++ b/pack/pack.go
@@ -3,6 +3,7 @@ package pack
 import (
 	"context"
 	"io"
+	"time"
 
 	"github.com/data-preservation-programs/singularity/analytics"
 	"github.com/data-preservation-programs/singularity/database"
@@ -112,9 +113,20 @@ func Pack(
 	var finalPieceSize uint64
 	var fileSize int64
 	if storageWriter != nil {
+		var renamed bool
 		reader := io.TeeReader(assembler, calc)
 		filename = uuid.NewString() + ".car"
 		obj, err := storageWriter.Write(ctx, filename, reader)
+		defer func() {
+			if !renamed && obj != nil {
+				removeCtx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+				err := storageWriter.Remove(removeCtx, obj)
+				if err != nil {
+					logger.Errorf("failed to remove temporary CAR file %s: %v", filename, err)
+				}
+				cancel()
+			}
+		}()
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
@@ -134,6 +146,7 @@ func Pack(
 		if err == nil {
 			filename = pieceCid.String() + ".car"
 		}
+		renamed = true
 	} else {
 		fileSize, err = io.Copy(calc, assembler)
 		if err != nil {

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -113,12 +113,12 @@ func Pack(
 	var finalPieceSize uint64
 	var fileSize int64
 	if storageWriter != nil {
-		var renamed bool
+		var carGenerated bool
 		reader := io.TeeReader(assembler, calc)
 		filename = uuid.NewString() + ".car"
 		obj, err := storageWriter.Write(ctx, filename, reader)
 		defer func() {
-			if !renamed && obj != nil {
+			if !carGenerated && obj != nil {
 				removeCtx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
 				err := storageWriter.Remove(removeCtx, obj)
 				if err != nil {
@@ -146,7 +146,7 @@ func Pack(
 		if err == nil {
 			filename = pieceCid.String() + ".car"
 		}
-		renamed = true
+		carGenerated = true
 	} else {
 		fileSize, err = io.Copy(calc, assembler)
 		if err != nil {

--- a/retriever/endpointfinder/endpointfinder_test.go
+++ b/retriever/endpointfinder/endpointfinder_test.go
@@ -77,8 +77,8 @@ func TestEndpointFetcher(t *testing.T) {
 			if !testCase.noHTTP {
 
 				response.Protocols = append(response.Protocols, struct {
-					Name      string                "json:\"name,omitempty\""
-					Addresses []multiaddr.Multiaddr "json:\"addresses,omitempty\""
+					Name      string                `json:"name,omitempty"`
+					Addresses []multiaddr.Multiaddr `json:"addresses,omitempty"`
 				}{
 					Name:      "http",
 					Addresses: []multiaddr.Multiaddr{m},


### PR DESCRIPTION
Remove the temporary CAR file if packing failed for any reason.
resolves #349 

This isn't easy for unit test because for local storage type, Rclone will delete the entry automatically if the writting fails