### PR TITLE
Ensure that the deal config template URL has a scheme

### DIFF
--- a/replication/makedeal.go
+++ b/replication/makedeal.go
@@ -284,6 +284,10 @@ func (d DealMakerImpl) MakeDeal120(
 		if fileSize == 0 {
 			return nil, ErrFileSizeNotSpecifiedForOnlineDeal
 		}
+		// Ensure URL includes scheme.
+		if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+			url = "http://" + url
+		}
 		transferParams := &boostly.HttpRequest{URL: url}
 		if len(dealConfig.HTTPHeaders) > 0 {
 			transferParams.Headers = dealConfig.HTTPHeaders


### PR DESCRIPTION
After replacing the values in replication.DealConfig.URLTemplate, the resulting URL is checked to see that it is prefixed with "http://" or "https://". If not, then "http://" is added.

Fixes #411

Fixes https://github.com/filecoin-project/motion/issues/207