### PR TITLE
make json flag discoverable

### DIFF
--- a/cmd/dataprep/list.go
+++ b/cmd/dataprep/list.go
@@ -12,6 +12,12 @@ var ListCmd = &cli.Command{
 	Name:     "list",
 	Usage:    "List all preparations",
 	Category: "Preparation Management",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "json",
+			Usage: "Enable JSON output",
+		},
+	},
 	Action: func(c *cli.Context) error {
 		db, closer, err := database.OpenFromCLI(c)
 		if err != nil {


### PR DESCRIPTION
Fixes https://github.com/data-preservation-programs/singularity/issues/558

The implementation was already there through the global `--json` flag.
However, this wasn't discoverable because the flag only appeared in global help, not in prep list --help

I added a local --json flag to the prep list command, which now provides both usage patterns:

```
  singularity prep list --json
```

```
  singularity --json prep list
```


The existing cliutil.Print() function already handled JSON formatting correctly via c.Bool("json"), so no additional logic was needed.

