### PR TITLE
feat: add log for retrieval paths

### DIFF
--- a/handler/file/retrieve.go
+++ b/handler/file/retrieve.go
@@ -18,10 +18,12 @@ import (
 
 var logger = log.Logger("singularity/handler/file")
 
-var ErrNoFileRangeRecord = errors.New("missing file range record")
-var ErrNoJobRecord = errors.New("missing job record")
-var ErrNoFilecoinDeals = errors.New("no filecoin deals available")
-var ErrByteOffsetBeyondFile = errors.New("byte offset would exceed file size")
+var (
+	ErrNoFileRangeRecord    = errors.New("missing file range record")
+	ErrNoJobRecord          = errors.New("missing job record")
+	ErrNoFilecoinDeals      = errors.New("no filecoin deals available")
+	ErrByteOffsetBeyondFile = errors.New("byte offset would exceed file size")
+)
 
 type UnableToServeRangeError struct {
 	Start int64
@@ -73,6 +75,7 @@ func (DefaultHandler) RetrieveFileHandler(
 
 	seeker, obj, err := storagesystem.Open(rclone, ctx, file.Path)
 	if err != nil {
+		logger.Infow("no local copy of file, returning filecoin reader", "id", id, "file", file.Path, "fileSize", file.Size, "cid", file.CID)
 		// we have no local copy, so we have to return a filecoin based reader
 		//nolint:nilerr
 		return &filecoinReader{
@@ -84,6 +87,7 @@ func (DefaultHandler) RetrieveFileHandler(
 		}, file.FileName(), time.Unix(0, file.LastModifiedNano), nil
 	}
 
+	logger.Infow("returning reader for local copy of file", "id", id, "file", file.Path, "fileSize", file.Size, "cid", file.CID)
 	return seeker, file.FileName(), obj.ModTime(ctx), nil
 }
 

--- a/retriever/retriever.go
+++ b/retriever/retriever.go
@@ -8,6 +8,7 @@ import (
 	"github.com/data-preservation-programs/singularity/retriever/deserializer"
 	lassietypes "github.com/filecoin-project/lassie/pkg/types"
 	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-car/v2"
 	"github.com/ipld/go-car/v2/storage"
 	trustlessutils "github.com/ipld/go-trustless-utils"
@@ -15,6 +16,8 @@ import (
 	"github.com/multiformats/go-multicodec"
 	"go.uber.org/multierr"
 )
+
+var logger = log.Logger("singularity/retriever")
 
 // EndpointFinder finds http endpoints for set of SPs
 type EndpointFinder interface {
@@ -77,6 +80,7 @@ func (r *Retriever) getContent(ctx context.Context, c cid.Cid, rangeStart int64,
 
 // Retrieve retrieves a byte range from a cid representing a unixfstree from a given list of SPs, writing the output to a car file
 func (r *Retriever) Retrieve(ctx context.Context, c cid.Cid, rangeStart int64, rangeEnd int64, sps []string, out io.Writer) error {
+	logger.Infow("retrieving from filecoin", "cid", c, "rangeStart", rangeStart, "rangeEnd", rangeEnd, "sps", sps)
 	reader, writer := io.Pipe()
 	errChan := make(chan error, 2)
 	go func() {


### PR DESCRIPTION
No indication on standard log output of any of this happening, which is odd given a lot of the other stuff that comes out.