### PR TITLE
Add curl to container image for health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . ./
 RUN go build -o singularity .
 FROM debian:bookworm-slim
 RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    ca-certificates && \
+    ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/singularity /app/singularity


### PR DESCRIPTION
This is the first step to resolve
- https://github.com/filecoin-project/motion/issues/155

This allows docker compose to define a health check based on curl