### PR TITLE
[DRAFT] enable union backend

### DIFF
--- a/storagesystem/types.go
+++ b/storagesystem/types.go
@@ -45,6 +45,7 @@ import (
 	_ "github.com/rclone/rclone/backend/storj"
 	_ "github.com/rclone/rclone/backend/sugarsync"
 	_ "github.com/rclone/rclone/backend/swift"
+	_ "github.com/rclone/rclone/backend/union"
 	_ "github.com/rclone/rclone/backend/uptobox"
 	_ "github.com/rclone/rclone/backend/webdav"
 	_ "github.com/rclone/rclone/backend/yandex"


### PR DESCRIPTION
this leverages built-in rclone features to allow backends that have one logical root (e.g. `internetarchive`) to seamlessly aggregate multiple paths into a single preparation

example usage:
```
RCLONE_CONFIG_IA_TYPE=internetarchive  singularity storage create union --upstreams 'ia:DuckandC1951 ia:0872_Angels_Flight_05_32_34_00' --path ''
```

this creates an implicit, ephemeral remote of the `internetarchive` type called `ia`  and aggregates paths specified by `--upstreams`