### PR TITLE
Disable metrics reporting by default

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -57,7 +57,7 @@ func Init(ctx context.Context, db *gorm.DB) error {
 	db.WithContext(ctx).Clauses(where).First(&identity)
 	Identity = identity.Value
 
-	if os.Getenv("SINGULARITY_ANALYTICS") == "0" {
+	if os.Getenv("SINGULARITY_ANALYTICS") != "1" {
 		Enabled = false
 	}
 	return nil


### PR DESCRIPTION
Metrics reporting will be disabled by default in case the metrics API is turned off