### PR TITLE
Allow setting identity during admin init

### DIFF
--- a/cmd/admin_test.go
+++ b/cmd/admin_test.go
@@ -27,7 +27,8 @@ func TestAdminInit(t *testing.T) {
 		mockHandler := new(admin.MockAdmin)
 		defer swapAdminHandler(mockHandler)()
 		mockHandler.On("InitHandler", mock.Anything, mock.Anything).Return(nil)
-		_, _, err := runner.Run(ctx, "singularity admin init")
+		mockHandler.On("SetIdentityHandler", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		_, _, err := runner.Run(ctx, "singularity admin init --identity test")
 		require.NoError(t, err)
 	})
 }

--- a/docs/en/cli-reference/admin/init.md
+++ b/docs/en/cli-reference/admin/init.md
@@ -12,6 +12,7 @@ DESCRIPTION:
    This commands need to be run before running any singularity daemon or after any version upgrade
 
 OPTIONS:
-   --help, -h  show help
+   --identity value  Name of the user or service that is running the Singularity for tracking and logging purpose
+   --help, -h        show help
 ```
 {% endcode %}


### PR DESCRIPTION
Due to how Motion docker compose is structured, the best way to set the identity to motion is through the admin init CLI command.

This is part of https://github.com/filecoin-project/motion/issues/174