### PR TITLE
Prefilter deals before unmarshalling

### DIFF
--- a/service/dealtracker/dealtracker_test.go
+++ b/service/dealtracker/dealtracker_test.go
@@ -172,7 +172,8 @@ func TestTrackDeal(t *testing.T) {
 		deals = append(deals, deal)
 		return nil
 	}
-	err := tracker.trackDeal(context.Background(), callback)
+	walletIDs := map[string]struct{}{"t0100": {}}
+	err := tracker.trackDeal(context.Background(), walletIDs, callback)
 	require.NoError(t, err)
 	require.Len(t, deals, 1)
 }


### PR DESCRIPTION
This increases dealtracking efficiency by 3-5x by not unmarshalling the 99.9999% of deals that we don't care about and just peeking at the client wallet

There are better fixes but this one is quick and effective