### PR TITLE
Fix onboard command workers cleanup - resolves #540

### DIFF
--- a/cmd/onboard.go
+++ b/cmd/onboard.go
@@ -251,18 +251,24 @@ This is the simplest way to onboard data from source to storage deals.`,
 			if err != nil {
 				return outputJSONError("monitoring failed", err)
 			}
-		}
-
-		// Cleanup workers if we started them
-		if workerManager != nil {
-			if !isJSON {
-				fmt.Println("\n🧹 Cleaning up workers...")
-			}
-			err = workerManager.Stop(ctx)
-			if err != nil {
+			
+			// Only cleanup workers after completion monitoring finishes successfully
+			if workerManager != nil {
 				if !isJSON {
-					fmt.Printf("⚠ Warning: failed to stop workers cleanly: %v\n", err)
+					fmt.Println("\n🧹 Cleaning up workers...")
 				}
+				err = workerManager.Stop(ctx)
+				if err != nil {
+					if !isJSON {
+						fmt.Printf("⚠ Warning: failed to stop workers cleanly: %v\n", err)
+					}
+				}
+			}
+		} else if workerManager != nil {
+			// When not waiting for completion, leave workers running to process jobs
+			if !isJSON {
+				fmt.Println("\n✅ Workers will continue running to process jobs")
+				fmt.Println("💡 Use --wait-for-completion to monitor progress and stop workers when done")
 			}
 		}
 
@@ -274,7 +280,11 @@ This is the simplest way to onboard data from source to storage deals.`,
 				"Check jobs: singularity job list",
 			}
 			if c.Bool("start-workers") {
-				nextSteps = append(nextSteps, "Workers will process jobs automatically")
+				if c.Bool("wait-for-completion") {
+					nextSteps = append(nextSteps, "Workers have been stopped after completion")
+				} else {
+					nextSteps = append(nextSteps, "Workers are running and will process jobs automatically")
+				}
 			} else {
 				nextSteps = append(nextSteps, "Start workers: singularity run unified")
 			}
@@ -301,7 +311,7 @@ This is the simplest way to onboard data from source to storage deals.`,
 				fmt.Println("   • Monitor progress: singularity prep status", prep.Name)
 				fmt.Println("   • Check jobs: singularity job list")
 				if c.Bool("start-workers") {
-					fmt.Println("   • Workers will process jobs automatically")
+					fmt.Println("   • Workers are running and will process jobs automatically")
 				} else {
 					fmt.Println("   • Start workers: singularity run unified")
 				}


### PR DESCRIPTION
## Summary

- Fixed issue where onboard command immediately stopped workers after completion, leaving scanning jobs stuck in "ready" state
- Modified worker cleanup logic to only stop workers when jobs are actually complete
- Updated user messaging to reflect new behavior

## Changes

- **Removed immediate worker cleanup**: Workers no longer stopped right after onboard command finishes
- **Conditional cleanup**: When `--wait-for-completion` is used, workers are only stopped after monitoring confirms all jobs are done
- **Default behavior**: When not using `--wait-for-completion`, workers continue running to process jobs (they will auto-scale down when idle)
- **Updated messaging**: Clear user feedback about worker status and suggestions for monitoring

## Test plan

- [x] Build succeeds without errors
- [x] All existing tests pass
- [x] Help text displays correctly
- [x] Behavior matches expected workflow described in issue

## Resolves

Fixes #540

The onboard command will now keep workers running to process scanning, packing, and daggen jobs to completion as intended.