### PR TITLE
Fix validation defaults: make output optional and set validation defaults to true

### DIFF
--- a/cmd/dataprep/create.go
+++ b/cmd/dataprep/create.go
@@ -152,11 +152,13 @@ var CreateCmd = &cli.Command{
 			Name:     "wallet-validation",
 			Usage:    "Enable wallet balance validation before deal creation",
 			Category: "Validation",
+			Value:    true,
 		},
 		&cli.BoolFlag{
 			Name:     "sp-validation",
 			Usage:    "Enable storage provider validation before deal creation",
 			Category: "Validation",
+			Value:    true,
 		},
 		&cli.BoolFlag{
 			Name:     "auto-start",

--- a/cmd/onboard.go
+++ b/cmd/onboard.go
@@ -138,10 +138,12 @@ This is the simplest way to onboard data from source to storage deals.`,
 		&cli.BoolFlag{
 			Name:  "wallet-validation",
 			Usage: "Enable wallet balance validation",
+			Value: true,
 		},
 		&cli.BoolFlag{
 			Name:  "sp-validation",
 			Usage: "Enable storage provider validation",
+			Value: true,
 		},
 
 		// Output format
@@ -585,17 +587,14 @@ func validateOnboardInputs(c *cli.Context) error {
 		return errors.New("preparation name is required (--name)")
 	}
 
-	// Source and output validation
+	// Source validation
 	sourcePaths := c.StringSlice("source")
-	outputPaths := c.StringSlice("output")
 
 	if len(sourcePaths) == 0 {
 		return errors.New("at least one source path is required (--source)")
 	}
 
-	if len(outputPaths) == 0 {
-		return errors.New("at least one output path is required (--output)")
-	}
+	// Output paths are optional - no validation needed
 
 	// Auto-deal validation
 	if c.Bool("auto-create-deals") {


### PR DESCRIPTION
## Summary
Fixes flag validation issues in onboard command by making output paths optional and setting proper validation defaults.

## Changes
- Made `--output` flag genuinely optional (removed validation requirement)
- Set `--wallet-validation` default to `true`
- Set `--sp-validation` default to `true`
- Updated validation logic to match help text

## Test plan
- [x] Verify onboard command works without `--output` flag
- [x] Confirm wallet and SP validation are enabled by default
- [x] Test explicit `--wallet-validation=false` and `--sp-validation=false` overrides

Fixes #530