### PR TITLE
feat: find endpoints asynchronously, cache errors

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -128,16 +128,14 @@ func InitServer(ctx context.Context, params APIParams) (Server, error) {
 	infoFetcher := replication.MinerInfoFetcher{
 		Client: util.NewLotusClient(params.LotusAPI, params.LotusToken),
 	}
-	endpointFinder, err := endpointfinder.NewEndpointFinder(
+	endpointFinder := endpointfinder.NewEndpointFinder(
 		infoFetcher,
 		h,
 		endpointfinder.WithLruSize(128),
+		endpointfinder.WithLruTimeout(time.Hour*2),
 		endpointfinder.WithErrorLruSize(128),
 		endpointfinder.WithErrorLruTimeout(time.Minute*5),
 	)
-	if err != nil {
-		return Server{}, errors.Wrap(err, "failed to init endpoint finder")
-	}
 	return Server{
 		db:          db,
 		host:        h,

--- a/api/api.go
+++ b/api/api.go
@@ -125,9 +125,10 @@ func InitServer(ctx context.Context, params APIParams) (Server, error) {
 	if err != nil {
 		return Server{}, errors.Wrap(err, "failed to init lassie")
 	}
-	endpointFinder, err := endpointfinder.NewEndpointFinder(replication.MinerInfoFetcher{
+	finderCfg := endpointfinder.EndpointFinderConfig{LruSize: 128, ErrorLruSize: 128, ErrorLruTimeout: time.Minute * 5}
+	endpointFinder, err := endpointfinder.NewEndpointFinder(finderCfg, replication.MinerInfoFetcher{
 		Client: util.NewLotusClient(params.LotusAPI, params.LotusToken),
-	}, h, 128)
+	}, h)
 	if err != nil {
 		return Server{}, errors.Wrap(err, "failed to init endpoint finder")
 	}
@@ -300,7 +301,8 @@ func (s Server) setupRoutes(e *echo.Echo) {
 		db *gorm.DB,
 		storageType string,
 		provider string,
-		request storage.CreateRequest) (*model.Storage, error) {
+		request storage.CreateRequest,
+	) (*model.Storage, error) {
 		request.Provider = provider
 		return s.storageHandler.CreateStorageHandler(ctx, db, storageType, request)
 	}))

--- a/api/api.go
+++ b/api/api.go
@@ -125,10 +125,16 @@ func InitServer(ctx context.Context, params APIParams) (Server, error) {
 	if err != nil {
 		return Server{}, errors.Wrap(err, "failed to init lassie")
 	}
-	finderCfg := endpointfinder.EndpointFinderConfig{LruSize: 128, ErrorLruSize: 128, ErrorLruTimeout: time.Minute * 5}
-	endpointFinder, err := endpointfinder.NewEndpointFinder(finderCfg, replication.MinerInfoFetcher{
+	infoFetcher := replication.MinerInfoFetcher{
 		Client: util.NewLotusClient(params.LotusAPI, params.LotusToken),
-	}, h)
+	}
+	endpointFinder, err := endpointfinder.NewEndpointFinder(
+		infoFetcher,
+		h,
+		endpointfinder.WithLruSize(128),
+		endpointfinder.WithErrorLruSize(128),
+		endpointfinder.WithErrorLruTimeout(time.Minute*5),
+	)
 	if err != nil {
 		return Server{}, errors.Wrap(err, "failed to init endpoint finder")
 	}

--- a/retriever/endpointfinder/endpointfinder.go
+++ b/retriever/endpointfinder/endpointfinder.go
@@ -4,14 +4,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/data-preservation-programs/singularity/replication"
 	"github.com/filecoin-shipyard/boostly"
 	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
+	"go.uber.org/multierr"
 )
+
+var logger = log.Logger("singularity/retriever/endpointfinder")
 
 // ErrHTTPNotSupported indicates we were able to look up the provider and contact them,
 // but they reported that they do not serve HTTP retrievals
@@ -30,22 +36,58 @@ type EndpointFinder struct {
 	minerInfoFetcher MinerInfoFetcher
 	h                host.Host
 	httpEndpoints    *lru.Cache[string, []peer.AddrInfo]
+	endpointErrors   *expirable.LRU[string, error]
+}
+
+const (
+	defaultLruSize         = 128
+	defaultErrorLruSize    = 128
+	defaultErrorLruTimeout = 5 * time.Minute
+)
+
+type EndpointFinderConfig struct {
+	LruSize         int
+	ErrorLruSize    int
+	ErrorLruTimeout time.Duration
+}
+
+func (cfg EndpointFinderConfig) lruSize() int {
+	if cfg.LruSize == 0 {
+		return defaultLruSize
+	}
+	return cfg.LruSize
+}
+
+func (cfg EndpointFinderConfig) errorLruSize() int {
+	if cfg.ErrorLruSize == 0 {
+		return defaultErrorLruSize
+	}
+	return cfg.ErrorLruSize
+}
+
+func (cfg EndpointFinderConfig) errorLruTimeout() time.Duration {
+	if cfg.ErrorLruTimeout == 0 {
+		return defaultErrorLruTimeout
+	}
+	return cfg.ErrorLruTimeout
 }
 
 // NewEndpointFinder returns a new instance of an EndpointFinder
-func NewEndpointFinder(minerInfoFetcher MinerInfoFetcher, h host.Host, size int) (*EndpointFinder, error) {
-	httpEndpoints, err := lru.New[string, []peer.AddrInfo](size)
+func NewEndpointFinder(cfg EndpointFinderConfig, minerInfoFetcher MinerInfoFetcher, h host.Host) (*EndpointFinder, error) {
+	httpEndpoints, err := lru.New[string, []peer.AddrInfo](cfg.lruSize())
 	if err != nil {
 		return nil, err
 	}
+	endpointErrors := expirable.NewLRU[string, error](cfg.errorLruSize(), func(key string, value error) {}, cfg.errorLruTimeout())
 	return &EndpointFinder{
 		minerInfoFetcher: minerInfoFetcher,
 		h:                h,
 		httpEndpoints:    httpEndpoints,
+		endpointErrors:   endpointErrors,
 	}, nil
 }
 
-func (ef *EndpointFinder) fetchHTTPEndpoint(ctx context.Context, provider string) ([]peer.AddrInfo, error) {
+func (ef *EndpointFinder) findHTTPEndpointsForProvider(ctx context.Context, provider string) ([]peer.AddrInfo, error) {
 	// lookup the provider on chain
 	minerInfo, err := ef.minerInfoFetcher.GetProviderInfo(ctx, provider)
 	if err != nil {
@@ -74,30 +116,58 @@ func (ef *EndpointFinder) fetchHTTPEndpoint(ctx context.Context, provider string
 	return nil, ErrHTTPNotSupported
 }
 
-// findOrFetchHTTPEndpoint attempts to load from cache before calling fetchHTTPEndpoint
-func (ef *EndpointFinder) findOrFetchHTTPEndpoint(ctx context.Context, provider string) ([]peer.AddrInfo, error) {
-	addrInfos, has := ef.httpEndpoints.Get(provider)
-	if has {
-		return addrInfos, nil
-	}
-	addrInfos, err := ef.fetchHTTPEndpoint(ctx, provider)
-	if err != nil {
-		return nil, err
-	}
-	ef.httpEndpoints.Add(provider, addrInfos)
-	return addrInfos, nil
-}
-
 // FindHTTPEndpoints finds http endpoints for a given set of providers
 func (ef *EndpointFinder) FindHTTPEndpoints(ctx context.Context, sps []string) ([]peer.AddrInfo, error) {
 	addrInfos := make([]peer.AddrInfo, 0, len(sps))
-	for _, sp := range sps {
-		// TODO: should we ignore if some but not all providers are configured correctly?
-		nextAddrInfos, err := ef.findOrFetchHTTPEndpoint(ctx, sp)
-		if err != nil {
-			return nil, err
+	type findResult struct {
+		addrs []peer.AddrInfo
+		err   error
+	}
+	addrChan := make(chan findResult)
+
+	for _, provider := range sps {
+		go func(provider string) {
+			var result findResult
+			// first check our caches
+			if providerAddrs, has := ef.httpEndpoints.Get(provider); has {
+				result.addrs = providerAddrs
+			} else if err, has := ef.endpointErrors.Get(provider); has {
+				logger.Errorf("error looking up http endpoint for %s (cached): %s", provider, err)
+				result.err = err
+			} else {
+				// not in caches, perform full lookup of provider
+				providerAddrs, err := ef.findHTTPEndpointsForProvider(ctx, provider)
+				result = findResult{addrs: providerAddrs, err: err}
+				if err != nil {
+					ef.endpointErrors.Add(provider, err)
+					logger.Errorf("error looking up http endpoint for %s: %s", provider, err)
+				} else {
+					ef.httpEndpoints.Add(provider, providerAddrs)
+				}
+			}
+			select {
+			case addrChan <- result:
+			case <-ctx.Done():
+			}
+		}(provider)
+	}
+
+	var err error
+	for range sps {
+		select {
+		case providerAddrs := <-addrChan:
+			if providerAddrs.addrs != nil {
+				addrInfos = append(addrInfos, providerAddrs.addrs...)
+			} else if providerAddrs.err != nil {
+				err = multierr.Append(err, providerAddrs.err)
+			}
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
-		addrInfos = append(addrInfos, nextAddrInfos...)
+	}
+
+	if len(addrInfos) == 0 {
+		return nil, fmt.Errorf("no http endpoints found for providers %v: %w", sps, err)
 	}
 	return addrInfos, nil
 }

--- a/retriever/endpointfinder/endpointfinder_test.go
+++ b/retriever/endpointfinder/endpointfinder_test.go
@@ -90,8 +90,7 @@ func TestEndpointFetcher(t *testing.T) {
 				other.SetStreamHandler(boostly.FilRetrievalTransportsProtocol_1_0_0, handler)
 			}
 
-			endpointFinder, err := endpointfinder.NewEndpointFinder(minerInfoFetcher, source, endpointfinder.WithErrorLruSize(3), endpointfinder.WithErrorLruSize(3))
-			require.NoError(t, err)
+			endpointFinder := endpointfinder.NewEndpointFinder(minerInfoFetcher, source, endpointfinder.WithErrorLruSize(3), endpointfinder.WithErrorLruSize(3))
 
 			addrInfos, err := endpointFinder.FindHTTPEndpoints(context.Background(), []string{testProvider})
 			if testCase.expectedErrString == "" {

--- a/retriever/endpointfinder/endpointfinder_test.go
+++ b/retriever/endpointfinder/endpointfinder_test.go
@@ -90,7 +90,7 @@ func TestEndpointFetcher(t *testing.T) {
 				other.SetStreamHandler(boostly.FilRetrievalTransportsProtocol_1_0_0, handler)
 			}
 
-			endpointFinder, err := endpointfinder.NewEndpointFinder(endpointfinder.EndpointFinderConfig{LruSize: 3, ErrorLruSize: 3}, minerInfoFetcher, source)
+			endpointFinder, err := endpointfinder.NewEndpointFinder(minerInfoFetcher, source, endpointfinder.WithErrorLruSize(3), endpointfinder.WithErrorLruSize(3))
 			require.NoError(t, err)
 
 			addrInfos, err := endpointFinder.FindHTTPEndpoints(context.Background(), []string{testProvider})

--- a/retriever/endpointfinder/options.go
+++ b/retriever/endpointfinder/options.go
@@ -4,12 +4,14 @@ import "time"
 
 const (
 	defaultLruSize         = 128
+	defaultLruTimeout      = 2 * time.Hour
 	defaultErrorLruSize    = 128
 	defaultErrorLruTimeout = 5 * time.Minute
 )
 
 type config struct {
 	LruSize         int
+	LruTimeout      time.Duration
 	ErrorLruSize    int
 	ErrorLruTimeout time.Duration
 }
@@ -31,6 +33,12 @@ type Option func(*config)
 func WithLruSize(size int) Option {
 	return func(cfg *config) {
 		cfg.LruSize = size
+	}
+}
+
+func WithLruTimeout(timeout time.Duration) Option {
+	return func(cfg *config) {
+		cfg.LruTimeout = timeout
 	}
 }
 

--- a/retriever/endpointfinder/options.go
+++ b/retriever/endpointfinder/options.go
@@ -1,0 +1,47 @@
+package endpointfinder
+
+import "time"
+
+const (
+	defaultLruSize         = 128
+	defaultErrorLruSize    = 128
+	defaultErrorLruTimeout = 5 * time.Minute
+)
+
+type config struct {
+	LruSize         int
+	ErrorLruSize    int
+	ErrorLruTimeout time.Duration
+}
+
+func applyOptions(opts ...Option) *config {
+	cfg := &config{
+		LruSize:         defaultLruSize,
+		ErrorLruSize:    defaultErrorLruSize,
+		ErrorLruTimeout: defaultErrorLruTimeout,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg
+}
+
+type Option func(*config)
+
+func WithLruSize(size int) Option {
+	return func(cfg *config) {
+		cfg.LruSize = size
+	}
+}
+
+func WithErrorLruSize(size int) Option {
+	return func(cfg *config) {
+		cfg.ErrorLruSize = size
+	}
+}
+
+func WithErrorLruTimeout(timeout time.Duration) Option {
+	return func(cfg *config) {
+		cfg.ErrorLruTimeout = timeout
+	}
+}


### PR DESCRIPTION
Goals:

1. Make endpoint lookup parallel across all SPs
2. Don't error unless we don't have any endpoints—but log an error
3. Cache the error case too because it's not cheap and with a misbehaving SP it'll slow down every call for a particular piece

Critique of my design decisions welcome of course, there's a bunch of ways this could be done, I made some choices.