### PR TITLE
Use lotus head latency in deal tracker

### DIFF
--- a/service/dealtracker/dealtracker_test.go
+++ b/service/dealtracker/dealtracker_test.go
@@ -342,7 +342,7 @@ func TestRunOnce(t *testing.T) {
 		url, server := setupTestServerWithBody(t, string(body))
 		defer server.Close()
 		require.NoError(t, err)
-		tracker := NewDealTracker(db, time.Minute, url, "", "", true)
+		tracker := NewDealTracker(db, time.Minute, url, "https://api.node.glif.io/", "", true)
 		err = tracker.runOnce(context.Background())
 		require.NoError(t, err)
 		var allDeals []model.Deal

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -33,6 +33,12 @@ func TestNewLotusClient(t *testing.T) {
 	}
 }
 
+func TestGetLotusHeadTime(t *testing.T) {
+	headTime, err := GetLotusHeadTime(context.Background(), "https://api.node.glif.io/", "")
+	require.NoError(t, err)
+	require.NotZero(t, headTime)
+}
+
 func TestPackJobSlice(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
resovles #336 

Previously, we are making a 24 hour buffer time to account for potential latency of StateMarketDeals call. However, that leads to some deal state to change between expired and published during 24 hour window as the buffer time for marking a deal expired comes from the last updated time inside StateMarketDeal payload.

This change fixes most of the problem by first calling Lotus ChainHead to determine the current lotus latency first. Edges cases are handled below
* If the StateMarketDeals response is based on an earlier epoch than ChainHead response, then it's likely some deals are in expired state based on ChainHead latency but is not expired in StateMarketDeals response, the state of the deal will be updated in the next run when StateMarketDeals response is based on a later epoch
* If the StateMarketDeals response is based on a latter epoch than ChainHead response, then those deals that are in non_expired state based on ChainHead latency will be marked as expired
