### PR TITLE
fix: strictly order car blocks for contiguous layout

### DIFF
--- a/service/contentprovider/http.go
+++ b/service/contentprovider/http.go
@@ -131,7 +131,7 @@ func getPieceMetadata(ctx context.Context, db *gorm.DB, car model.Car) (*PieceMe
 	}
 
 	var carBlocks []model.CarBlock
-	err = db.Where("car_id = ?", car.ID).Find(&carBlocks).Error
+	err = db.Where("car_id = ?", car.ID).Order("id ASC").Find(&carBlocks).Error
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}


### PR DESCRIPTION
Fixes piece retrieval errors such as:

  failed to find piece: failed to create piece reader: previous offset 1058920619, next offset 1104493679: Blocks must be contiguous