### PR TITLE
Pin goreleaser to latest 1.X

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -23,7 +23,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
-          version: latest
+          version: v2.1.0
           args: ${{ github.event_name == 'pull_request' && 'release --snapshot --skip-publish' || 'release --clean' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
goreleaser 2.x has changed the configuration format, which breaks tagged package releases

this workaround pins goreleaser to latest 1.x release