### PR TITLE
Consolidate service worker channels and goroutines

### DIFF
--- a/.github/workflows/go-test-config.json
+++ b/.github/workflows/go-test-config.json
@@ -1,0 +1,3 @@
+{
+  "skip32bit": true
+}

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -19,6 +19,8 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+const flushInterval = time.Hour
+
 var Enabled = true
 
 var logger = log.Logger("analytics")
@@ -184,11 +186,14 @@ func (c *Collector) Flush() error {
 }
 
 func (c *Collector) Start(ctx context.Context) {
+	timer := time.NewTimer(flushInterval)
+	defer timer.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(time.Hour):
+		case <-timer.C:
+			timer.Reset(flushInterval)
 		}
 		//nolint:contextcheck
 		c.Flush()

--- a/api/api.go
+++ b/api/api.go
@@ -396,10 +396,10 @@ var logger = logging.Logger("api")
 //     3. Completion of analytics event flushing.
 //   - A channel (service.Fail) that reports errors that occur while the server is running.
 //   - An error if there is an issue during the initialization phase, otherwise nil.
-func (s Server) Start(ctx context.Context) ([]service.Done, service.Fail, error) {
+func (s Server) Start(ctx context.Context, exitErr chan<- error) error {
 	err := analytics.Init(ctx, s.db)
 	if err != nil {
-		return nil, nil, errors.WithStack(err)
+		return errors.WithStack(err)
 	}
 	e := echo.New()
 	e.Debug = true
@@ -447,16 +447,18 @@ func (s Server) Start(ctx context.Context) ([]service.Done, service.Fail, error)
 	e.Listener = s.listener
 
 	done := make(chan struct{})
-	fail := make(chan error)
+	eventsFlushed := make(chan struct{})
+
 	go func() {
 		err := e.Start("")
-		if err != nil {
-			select {
-			case <-ctx.Done():
-			case fail <- err:
-			}
+		<-eventsFlushed
+		<-done
+
+		if exitErr != nil {
+			exitErr <- err
 		}
 	}()
+
 	go func() {
 		defer close(done)
 		<-ctx.Done()
@@ -471,21 +473,18 @@ func (s Server) Start(ctx context.Context) ([]service.Done, service.Fail, error)
 		if err != nil {
 			logger.Errorw("failed to close database connection", "err", err)
 		}
-	}()
-	hostDone := make(chan struct{})
-	go func() {
-		defer close(hostDone)
-		<-ctx.Done()
+
 		s.host.Close()
 	}()
-	eventsFlushed := make(chan struct{})
+
 	go func() {
 		defer close(eventsFlushed)
 		analytics.Default.Start(ctx)
 		//nolint:contextcheck
 		analytics.Default.Flush()
 	}()
-	return []service.Done{done, hostDone, eventsFlushed}, fail, nil
+
+	return nil
 }
 
 func isIntKind(kind reflect.Kind) bool {

--- a/cmd/testutil.go
+++ b/cmd/testutil.go
@@ -182,7 +182,7 @@ func WaitForServerReady(ctx context.Context, url string) error {
 			return nil
 		}
 		if timer == nil {
-			timer := time.NewTimer(100 * time.Millisecond)
+			timer = time.NewTimer(100 * time.Millisecond)
 			defer timer.Stop()
 		} else {
 			timer.Reset(100 * time.Millisecond)

--- a/cmd/testutil.go
+++ b/cmd/testutil.go
@@ -171,6 +171,7 @@ func CalculateCommp(t *testing.T, content []byte, targetPieceSize uint64) string
 func WaitForServerReady(ctx context.Context, url string) error {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
+	var timer *time.Timer
 	for {
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -180,10 +181,16 @@ func WaitForServerReady(ctx context.Context, url string) error {
 		if err == nil && resp != nil && resp.StatusCode == http.StatusOK {
 			return nil
 		}
+		if timer == nil {
+			timer := time.NewTimer(100 * time.Millisecond)
+			defer timer.Stop()
+		} else {
+			timer.Reset(100 * time.Millisecond)
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(100 * time.Millisecond):
+		case <-timer.C:
 		}
 	}
 }

--- a/service/contentprovider/bitswap_test.go
+++ b/service/contentprovider/bitswap_test.go
@@ -21,15 +21,18 @@ func TestBitswapServer(t *testing.T) {
 			host:        h,
 		}
 		require.Equal(t, "Bitswap", s.Name())
+
+		exitErr := make(chan error, 1)
 		ctx, cancel := context.WithCancel(ctx)
-		done, _, err := s.Start(ctx)
+		err = s.Start(ctx, exitErr)
 		require.NoError(t, err)
 		time.Sleep(200 * time.Millisecond)
 		cancel()
 		select {
 		case <-time.After(1 * time.Second):
 			t.Fatal("bitswap server did not stop")
-		case <-done[0]:
+		case err = <-exitErr:
+			require.NoError(t, err)
 		}
 	})
 }

--- a/service/contentprovider/http_test.go
+++ b/service/contentprovider/http_test.go
@@ -27,8 +27,9 @@ func TestHTTPServerStart(t *testing.T) {
 			bind:        "127.0.0.1:65432",
 		}
 		require.Equal(t, "HTTPServer", s.Name())
+		exitErr := make(chan error, 1)
 		ctx, cancel := context.WithCancel(ctx)
-		done, _, err := s.Start(ctx)
+		err := s.Start(ctx, exitErr)
 		require.NoError(t, err)
 		time.Sleep(200 * time.Millisecond)
 		gorequest.New().Get("http://127.0.0.1:65432/health").End()
@@ -37,7 +38,8 @@ func TestHTTPServerStart(t *testing.T) {
 		select {
 		case <-time.After(1 * time.Second):
 			t.Fatal("http server did not stop")
-		case <-done[0]:
+		case err = <-exitErr:
+			require.NoError(t, err)
 		}
 	})
 }

--- a/service/datasetworker/datasetworker.go
+++ b/service/datasetworker/datasetworker.go
@@ -108,7 +108,7 @@ func (w *Thread) Start(ctx context.Context, exitErr chan<- error) error {
 	go func() {
 		err := w.run(ctx)
 		if exitErr != nil {
-			// exitErrs should be buffered so a write from each service always succeeds.
+			// exitErr should be buffered so a write from each service always succeeds.
 			defer func(err error) {
 				exitErr <- err
 			}(err)

--- a/service/datasetworker/datasetworker.go
+++ b/service/datasetworker/datasetworker.go
@@ -116,6 +116,7 @@ func (w *Thread) Start(ctx context.Context, exitErr chan<- error) error {
 		cancel() // Stop components.
 
 		ctxCleanup, cancelCleanup := context.WithTimeout(context.Background(), cleanupTimeout)
+		//nolint:contextcheck
 		err = w.cleanup(ctxCleanup)
 		if err != nil {
 			w.logger.Errorw("failed to cleanup", "error", err)

--- a/service/datasetworker/datasetworker.go
+++ b/service/datasetworker/datasetworker.go
@@ -27,6 +27,7 @@ type Worker struct {
 
 const defaultMinInterval = 5 * time.Second
 const defaultMaxInterval = 160 * time.Second
+const cleanupTimeout = 5 * time.Second
 
 type Config struct {
 	Concurrency    int
@@ -80,14 +81,14 @@ type Thread struct {
 //   - []service.Done : A slice of channels that are closed when respective components of the worker complete their execution.
 //   - service.Fail   : A channel that receives an error if the worker encounters a failure during its execution.
 //   - error          : An error is returned if the worker fails to register with the health check service. Otherwise, it returns nil.
-func (w *Thread) Start(ctx context.Context) ([]service.Done, service.Fail, error) {
+func (w *Thread) Start(ctx context.Context, exitErr chan<- error) error {
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithCancel(ctx)
 
 	_, err := healthcheck.Register(ctx, w.dbNoContext, w.id, model.DatasetWorker, true)
 	if err != nil {
 		cancel()
-		return nil, nil, errors.Wrap(err, "failed to register worker")
+		return errors.Wrap(err, "failed to register worker")
 	}
 
 	healthcheckDone := make(chan struct{})
@@ -104,26 +105,33 @@ func (w *Thread) Start(ctx context.Context) ([]service.Done, service.Fail, error
 		w.logger.Info("healthcheck cleanup stopped")
 	}()
 
-	done := make(chan struct{})
-	fail := make(chan error)
 	go func() {
-		defer close(done)
-		w.run(ctx, fail)
-		w.logger.Info("worker thread finished")
-		cancel()
+		err := w.run(ctx)
+		if exitErr != nil {
+			// exitErrs should be buffered so a write from each service always succeeds.
+			defer func(err error) {
+				exitErr <- err
+			}(err)
+		}
+		cancel() // Stop components.
 
-		ctxCleanup, cancelCleanup := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancelCleanup()
-		//nolint:contextcheck
-		err := w.cleanup(ctxCleanup)
+		ctxCleanup, cancelCleanup := context.WithTimeout(context.Background(), cleanupTimeout)
+		err = w.cleanup(ctxCleanup)
 		if err != nil {
 			w.logger.Errorw("failed to cleanup", "error", err)
 		} else {
 			w.logger.Info("cleanup complete")
 		}
+		cancelCleanup()
+
+		// Wait for components to end.
+		<-healthcheckDone
+		<-healthcheckCleanupDone
+
+		w.logger.Info("worker thread finished")
 	}()
 
-	return []service.Done{done, healthcheckDone, healthcheckCleanupDone}, fail, nil
+	return nil
 }
 
 func (w *Thread) Name() string {
@@ -177,10 +185,10 @@ func (w Worker) Run(ctx context.Context) error {
 		}
 		threads[i] = thread
 	}
-	monitorDone := w.stateMonitor.Start(ctx)
+	w.stateMonitor.Start(ctx)
 	err = service.StartServers(ctx, logger, threads...)
 	cancel()
-	<-monitorDone
+	<-w.stateMonitor.Done()
 	<-eventsFlushed
 	return errors.WithStack(err)
 }
@@ -233,15 +241,16 @@ func (w *Thread) handleWorkError(ctx context.Context, jobID model.JobID, err err
 // Parameters:
 //
 //   - ctx     : The context used for managing the lifecycle of the run loop. If Done, the loop exits cleanly.
-//   - errChan : A channel for reporting errors that cause the loop to exit when ExitOnError is true.
 //
-// This function is intended to run as a goroutine.
+// Returns:
+//
+//   - error : Error if failure to run or recovered panic.
 //
 // In case of a panic, the error is recovered and sent to the errChan.
-func (w *Thread) run(ctx context.Context, errChan chan error) {
+func (w *Thread) run(ctx context.Context) (retErr error) {
 	defer func() {
 		if err := recover(); err != nil {
-			errChan <- errors.Errorf("panic: %v", err)
+			retErr = errors.Errorf("panic: %v", err)
 		}
 	}()
 
@@ -270,7 +279,7 @@ func (w *Thread) run(ctx context.Context, errChan chan error) {
 			if w.config.ExitOnComplete {
 				w.logger.Info("no work found, exiting")
 				workCancel()
-				return
+				return nil
 			}
 			w.logger.Info("no work found")
 			workCancel()
@@ -313,15 +322,11 @@ func (w *Thread) run(ctx context.Context, errChan chan error) {
 	errorLoop:
 		if ctx.Err() != nil {
 			w.logger.Info("context cancelled, exiting")
-			return
+			return nil
 		}
 		w.logger.Errorw("error encountered", "error", err)
 		if w.config.ExitOnError {
-			select {
-			case errChan <- err:
-			case <-ctx.Done():
-			}
-			return
+			return err
 		}
 	loop:
 		w.logger.Infof("sleeping for %s", interval)
@@ -333,7 +338,7 @@ func (w *Thread) run(ctx context.Context, errChan chan error) {
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return
+			return nil
 		case <-timer.C:
 			interval *= 2
 			if interval > w.config.MaxInterval {

--- a/service/datasetworker/statemonitor.go
+++ b/service/datasetworker/statemonitor.go
@@ -22,7 +22,7 @@ func NewStateMonitor(db *gorm.DB) *StateMonitor {
 type StateMonitor struct {
 	db   *gorm.DB
 	jobs map[model.JobID]context.CancelFunc
-	mu   sync.RWMutex
+	mu   sync.Mutex
 	done chan struct{}
 }
 
@@ -45,13 +45,13 @@ func (s *StateMonitor) Start(ctx context.Context) {
 		var timer *time.Timer
 		for {
 			var i int
-			s.mu.RLock()
+			s.mu.Lock()
 			jobIDs := make([]model.JobID, len(s.jobs))
 			for jobID := range s.jobs {
 				jobIDs[i] = jobID
 				i++
 			}
-			s.mu.RUnlock()
+			s.mu.Unlock()
 
 			var jobs []model.Job
 			if len(jobIDs) > 0 {

--- a/service/datasetworker/statemonitor.go
+++ b/service/datasetworker/statemonitor.go
@@ -6,14 +6,16 @@ import (
 	"time"
 
 	"github.com/data-preservation-programs/singularity/model"
-	"github.com/data-preservation-programs/singularity/service"
 	"gorm.io/gorm"
 )
+
+const jobCheckInterval = 5 * time.Second
 
 func NewStateMonitor(db *gorm.DB) *StateMonitor {
 	return &StateMonitor{
 		db:   db,
 		jobs: make(map[model.JobID]context.CancelFunc),
+		done: make(chan struct{}),
 	}
 }
 
@@ -21,6 +23,7 @@ type StateMonitor struct {
 	db   *gorm.DB
 	jobs map[model.JobID]context.CancelFunc
 	mu   sync.RWMutex
+	done chan struct{}
 }
 
 func (s *StateMonitor) AddJob(jobID model.JobID, cancel context.CancelFunc) {
@@ -35,18 +38,21 @@ func (s *StateMonitor) RemoveJob(jobID model.JobID) {
 	delete(s.jobs, jobID)
 }
 
-func (s *StateMonitor) Start(ctx context.Context) service.Done {
+func (s *StateMonitor) Start(ctx context.Context) {
 	db := s.db.WithContext(ctx)
-	monitorDone := make(chan struct{})
 	go func() {
-		defer close(monitorDone)
+		defer close(s.done)
+		var timer *time.Timer
 		for {
-			var jobIDs []model.JobID
+			var i int
 			s.mu.RLock()
+			jobIDs := make([]model.JobID, len(s.jobs))
 			for jobID := range s.jobs {
-				jobIDs = append(jobIDs, jobID)
+				jobIDs[i] = jobID
+				i++
 			}
 			s.mu.RUnlock()
+
 			var jobs []model.Job
 			if len(jobIDs) > 0 {
 				err := db.Where("state = ?", model.Paused).Find(&jobs, jobIDs).Error
@@ -54,6 +60,7 @@ func (s *StateMonitor) Start(ctx context.Context) service.Done {
 					logger.Errorf("failed to fetch paused jobs: %v", err)
 				}
 			}
+
 			s.mu.Lock()
 			for _, job := range jobs {
 				jobID := job.ID
@@ -64,12 +71,22 @@ func (s *StateMonitor) Start(ctx context.Context) service.Done {
 				}
 			}
 			s.mu.Unlock()
+
+			if timer == nil {
+				timer = time.NewTimer(jobCheckInterval)
+				defer timer.Stop()
+			} else {
+				timer.Reset(jobCheckInterval)
+			}
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(5 * time.Second):
+			case <-timer.C:
 			}
 		}
 	}()
-	return monitorDone
+}
+
+func (s *StateMonitor) Done() <-chan struct{} {
+	return s.done
 }

--- a/service/dealpusher/dealpusher.go
+++ b/service/dealpusher/dealpusher.go
@@ -593,6 +593,7 @@ func (d *DealPusher) Start(ctx context.Context, exitErr chan<- error) error {
 		}
 
 		ctx2, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		//nolint:contextcheck
 		err := d.cleanup(ctx2)
 		if err != nil {
 			Logger.Errorw("failed to cleanup", "error", err)

--- a/service/dealtracker/dealtracker.go
+++ b/service/dealtracker/dealtracker.go
@@ -350,6 +350,7 @@ func (d *DealTracker) Start(ctx context.Context, exitErr chan<- error) error {
 
 		ctx2, cancel2 := context.WithTimeout(context.Background(), cleanupTimeout)
 		defer cancel2()
+		//nolint:contextcheck
 		err := d.cleanup(ctx2)
 		if err != nil {
 			Logger.Errorw("failed to cleanup", "error", err)

--- a/service/dealtracker/dealtracker.go
+++ b/service/dealtracker/dealtracker.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/model"
-	"github.com/data-preservation-programs/singularity/service"
 	"github.com/data-preservation-programs/singularity/service/epochutil"
 	"github.com/data-preservation-programs/singularity/service/healthcheck"
 	"github.com/data-preservation-programs/singularity/util"
@@ -29,6 +28,9 @@ import (
 )
 
 var ErrAlreadyRunning = errors.New("another worker already running")
+
+const healthRegisterRetryInterval = time.Minute
+const cleanupTimeout = 5 * time.Second
 
 type Deal struct {
 	Proposal DealProposal
@@ -266,34 +268,37 @@ func (*DealTracker) Name() string {
 //     - If an error occurs during cleanup, it logs an error message.
 //
 //  7. Returns a list of service.Done channels containing healthcheckDone, runDone, and cleanupDone, the service.Fail channel fail, and nil for the error.
-func (d *DealTracker) Start(ctx context.Context) ([]service.Done, service.Fail, error) {
-	var cancel context.CancelFunc
-	ctx, cancel = context.WithCancel(ctx)
-
+func (d *DealTracker) Start(ctx context.Context, exitErr chan<- error) error {
+	var regTimer *time.Timer
 	for {
 		alreadyRunning, err := healthcheck.Register(ctx, d.dbNoContext, d.workerID, model.DealTracker, false)
-		if err == nil && !alreadyRunning {
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if !alreadyRunning {
 			break
 		}
-		if err != nil {
-			cancel()
-			return nil, nil, errors.WithStack(err)
-		}
-		if alreadyRunning {
-			Logger.Warnw("another worker already running")
-			if d.once {
-				cancel()
-				return nil, nil, ErrAlreadyRunning
-			}
+
+		Logger.Warnw("another worker already running")
+		if d.once {
+			return ErrAlreadyRunning
 		}
 		Logger.Warn("retrying in 1 minute")
+		if regTimer == nil {
+			regTimer = time.NewTimer(healthRegisterRetryInterval)
+			defer regTimer.Stop()
+		} else {
+			regTimer.Reset(healthRegisterRetryInterval)
+		}
 		select {
 		case <-ctx.Done():
-			cancel()
-			return nil, nil, ctx.Err()
-		case <-time.After(time.Minute):
+			return ctx.Err()
+		case <-regTimer.C:
 		}
 	}
+
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
 
 	healthcheckDone := make(chan struct{})
 	go func() {
@@ -302,46 +307,63 @@ func (d *DealTracker) Start(ctx context.Context) ([]service.Done, service.Fail, 
 		Logger.Info("health report stopped")
 	}()
 
-	runDone := make(chan struct{})
-	fail := make(chan error)
 	go func() {
-		defer cancel()
-		defer close(runDone)
+		var timer *time.Timer
+		var runErr error
 		for {
-			err := d.runOnce(ctx)
-			if err != nil && ctx.Err() == nil {
-				Logger.Errorw("failed to run once", "error", err)
+			runErr = d.runOnce(ctx)
+			if runErr != nil {
+				if ctx.Err() != nil {
+					if errors.Is(runErr, context.Canceled) {
+						runErr = nil
+					}
+					Logger.Info("run stopped")
+					break
+				}
+				Logger.Errorw("failed to run once", "error", runErr)
 			}
 			if d.once {
-				cancel()
 				Logger.Info("run once done")
-				return
+				break
 			}
+			if timer == nil {
+				timer = time.NewTimer(d.interval)
+				defer timer.Stop()
+			} else {
+				timer.Reset(d.interval)
+			}
+
+			var stopped bool
 			select {
 			case <-ctx.Done():
+				stopped = true
+			case <-timer.C:
+			}
+			if stopped {
 				Logger.Info("run stopped")
-				return
-			case <-time.After(d.interval):
+				break
 			}
 		}
-	}()
 
-	cleanupDone := make(chan struct{})
-	go func() {
-		defer close(cleanupDone)
-		<-ctx.Done()
-		ctx2, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		//nolint:contextcheck
+		cancel()
+
+		ctx2, cancel2 := context.WithTimeout(context.Background(), cleanupTimeout)
+		defer cancel2()
 		err := d.cleanup(ctx2)
 		if err != nil {
 			Logger.Errorw("failed to cleanup", "error", err)
 		} else {
 			Logger.Info("cleanup done")
 		}
+
+		<-healthcheckDone
+
+		if exitErr != nil {
+			exitErr <- runErr
+		}
 	}()
 
-	return []service.Done{healthcheckDone, runDone, cleanupDone}, fail, nil
+	return nil
 }
 
 func (d *DealTracker) cleanup(ctx context.Context) error {

--- a/service/downloadserver/downloadserver.go
+++ b/service/downloadserver/downloadserver.go
@@ -253,6 +253,7 @@ func (d *DownloadServer) Start(ctx context.Context, exitErr chan<- error) error 
 
 	go func() {
 		<-ctx.Done()
+		//nolint:contextcheck
 		shutdownErr <- e.Shutdown(context.Background())
 	}()
 

--- a/service/downloadserver/downloadserver.go
+++ b/service/downloadserver/downloadserver.go
@@ -23,6 +23,8 @@ import (
 	"github.com/rjNemo/underscore"
 )
 
+const shutdownTimeout = 5 * time.Second
+
 type DownloadServer struct {
 	bind         string
 	api          string
@@ -240,7 +242,7 @@ func (d *DownloadServer) Start(ctx context.Context, exitErr chan<- error) error 
 		runErr := e.Start(d.bind)
 		close(forceShutdown)
 
-		err = <-shutdownErr
+		err := <-shutdownErr
 		d.usageCache.Close()
 
 		if exitErr != nil {
@@ -256,7 +258,7 @@ func (d *DownloadServer) Start(ctx context.Context, exitErr chan<- error) error 
 		case <-ctx.Done():
 		case <-forceShutdown:
 		}
-		ctx, cancel := context.WithTimeout(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
 		//nolint:contextcheck
 		shutdownErr <- e.Shutdown(ctx)

--- a/service/downloadserver/downloadserver.go
+++ b/service/downloadserver/downloadserver.go
@@ -41,7 +41,7 @@ type cacheItem[C any] struct {
 
 type UsageCache[C any] struct {
 	data   map[string]*cacheItem[C]
-	mu     sync.RWMutex
+	mu     sync.Mutex
 	ttl    time.Duration
 	cancel context.CancelFunc
 }

--- a/service/service.go
+++ b/service/service.go
@@ -2,9 +2,9 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
-	"sync"
 	"syscall"
 
 	"github.com/cockroachdb/errors"
@@ -13,16 +13,16 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-type Done = <-chan struct{}
-
-type Fail = <-chan error
-
 // Server is an interface that represents a server that can be started and has a name.
 type Server interface {
-	// Start Starts the server and returns two channels. The Done channels are closed when the server is done running,
-	//	and the Fail channel receives an error if the server fails. The method also returns an error immediately
-	//	if the server fails to start. The server runs until the provided context is cancelled.
-	Start(ctx context.Context) ([]Done, Fail, error)
+	// Start Starts the server. The method also returns an error immediately if
+	// the server fails to start. The server runs until the provided context is
+	// cancelled.
+	//
+	// If an exitErr channel is given, then the server writes an error or nil
+	// to the channel when it exits. This channel should be buffered so that
+	// every service writing to it perform one non-blocking write.
+	Start(ctx context.Context, exitErr chan<- error) error
 	// Name returns the name of the server.
 	Name() string
 }
@@ -51,74 +51,55 @@ func StartServers(ctx context.Context, logger *log.ZapEventLogger, servers ...Se
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
 
-	var dones []Done
-	var fails []Fail
-
+	serviceExitErrs := make(chan error, len(servers))
 	for _, server := range servers {
-		logger.Info("starting service: " + server.Name())
-		done, fail, err := server.Start(ctx)
+		logger.Infow("starting service", "name", server.Name())
+		err := server.Start(ctx, serviceExitErrs)
 		if err != nil {
 			cancel()
-			logger.Errorw("failed to start service "+server.Name(), "error", err)
+			logger.Errorw("failed to start service", "name", server.Name(), "error", err)
 			return errors.Wrapf(err, "failed to start service %s", server.Name())
 		}
-		dones = append(dones, done...)
-		fails = append(fails, fail)
 	}
-
-	anyFail := make(chan error)
-	for _, fail := range fails {
-		go func(fail Fail) {
-			select {
-			case v := <-fail:
-				select {
-				case <-ctx.Done():
-				case anyFail <- v:
-				}
-			case <-ctx.Done():
-			}
-		}(fail)
-	}
-
-	var wg sync.WaitGroup
-	var allDone = make(chan struct{})
-	for _, done := range dones {
-		wg.Add(1)
-		go func(done Done) {
-			<-done
-			wg.Done()
-		}(done)
-	}
-	go func() {
-		wg.Wait()
-		close(allDone)
-	}()
 
 	var err error
-	select {
-	case <-ctx.Done():
-		logger.Debug("context cancelled")
-		err = ctx.Err()
-		cancel()
-	case sig := <-signalChan:
-		logger.Warnf("received signal %s", sig.String())
-		signal.Stop(signalChan)
-		signal.Reset(os.Interrupt, syscall.SIGTERM)
-		err = cli.Exit(sig.String(), 130)
-		cancel()
-	case err = <-anyFail:
-		logger.Errorw("service failed", "error", err)
-		cancel()
-	case <-allDone:
-		logger.Info("all services stopped")
-		cancel()
-		return errors.WithStack(err)
+	var i int
+	running := len(servers)
+
+	for running != 0 {
+		select {
+		case err = <-serviceExitErrs:
+			running--
+			i++
+			if err != nil {
+				logger.Errorw("service failed", "error", err)
+			} else {
+				logger.Infow("service stopped", "stopped", fmt.Sprintf("%d out of %d", i, len(servers)))
+				continue
+			}
+		case <-ctx.Done():
+			logger.Debug("context cancelled")
+			err = ctx.Err()
+		case sig := <-signalChan:
+			logger.Warnf("received signal %s", sig.String())
+			signal.Stop(signalChan)
+			signal.Reset(os.Interrupt, syscall.SIGTERM)
+			err = cli.Exit(sig.String(), 130)
+		}
+		break
 	}
 
-	<-allDone
+	cancel()
+	for running != 0 {
+		<-serviceExitErrs
+		running--
+	}
+
 	logger.Info("all services stopped")
 	return errors.WithStack(err)
 }


### PR DESCRIPTION
Instead of having every service worker report a failure error and the done status of each goroutine within the service, use a single channel to have all service report on their status and completion.

Fixes #415