### PR TITLE
Add max replica constraint

### DIFF
--- a/cmd/run/dealpusher.go
+++ b/cmd/run/dealpusher.go
@@ -19,6 +19,12 @@ var DealPusherCmd = &cli.Command{
 			Aliases: []string{"d"},
 			Value:   3,
 		},
+		&cli.UintFlag{
+			Name:        "max-replication-factor",
+			Usage:       "Max number of replicas for each individual PieceCID across all clients and providers",
+			Aliases:     []string{"M"},
+			DefaultText: "Unlimited",
+		},
 	},
 	Action: func(c *cli.Context) error {
 		db, closer, err := database.OpenFromCLI(c)
@@ -33,7 +39,7 @@ var DealPusherCmd = &cli.Command{
 			return errors.WithStack(err)
 		}
 
-		dm, err := dealpusher.NewDealPusher(db, c.String("lotus-api"), c.String("lotus-token"), c.Uint("deal-attempts"))
+		dm, err := dealpusher.NewDealPusher(db, c.String("lotus-api"), c.String("lotus-token"), c.Uint("deal-attempts"), c.Uint("max-replication-factor"))
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/docs/en/cli-reference/run/deal-pusher.md
+++ b/docs/en/cli-reference/run/deal-pusher.md
@@ -9,7 +9,8 @@ USAGE:
    singularity run deal-pusher [command options] [arguments...]
 
 OPTIONS:
-   --deal-attempts value, -d value  Number of times to attempt a deal before giving up (default: 3)
-   --help, -h                       show help
+   --deal-attempts value, -d value           Number of times to attempt a deal before giving up (default: 3)
+   --max-replication-factor value, -M value  Max number of replicas for each individual PieceCID across all clients and providers (default: Unlimited)
+   --help, -h                                show help
 ```
 {% endcode %}

--- a/util/testutil/testutils.go
+++ b/util/testutil/testutils.go
@@ -92,6 +92,7 @@ func getTestDB(t *testing.T, dialect string) (db *gorm.DB, closer io.Closer, con
 	if errors.As(err, &opError) {
 		return
 	}
+	require.NoError(t, err)
 	err = db1.Exec("CREATE DATABASE " + dbName + "").Error
 	require.NoError(t, err)
 	connStr = strings.ReplaceAll(connStr, "singularity?", dbName+"?")


### PR DESCRIPTION
fixes #315
fixes #209

Adds a flag to limit number of replicas per PieceCID.
Long term goal is to offer a more granular way to define number of replicas. For now, we'll use a global flag.