### PR TITLE
chore: bump version to v0.6.0-RC3

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,1 +1,3 @@
-{"version": "v0.6.0-RC2"}
+{
+    "version": "v0.6.0-RC3"
+}


### PR DESCRIPTION
Updates version.json to reflect the new release tag v0.6.0-RC3.