### PR TITLE
Fix scan handler bug: pass correct preparation and storage IDs

### DIFF
--- a/cmd/dataprep/create.go
+++ b/cmd/dataprep/create.go
@@ -326,7 +326,7 @@ func autoStartScanning(ctx context.Context, db *gorm.DB, prep *model.Preparation
 
 	// Start scan jobs for each source attachment
 	for _, attachment := range attachments {
-		_, err = jobHandler.StartScanHandler(ctx, db, strconv.FormatUint(uint64(attachment.ID), 10), "")
+		_, err = jobHandler.StartScanHandler(ctx, db, strconv.FormatUint(uint64(attachment.PreparationID), 10), strconv.FormatUint(uint64(attachment.StorageID), 10))
 		if err != nil {
 			fmt.Printf("⚠ Failed to start scan for attachment %d: %v\n", attachment.ID, err)
 			continue

--- a/cmd/onboard.go
+++ b/cmd/onboard.go
@@ -400,7 +400,7 @@ func startScanningForPreparation(ctx context.Context, db *gorm.DB, prep *model.P
 
 	// Start scan jobs for each source attachment
 	for _, attachment := range attachments {
-		_, err = jobHandler.StartScanHandler(ctx, db, strconv.FormatUint(uint64(attachment.ID), 10), "")
+		_, err = jobHandler.StartScanHandler(ctx, db, strconv.FormatUint(uint64(attachment.PreparationID), 10), strconv.FormatUint(uint64(attachment.StorageID), 10))
 		if err != nil {
 			fmt.Printf("⚠ Failed to start scan for attachment %d: %v\n", attachment.ID, err)
 			continue


### PR DESCRIPTION
## Summary
Fixes scan handler bug in onboard workflow by passing correct parameters to StartScanHandler.

## Changes
- Fixed `startScanningForPreparation` to pass `attachment.PreparationID` and `attachment.StorageID` instead of `attachment.ID` and empty string
- Updated both `cmd/onboard.go` and `cmd/dataprep/create.go` for consistency

## Test plan
- [x] Verify onboard command no longer fails with "sourceAttachment '' is not attached to preparation" error
- [x] Confirm scan jobs are created successfully during onboarding
- [x] Test with multiple source attachments

Fixes #530