### PR TITLE
Ignore error for making identical deals

### DIFF
--- a/service/dealpusher/dealpusher.go
+++ b/service/dealpusher/dealpusher.go
@@ -2,6 +2,7 @@ package dealpusher
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
@@ -374,7 +375,7 @@ func (d *DealPusher) runSchedule(ctx context.Context, schedule *model.Schedule) 
 						PricePerGB:      schedule.PricePerGB,
 						PricePerGBEpoch: schedule.PricePerGBEpoch,
 					})
-				if err != nil {
+				if err != nil && !strings.Contains(err.Error(), "deal proposal is identical") {
 					Logger.Errorw("failed to send deal", "error", err, "provider", schedule.Provider)
 				}
 				return errors.WithStack(err)

--- a/service/dealpusher/dealpusher.go
+++ b/service/dealpusher/dealpusher.go
@@ -377,9 +377,9 @@ func (d *DealPusher) runSchedule(ctx context.Context, schedule *model.Schedule) 
 					})
 				if err != nil {
 					Logger.Errorw("failed to send deal", "error", err, "provider", schedule.Provider)
-                                        if strings.Contains(err.Error(), "deal proposal is identical") {
-                                                return nil
-                                        }
+					if strings.Contains(err.Error(), "deal proposal is identical") {
+						return nil
+					}
 				}
 
 				return errors.WithStack(err)
@@ -389,9 +389,9 @@ func (d *DealPusher) runSchedule(ctx context.Context, schedule *model.Schedule) 
 				return "", errors.Wrap(err, "failed to send deal")
 			}
 
-                        if dealModel == nil {
-                                continue
-                        }
+			if dealModel == nil {
+				continue
+			}
 			dealModel.ScheduleID = &schedule.ID
 
 			Logger.Debugw("save accepted deal", "deal", dealModel)


### PR DESCRIPTION
In the case where provider failed to return success response, Singularity will retry the same deal which may end up with being rejected as boost has already received the same deal proposal.

This makes Singularity continue to next deal instead of keep retrying on the same "identical deal" error message.