### PR TITLE
Benchmark before optimization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/ipfs/go-merkledag v0.11.0
 	github.com/ipfs/go-unixfs v0.4.5
-	github.com/ipfs/go-unixfsnode v1.8.0
+	github.com/ipfs/go-unixfsnode v1.9.0
 	github.com/ipld/go-car v0.6.1
 	github.com/ipld/go-car/v2 v2.13.1
 	github.com/ipld/go-codec-dagpb v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -586,8 +586,8 @@ github.com/ipfs/go-peertaskqueue v0.8.1 h1:YhxAs1+wxb5jk7RvS0LHdyiILpNmRIRnZVzte
 github.com/ipfs/go-peertaskqueue v0.8.1/go.mod h1:Oxxd3eaK279FxeydSPPVGHzbwVeHjatZ2GA8XD+KbPU=
 github.com/ipfs/go-unixfs v0.4.5 h1:wj8JhxvV1G6CD7swACwSKYa+NgtdWC1RUit+gFnymDU=
 github.com/ipfs/go-unixfs v0.4.5/go.mod h1:BIznJNvt/gEx/ooRMI4Us9K8+qeGO7vx1ohnbk8gjFg=
-github.com/ipfs/go-unixfsnode v1.8.0 h1:yCkakzuE365glu+YkgzZt6p38CSVEBPgngL9ZkfnyQU=
-github.com/ipfs/go-unixfsnode v1.8.0/go.mod h1:HxRu9HYHOjK6HUqFBAi++7DVoWAHn0o4v/nZ/VA+0g8=
+github.com/ipfs/go-unixfsnode v1.9.0 h1:ubEhQhr22sPAKO2DNsyVBW7YB/zA8Zkif25aBvz8rc8=
+github.com/ipfs/go-unixfsnode v1.9.0/go.mod h1:HxRu9HYHOjK6HUqFBAi++7DVoWAHn0o4v/nZ/VA+0g8=
 github.com/ipfs/go-verifcid v0.0.2 h1:XPnUv0XmdH+ZIhLGKg6U2vaPaRDXb9urMyNVCE7uvTs=
 github.com/ipfs/go-verifcid v0.0.2/go.mod h1:40cD9x1y4OWnFXbLNJYRe7MpNvWlMn3LZAG5Wb4xnPU=
 github.com/ipld/go-car v0.6.1 h1:blWbEHf1j62JMWFIqWE//YR0m7k5ZMw0AuUOU5hjrH8=

--- a/handler/file/retrieve.go
+++ b/handler/file/retrieve.go
@@ -98,8 +98,6 @@ type filecoinReader struct {
 }
 
 func (r *filecoinReader) Read(p []byte) (int, error) {
-	logger.Infof("buffer size: %v", len(p))
-
 	buf := bytes.NewBuffer(p)
 	buf.Reset()
 

--- a/handler/file/retrieve_test.go
+++ b/handler/file/retrieve_test.go
@@ -344,7 +344,6 @@ func BenchmarkFilecoinRetrieve(b *testing.B) {
 		require.NoError(b, err)
 	}
 
-	deals := make([]model.Deal, 0, 4)
 	for i, testCid := range testCids {
 		deal := model.Deal{
 			State:    model.DealActive,
@@ -355,7 +354,6 @@ func BenchmarkFilecoinRetrieve(b *testing.B) {
 		err = db.Create(&deal).Error
 		require.NoError(b, err)
 
-		deals = append(deals, deal)
 		state := model.DealPublished
 		if i > 0 {
 			state = model.DealProposed
@@ -368,7 +366,6 @@ func BenchmarkFilecoinRetrieve(b *testing.B) {
 		}
 		err = db.Create(&deal).Error
 		require.NoError(b, err)
-		deals = append(deals, deal)
 	}
 	fr := &fakeRetriever{
 		lsys: &lsys,

--- a/handler/file/retrieve_test.go
+++ b/handler/file/retrieve_test.go
@@ -9,7 +9,9 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 
+	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/util/testutil"
 	"github.com/gotidy/ptr"
@@ -241,4 +243,162 @@ func (fr *fakeRetriever) Retrieve(ctx context.Context, c cid.Cid, rangeStart int
 	rangeLeftReader := io.LimitReader(nlr, rangeEnd-rangeStart)
 	_, err = io.Copy(out, rangeLeftReader)
 	return err
+}
+
+type tinyWriter struct {
+	dst    []byte
+	offset int
+}
+
+func (w *tinyWriter) Write(p []byte) (int, error) {
+	n := copy(w.dst[w.offset:], p)
+	w.offset += n
+	return n, nil
+}
+
+func (w *tinyWriter) reset() {
+	w.offset = 0
+}
+
+func BenchmarkFilecoinRetrieve(b *testing.B) {
+	connStr := "sqlite:" + b.TempDir() + "/singularity.db"
+	db, closer, err := database.OpenWithLogger(connStr)
+	require.NoError(b, err)
+	defer closer.Close()
+	b.Setenv("DATABASE_CONNECTION_STRING", connStr)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	db = db.WithContext(ctx)
+	require.NoError(b, model.AutoMigrate(db))
+
+	path := b.TempDir()
+	lsys := cidlink.DefaultLinkSystem()
+	memSys := memstore.Store{
+		Bag: make(map[string][]byte),
+	}
+	lsys.SetReadStorage(&memSys)
+	lsys.SetWriteStorage(&memSys)
+	lsys.TrustedStorage = true
+	ranges := make([]testRange, 0, 4)
+	for i := 0; i < 4; i++ {
+		expectedByteRange := make([]byte, 1<<24)
+		expectedBytesWriter := bytes.NewBuffer(expectedByteRange)
+		expectedBytesWriter.Reset()
+		fileReader := io.TeeReader(rand.Reader, expectedBytesWriter)
+		file := ufstestutil.GenerateFile(b, &lsys, fileReader, 1<<24)
+		ranges = append(ranges, testRange{expectedByteRange, file})
+	}
+
+	name := "deletedFile.txt"
+	file := model.File{
+		Path: name,
+		Size: 4 << 24,
+		Attachment: &model.SourceAttachment{
+			Preparation: &model.Preparation{
+				Name: "prep",
+			},
+			Storage: &model.Storage{
+				Name: "source",
+				Type: "local",
+				Path: path,
+			},
+		},
+	}
+	err = db.Create(&file).Error
+	require.NoError(b, err)
+
+	jobs := make([]model.Job, 2)
+	for i := 0; i < 2; i++ {
+		job := model.Job{
+			AttachmentID: file.Attachment.ID,
+		}
+		err = db.Create(&job).Error
+		require.NoError(b, err)
+		jobs[i] = job
+	}
+
+	for i, testRange := range ranges {
+		fileRange := model.FileRange{
+			FileID: file.ID,
+			CID:    model.CID(testRange.file.Root),
+			Offset: int64(i) * (1 << 24),
+			Length: 1 << 24,
+			JobID:  ptr.Of(jobs[i/2].ID),
+		}
+		err = db.Create(&fileRange).Error
+		require.NoError(b, err)
+	}
+
+	testCids := make([]cid.Cid, 0, 2)
+	for i := 0; i < 2; i++ {
+		testCids = append(testCids, cid.NewCidV1(cid.Raw, util.Hash([]byte("test"+strconv.Itoa(i)))))
+	}
+
+	for i, job := range jobs {
+		car := model.Car{
+			JobID:         ptr.Of(job.ID),
+			PieceCID:      model.CID(testCids[i]),
+			PreparationID: file.Attachment.PreparationID,
+		}
+		err = db.Create(&car).Error
+		require.NoError(b, err)
+	}
+
+	deals := make([]model.Deal, 0, 4)
+	for i, testCid := range testCids {
+		deal := model.Deal{
+			State:    model.DealActive,
+			PieceCID: model.CID(testCid),
+			Provider: "apples" + strconv.Itoa(i),
+			Wallet:   &model.Wallet{},
+		}
+		err = db.Create(&deal).Error
+		require.NoError(b, err)
+
+		deals = append(deals, deal)
+		state := model.DealPublished
+		if i > 0 {
+			state = model.DealProposed
+		}
+		deal = model.Deal{
+			State:    state,
+			PieceCID: model.CID(testCid),
+			Provider: "oranges" + strconv.Itoa(i),
+			Wallet:   &model.Wallet{},
+		}
+		err = db.Create(&deal).Error
+		require.NoError(b, err)
+		deals = append(deals, deal)
+	}
+	fr := &fakeRetriever{
+		lsys: &lsys,
+	}
+	outBuf := make([]byte, 1<<20)
+
+	// tinyWriter forces copying through the small buffer created with io.CopyN.
+	tinyW := &tinyWriter{
+		dst: outBuf,
+	}
+	readLen := int64(len(outBuf))
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		seeker, _, _, _ := Default.RetrieveFileHandler(ctx, db, fr, uint64(file.ID))
+		fr.requests = nil
+
+		// Read the entire file in 1Mib chunks.
+		for {
+			n, _ := io.CopyN(tinyW, seeker, readLen)
+			tinyW.reset()
+			if n == 0 {
+				break
+			}
+		}
+
+		seeker.Close()
+	}
+
+	b.StopTimer()
+	b.Log("Number of retrieve requests:", len(fr.requests))
 }


### PR DESCRIPTION
Added a benchmark of filecoin retrievals to compare before and after optimization.

Benchmark uses a file composed of 4 sections, each 16Mib in size. The entire file is retrieved by requesting 1Mib chunks. The 1Mib reads are done through `io.CopyN`, which copies the data through a 32k buffer.

The non-optimized version does a retrieval for each buffer copy to copy the file data. The optimized version only does as many retrievals as there are independently retrievable sections of the file.

**Before optimization:**
```
goos: darwin
goarch: arm64
pkg: github.com/data-preservation-programs/singularity/handler/file
BenchmarkFilecoinRetrieve
    retrieve_test.go:403: Number of retrieve requests: 2048
    retrieve_test.go:403: Number of retrieve requests: 2048
    retrieve_test.go:403: Number of retrieve requests: 2048
BenchmarkFilecoinRetrieve-10                   4         328260781 ns/op
```

**After optimization:** (PR #404)
```
goos: darwin
goarch: arm64
pkg: github.com/data-preservation-programs/singularity/handler/file
BenchmarkFilecoinRetrieve
    retrieve_test.go:692: Number of retrieve requests: 4
    retrieve_test.go:692: Number of retrieve requests: 4
    retrieve_test.go:692: Number of retrieve requests: 4
BenchmarkFilecoinRetrieve-10                  27          37292077 ns/op
```
