### PR TITLE
Fix and Refactor Wallet Balance Logic for Lotus Integration and Troubleshooting

### DIFF
--- a/cmd/wallet/balance.go
+++ b/cmd/wallet/balance.go
@@ -13,12 +13,12 @@ var BalanceCmd = &cli.Command{
 	Name:      "balance",
 	Usage:     "Get wallet balance information",
 	ArgsUsage: "<wallet_address>",
-	Description: `Get FIL balance and FIL+ datacap balance for a specific wallet address.
+Description: `Get FIL balance and FIL+ datacap balance for a specific wallet address.
 This command queries the Lotus network to retrieve current balance information.
 
 Examples:
-  singularity wallet balance f12syf7zd3lfsv43aj2kb454ymaqw7debhumjnbqa
-  singularity wallet balance --json f1abc123...def456
+  singularity wallet balance f1abcde7zd3lfsv43aj2kb454ymaqw7debhumjxyz
+  singularity wallet balance --json f1abcde7zd3lfsv43aj2kb454ymaqw7debhumjxyz
 
 The command returns:
 - FIL balance in human-readable format (e.g., "1.000000 FIL")

--- a/cmd/wallet/list.go
+++ b/cmd/wallet/list.go
@@ -1,28 +1,61 @@
 package wallet
 
 import (
-	"github.com/cockroachdb/errors"
-	"github.com/data-preservation-programs/singularity/cmd/cliutil"
-	"github.com/data-preservation-programs/singularity/database"
-	"github.com/data-preservation-programs/singularity/handler/wallet"
-	"github.com/urfave/cli/v2"
+   "github.com/cockroachdb/errors"
+   "github.com/data-preservation-programs/singularity/cmd/cliutil"
+   "github.com/data-preservation-programs/singularity/database"
+   "github.com/data-preservation-programs/singularity/handler/wallet"
+   "github.com/data-preservation-programs/singularity/util"
+   "github.com/urfave/cli/v2"
 )
 
 var ListCmd = &cli.Command{
-	Name:  "list",
-	Usage: "List all imported wallets",
-	Action: func(c *cli.Context) error {
-		db, closer, err := database.OpenFromCLI(c)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		defer func() { _ = closer.Close() }()
-		wallets, err := wallet.Default.ListHandler(c.Context, db)
-		if err != nil {
-			return errors.WithStack(err)
-		}
+   Name:  "list",
+   Usage: "List all imported wallets",
+   Flags: []cli.Flag{
+	   &cli.BoolFlag{
+		   Name:    "with-balance",
+		   Usage:   "Fetch and display live wallet balances from Lotus",
+		   Value:   false,
+	   },
+	   &cli.StringFlag{
+		   Name:    "lotus-api",
+		   Usage:   "Lotus JSON-RPC API endpoint (required for --with-balance)",
+		   EnvVars: []string{"LOTUS_API"},
+	   },
+	   &cli.StringFlag{
+		   Name:    "lotus-token",
+		   Usage:   "Lotus API authorization token (required for --with-balance)",
+		   EnvVars: []string{"LOTUS_TOKEN"},
+	   },
+   },
+   Action: func(c *cli.Context) error {
+	   db, closer, err := database.OpenFromCLI(c)
+	   if err != nil {
+		   return errors.WithStack(err)
+	   }
+	   defer func() { _ = closer.Close() }()
 
-		cliutil.Print(c, wallets)
-		return nil
-	},
+	   if c.Bool("with-balance") {
+		   lotusAPI := c.String("lotus-api")
+		   lotusToken := c.String("lotus-token")
+		   if lotusAPI == "" || lotusToken == "" {
+			   return errors.New("Both --lotus-api and --lotus-token must be provided to fetch wallet balances.")
+		   }
+		   lotusClient := util.NewLotusClient(lotusAPI, lotusToken)
+		   wallets, err := wallet.ListWithBalanceHandler(c.Context, db, lotusClient)
+		   if err != nil {
+			   return errors.WithStack(err)
+		   }
+		   cliutil.Print(c, wallets)
+		   return nil
+	   }
+
+	   wallets, err := wallet.Default.ListHandler(c.Context, db)
+	   if err != nil {
+		   return errors.WithStack(err)
+	   }
+	   cliutil.Print(c, wallets)
+	   return nil
+   },
 }

--- a/docs/en/cli-reference/wallet/README.md
+++ b/docs/en/cli-reference/wallet/README.md
@@ -51,10 +51,10 @@ OPTIONS:
 **Check wallet balance:**
 ```bash
 # Get balance for a specific wallet
-singularity wallet balance f12syf7zd3lfsv43aj2kb454ymaqw7debhumjnbqa
+singularity wallet balance f1abcde7zd3lfsv43aj2kb454ymaqw7debhumjxyz
 
 # Get balance in JSON format
-singularity --json wallet balance f12syf7zd3lfsv43aj2kb454ymaqw7debhumjnbqa
+singularity --json wallet balance f1abcde7zd3lfsv43aj2kb454ymaqw7debhumjxyz
 ```
 
 **Create and manage wallets:**

--- a/docs/en/cli-reference/wallet/balance.md
+++ b/docs/en/cli-reference/wallet/balance.md
@@ -22,7 +22,7 @@ The command returns detailed balance information:
 
 | Field | Description | Example |
 |-------|-------------|---------|
-| **address** | The wallet address queried | `f12syf7zd3lfsv43aj2kb454ymaqw7debhumjnbqa` |
+| **address** | The wallet address queried | `f1abcde7zd3lfsv43aj2kb454ymaqw7debhumjxyz` |
 | **balance** | FIL balance in human-readable format | `1.000000 FIL` |
 | **balanceAttoFIL** | Raw balance in attoFIL (10^-18 FIL) | `1000000000000000000` |
 | **dataCap** | FIL+ datacap balance in GiB | `1024.50 GiB` |
@@ -35,26 +35,26 @@ The command returns detailed balance information:
 
 ```bash
 # Check balance for a wallet
-singularity wallet balance f12syf7zd3lfsv43aj2kb454ymaqw7debhumjnbqa
+singularity wallet balance f1abcde7zd3lfsv43aj2kb454ymaqw7debhumjxyz
 ```
 
 **Output:**
 ```
 Address                                    Balance       BalanceAttoFIL       DataCap      DataCapBytes   Error  
-f12syf7zd3lfsv43aj2kb454ymaqw7debhumjnbqa  1.000000 FIL  1000000000000000000  1024.50 GiB  1100048498688  <nil>  
+f1abcde7zd3lfsv43aj2kb454ymaqw7debhumjxyz  1.000000 FIL  1000000000000000000  1024.50 GiB  1100048498688  <nil>  
 ```
 
 ### JSON Output
 
 ```bash
 # Get balance in JSON format for programmatic use
-singularity --json wallet balance f12syf7zd3lfsv43aj2kb454ymaqw7debhumjnbqa
+singularity --json wallet balance f1abcde7zd3lfsv43aj2kb454ymaqw7debhumjxyz
 ```
 
 **Output:**
 ```json
 {
-  "address": "f12syf7zd3lfsv43aj2kb454ymaqw7debhumjnbqa",
+  "address": "f1abcde7zd3lfsv43aj2kb454ymaqw7debhumjxyz",
   "balance": "1.000000 FIL",
   "balanceAttoFIL": "1000000000000000000",
   "dataCap": "1024.50 GiB",

--- a/docs/jp/cli-reference/wallet/list.md
+++ b/docs/jp/cli-reference/wallet/list.md
@@ -9,6 +9,19 @@ NAME:
    singularity wallet list [コマンドオプション] [引数...]
 
 オプション:
-   --help, -h  ヘルプを表示する
+   --with-balance  Lotusからライブウォレット残高を取得して表示する
+   --help, -h      ヘルプを表示する
 ```
 {% endcode %}
+
+## 例: 残高付きでウォレットをリスト
+
+```
+singularity wallet list --with-balance --lotus-api <API> --lotus-token <TOKEN>
+
+ADDRESS                                 BALANCE        DATACAP
+f1abcde7zd3lfsv43aj2kb454ymaqw7debhumjxyz  1.000000 FIL   0
+...
+```
+
+`--with-balance` フラグを指定すると、各ウォレットのFIL残高とFIL+データキャップが表示されます。

--- a/handler/wallet/list.go
+++ b/handler/wallet/list.go
@@ -2,11 +2,58 @@ package wallet
 
 import (
 	"context"
-
 	"github.com/cockroachdb/errors"
 	"github.com/data-preservation-programs/singularity/model"
+	"github.com/ybbus/jsonrpc/v3"
 	"gorm.io/gorm"
 )
+// WalletWithBalance combines wallet info with live balance fields
+type WalletWithBalance struct {
+	model.Wallet
+	Balance        string `json:"balance"`
+	BalanceAttoFIL string `json:"balanceAttoFIL"`
+	DataCap        string `json:"dataCap"`
+	DataCapBytes   int64  `json:"dataCapBytes"`
+	Error          *string `json:"error,omitempty"`
+}
+
+// ListWithBalanceHandler retrieves all wallets and fetches their balances from Lotus
+func ListWithBalanceHandler(
+	ctx context.Context,
+	db *gorm.DB,
+	lotusClient jsonrpc.RPCClient,
+) ([]WalletWithBalance, error) {
+	db = db.WithContext(ctx)
+	var wallets []model.Wallet
+	err := db.Find(&wallets).Error
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+   var result []WalletWithBalance
+   allFailed := true
+   for _, w := range wallets {
+	   bal, err := DefaultHandler{}.GetBalanceHandler(ctx, db, lotusClient, w.Address)
+	   wb := WalletWithBalance{Wallet: w}
+	   if err == nil && bal != nil {
+		   wb.Balance = bal.Balance
+		   wb.BalanceAttoFIL = bal.BalanceAttoFIL
+		   wb.DataCap = bal.DataCap
+		   wb.DataCapBytes = bal.DataCapBytes
+		   wb.Error = bal.Error
+		   allFailed = false
+	   } else if err != nil {
+		   errMsg := err.Error()
+		   wb.Error = &errMsg
+	   }
+	   result = append(result, wb)
+   }
+   if allFailed && len(wallets) > 0 {
+	   return result, errors.New("Failed to fetch balances for all wallets. Lotus may be unreachable or misconfigured.")
+   }
+   return result, nil
+}
+
+
 
 // ListHandler retrieves a list of all the wallets stored in the database.
 //

--- a/handler/wallet/list_test.go
+++ b/handler/wallet/list_test.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"context"
+	"github.com/cockroachdb/errors"
 	"testing"
 
 	"github.com/data-preservation-programs/singularity/model"
@@ -11,13 +12,115 @@ import (
 )
 
 func TestListHandler(t *testing.T) {
+// Skip this test if MySQL is not available
+if testing.Short() {
+	t.Skip("Skipping due to missing MySQL (integration test)")
+}
+testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
+	t.Run("success", func(t *testing.T) {
+		err := db.Create(&model.Wallet{}).Error
+		require.NoError(t, err)
+		wallets, err := Default.ListHandler(ctx, db)
+		require.NoError(t, err)
+		require.Len(t, wallets, 1)
+	})
+})
+}
+
+
+func TestListWithBalanceHandler(t *testing.T) {
+   // Skip this test if MySQL is not available
+   if testing.Short() {
+	   t.Skip("Skipping due to missing MySQL (integration test)")
+   }
+   t.Run("all Lotus errors", func(t *testing.T) {
+		   testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
+					   w := model.Wallet{Address: "f1abcde7zd3lfsv43aj2kb454ymaqw7debhumjxyz"}
+					   err := db.Create(&w).Error
+					   require.NoError(t, err)
+					   mockLotus := testutil.NewMockLotusClient()
+					   mockLotus.SetError("Filecoin.WalletBalance", errors.New("lotus unreachable"))
+					   mockLotus.SetError("Filecoin.StateVerifiedClientStatus", errors.New("lotus unreachable"))
+					   wallets, err := ListWithBalanceHandler(ctx, db, mockLotus)
+					   require.Error(t, err)
+					   require.Len(t, wallets, 1)
+					   require.NotNil(t, wallets[0].Error)
+					   require.Contains(t, *wallets[0].Error, "lotus unreachable")
+			   })
+	   })
+
+	   t.Run("partial Lotus errors", func(t *testing.T) {
+			   testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
+					   w1 := model.Wallet{Address: "f1abcde7zd3lfsv43aj2kb454ymaqw7debhumjxyz"}
+					   w2 := model.Wallet{Address: "f1fib3pv7jua2ockdugtz7viz3cyy6lkhh7rfx3sa"}
+					   err := db.Create(&w1).Error
+					   require.NoError(t, err)
+					   err = db.Create(&w2).Error
+					   require.NoError(t, err)
+					   mockLotus := testutil.NewMockLotusClient()
+					   mockLotus.SetResponse("Filecoin.WalletBalance", "1000000000000000000")
+					   mockLotus.SetResponse("Filecoin.StateVerifiedClientStatus", "0")
+					   mockLotus.SetError("Filecoin.WalletBalance", errors.New("lotus error"))
+					   wallets, err := ListWithBalanceHandler(ctx, db, mockLotus)
+					   require.NoError(t, err)
+					   require.Len(t, wallets, 2)
+					   foundError := false
+					   for _, w := range wallets {
+							   if w.Error != nil {
+									   foundError = true
+							   }
+					   }
+					   require.True(t, foundError)
+			   })
+	   })
+
+	   t.Run("Lotus timeout", func(t *testing.T) {
+			   testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
+					   w := model.Wallet{Address: "f1abcde7zd3lfsv43aj2kb454ymaqw7debhumjxyz"}
+					   err := db.Create(&w).Error
+					   require.NoError(t, err)
+					   mockLotus := testutil.NewMockLotusClient()
+					   mockLotus.SetError("Filecoin.WalletBalance", context.DeadlineExceeded)
+					   wallets, err := ListWithBalanceHandler(ctx, db, mockLotus)
+					   require.Error(t, err)
+					   require.Len(t, wallets, 1)
+					   require.NotNil(t, wallets[0].Error)
+					   require.Contains(t, *wallets[0].Error, "context deadline exceeded")
+			   })
+	   })
+	   t.Run("empty db", func(t *testing.T) {
+			   testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
+					   mockLotus := testutil.NewMockLotusClient()
+					   wallets, err := ListWithBalanceHandler(ctx, db, mockLotus)
+					   require.NoError(t, err)
+					   require.Len(t, wallets, 0)
+			   })
+	   })
+
+	   t.Run("db error", func(t *testing.T) {
+			   ctx := context.Background()
+			   badDB, _ := gorm.Open(nil, &gorm.Config{})
+			   mockLotus := testutil.NewMockLotusClient()
+			   wallets, err := ListWithBalanceHandler(ctx, badDB, mockLotus)
+			   require.Error(t, err)
+			   require.Nil(t, wallets)
+	   })
 	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
-		t.Run("success", func(t *testing.T) {
-			err := db.Create(&model.Wallet{}).Error
-			require.NoError(t, err)
-			wallets, err := Default.ListHandler(ctx, db)
-			require.NoError(t, err)
-			require.Len(t, wallets, 1)
-		})
+		// Insert a wallet with a different valid address
+		w := model.Wallet{Address: "f1abcde7zd3lfsv43aj2kb454ymaqw7debhumjxyz"}
+		err := db.Create(&w).Error
+		require.NoError(t, err)
+
+		// Set up mock Lotus client
+		mockLotus := testutil.NewMockLotusClient()
+		mockLotus.SetResponse("Filecoin.WalletBalance", "1000000000000000000") // 1 FIL
+		mockLotus.SetResponse("Filecoin.StateVerifiedClientStatus", "0")
+
+		wallets, err := ListWithBalanceHandler(ctx, db, mockLotus)
+		require.NoError(t, err)
+		require.Len(t, wallets, 1)
+		require.Equal(t, "1.000000 FIL", wallets[0].Balance)
+		require.Equal(t, "1000000000000000000", wallets[0].BalanceAttoFIL)
+		require.Equal(t, "0", wallets[0].DataCap)
 	})
 }


### PR DESCRIPTION
**Description:**
This PR updates and refactors the wallet and handler logic to improve troubleshooting and integration with Lotus for wallet balance queries. Key changes include:

- Refactored [testutil.go]to ensure test mocks do not interfere with CLI or integration runs, allowing real Lotus balance queries when required.
- Updated wallet handler and CLI logic to better support the --with-balance flag, ensuring balances are fetched from Lotus when API and token are provided.
- Improved error handling and documentation in wallet-related commands and handlers.
- Updated and clarified CLI documentation for wallet commands, including usage of the --with-balance flag and Lotus API requirements.
- Added and updated tests to cover edge cases and integration scenarios for wallet balance retrieval.
- Excluded sensitive or user-specific files (e.g., my_keys.txt) from the commit.
**This PR is intended to:**
- Enable more reliable troubleshooting of Lotus integration issues.
- Allow balances to be displayed for real addresses when running the CLI with the correct Lotus API and token.
- Prepare the codebase for further debugging and improvements related to wallet and Lotus connectivity.

**How to test:**

- Run singularity wallet list --with-balance --lotus-api <API_URL> --lotus-token <TOKEN> to verify balances are fetched from Lotus.
- Run the test suite to ensure all wallet and handler tests pass.
- Review updated documentation for clarity on wallet command usage.