### PR TITLE
Fix duplicate scan and pack with concurrency greater than 1

### DIFF
--- a/database/util.go
+++ b/database/util.go
@@ -15,7 +15,7 @@ import (
 )
 
 func retryOn(err error) bool {
-	return strings.Contains(err.Error(), "database is locked") || strings.Contains(err.Error(), "database table is locked")
+	return strings.Contains(err.Error(), "could not serialize access ") || strings.Contains(err.Error(), "database is locked") || strings.Contains(err.Error(), "database table is locked")
 }
 
 func DoRetry(ctx context.Context, f func() error) error {

--- a/database/util.go
+++ b/database/util.go
@@ -15,7 +15,8 @@ import (
 )
 
 func retryOn(err error) bool {
-	return strings.Contains(err.Error(), "could not serialize access") || strings.Contains(err.Error(), "database is locked") || strings.Contains(err.Error(), "database table is locked")
+	emsg := err.Error()
+	return strings.Contains(emsg, "could not serialize access") || strings.Contains(emsg, "Deadlock found when trying to get lock") || strings.Contains(emsg, "database is locked") || strings.Contains(emsg, "database table is locked")
 }
 
 func DoRetry(ctx context.Context, f func() error) error {

--- a/database/util.go
+++ b/database/util.go
@@ -14,9 +14,19 @@ import (
 	logger2 "gorm.io/gorm/logger"
 )
 
+// SQL state value that appears in serialization errors from all DBs.
+const sqlSerializationFailure = "40001"
+
+var logger = logging.Logger("database")
+
+var (
+	ErrInmemoryWithHighConcurrency = errors.New("cannot use in-memory database with concurrency > 1")
+	ErrDatabaseNotSupported        = errors.New("database not supported")
+)
+
 func retryOn(err error) bool {
 	emsg := err.Error()
-	return strings.Contains(emsg, "could not serialize access") || strings.Contains(emsg, "Deadlock found when trying to get lock") || strings.Contains(emsg, "database is locked") || strings.Contains(emsg, "database table is locked")
+	return strings.Contains(emsg, sqlSerializationFailure) || strings.Contains(emsg, "database is locked") || strings.Contains(emsg, "database table is locked")
 }
 
 func DoRetry(ctx context.Context, f func() error) error {
@@ -55,7 +65,7 @@ func (d *databaseLogger) Trace(ctx context.Context, begin time.Time, fc func() (
 		lvl = logging.LevelWarn
 		sql = "[SLOW!] " + sql
 	}
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) && !strings.Contains(err.Error(), "could not serialize access") {
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) && !strings.Contains(err.Error(), sqlSerializationFailure) {
 		lvl = logging.LevelError
 	}
 
@@ -85,9 +95,3 @@ func OpenFromCLI(c *cli.Context) (*gorm.DB, io.Closer, error) {
 	connString := c.String("database-connection-string")
 	return OpenWithLogger(connString)
 }
-
-var ErrInmemoryWithHighConcurrency = errors.New("cannot use in-memory database with concurrency > 1")
-
-var ErrDatabaseNotSupported = errors.New("database not supported")
-
-var logger = logging.Logger("database")

--- a/database/util.go
+++ b/database/util.go
@@ -15,7 +15,7 @@ import (
 )
 
 func retryOn(err error) bool {
-	return strings.Contains(err.Error(), "could not serialize access ") || strings.Contains(err.Error(), "database is locked") || strings.Contains(err.Error(), "database table is locked")
+	return strings.Contains(err.Error(), "could not serialize access") || strings.Contains(err.Error(), "database is locked") || strings.Contains(err.Error(), "database table is locked")
 }
 
 func DoRetry(ctx context.Context, f func() error) error {
@@ -54,7 +54,7 @@ func (d *databaseLogger) Trace(ctx context.Context, begin time.Time, fc func() (
 		lvl = logging.LevelWarn
 		sql = "[SLOW!] " + sql
 	}
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) && !strings.Contains(err.Error(), "could not serialize access") {
 		lvl = logging.LevelError
 	}
 

--- a/service/datasetworker/find.go
+++ b/service/datasetworker/find.go
@@ -26,7 +26,7 @@ func (w *Thread) findJob(ctx context.Context, typesOrdered []model.JobType) (*mo
 	db := w.dbNoContext.WithContext(ctx)
 
 	txOpts := &sql.TxOptions{
-		Isolation: sql.LevelRepeatableRead,
+		Isolation: sql.LevelSerializable,
 	}
 	var job model.Job
 	for _, jobType := range typesOrdered {


### PR DESCRIPTION
When concurrency is n, then n dataset workers are created. They each call scan. Is is necessary to ensure that each dataset worker's scan does not do the same scan as any other dataset worker. This is fixed by setting the transaction isolation level in the finding jobs and marking them as belonging to a worker.

Fixes #388
Might fix #375 and #358
