### PR TITLE
Fix/cascade

### DIFF
--- a/cmd/admin/migrate.go
+++ b/cmd/admin/migrate.go
@@ -101,7 +101,7 @@ var MigrateCmd = &cli.Command{
 				if err != nil {
 					return errors.WithStack(err)
 				}
-				fmt.Printf("Current migration: " + last + "\n")
+                fmt.Printf("Current migration: %s\n", last)
 				return nil
 			},
 		},

--- a/handler/dataprep/remove_test.go
+++ b/handler/dataprep/remove_test.go
@@ -2,9 +2,11 @@ package dataprep
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/data-preservation-programs/singularity/handler/handlererror"
 	"github.com/data-preservation-programs/singularity/model"
@@ -108,5 +110,72 @@ func TestRemovePreparationHandler_Success(t *testing.T) {
 		entries, err := os.ReadDir(tmp)
 		require.NoError(t, err)
 		require.Len(t, entries, 0)
+	})
+}
+
+// postgres-only: used to hang on delete due to duplicate cascade paths
+// test the handler path and fail fast if it blocks, dialect branch is intentional
+func TestRemovePreparationHandler_CascadeCycle_Postgres(t *testing.T) {
+	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
+		if db.Dialector.Name() != "postgres" {
+			t.Skip("Skip non-Postgres dialect")
+			return
+		}
+		prep := model.Preparation{Name: "pg-prep"}
+		require.NoError(t, db.Create(&prep).Error)
+		tmpPg := t.TempDir()
+		stor := model.Storage{Name: "pg-storage", Type: "local", Path: tmpPg}
+		require.NoError(t, db.Create(&stor).Error)
+		sa := model.SourceAttachment{PreparationID: prep.ID, StorageID: stor.ID}
+		require.NoError(t, db.Create(&sa).Error)
+		root := model.Directory{AttachmentID: sa.ID, Name: "", ParentID: nil}
+		require.NoError(t, db.Create(&root).Error)
+		d1 := model.Directory{AttachmentID: sa.ID, Name: "sub", ParentID: &root.ID}
+		require.NoError(t, db.Create(&d1).Error)
+		f := model.File{AttachmentID: sa.ID, DirectoryID: &d1.ID, Path: "sub/a.txt", Size: 1}
+		require.NoError(t, db.Create(&f).Error)
+		fr := model.FileRange{FileID: f.ID, Offset: 0, Length: 1}
+		require.NoError(t, db.Create(&fr).Error)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- Default.RemovePreparationHandler(ctx, db, fmt.Sprintf("%d", prep.ID), RemoveRequest{})
+		}()
+
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(3 * time.Second):
+			t.Fatal("DELETE hung (deadlock) on Postgres")
+		}
+	})
+}
+
+// mysql-only: innodb used to reject the delete with duplicate cascade paths
+// test the handler path and expect success, dialect branch is intentional
+func TestRemovePreparationHandler_CascadeCycle_MySQL(t *testing.T) {
+	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
+		if db.Dialector.Name() != "mysql" {
+			t.Skip("Skip non-MySQL dialect")
+			return
+		}
+		prep := model.Preparation{Name: "my-prep"}
+		require.NoError(t, db.Create(&prep).Error)
+		tmpMy := t.TempDir()
+		stor := model.Storage{Name: "my-storage", Type: "local", Path: tmpMy}
+		require.NoError(t, db.Create(&stor).Error)
+		sa := model.SourceAttachment{PreparationID: prep.ID, StorageID: stor.ID}
+		require.NoError(t, db.Create(&sa).Error)
+		root := model.Directory{AttachmentID: sa.ID, Name: "", ParentID: nil}
+		require.NoError(t, db.Create(&root).Error)
+		d1 := model.Directory{AttachmentID: sa.ID, Name: "sub", ParentID: &root.ID}
+		require.NoError(t, db.Create(&d1).Error)
+		f := model.File{AttachmentID: sa.ID, DirectoryID: &d1.ID, Path: "sub/a.txt", Size: 1}
+		require.NoError(t, db.Create(&f).Error)
+		fr := model.FileRange{FileID: f.ID, Offset: 0, Length: 1}
+		require.NoError(t, db.Create(&fr).Error)
+
+		err := Default.RemovePreparationHandler(ctx, db, fmt.Sprintf("%d", prep.ID), RemoveRequest{})
+		require.NoError(t, err)
 	})
 }

--- a/migrate/migrations/202509171710_wallet_assignments_cascade.go
+++ b/migrate/migrations/202509171710_wallet_assignments_cascade.go
@@ -1,0 +1,75 @@
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/pkg/errors"
+	"gorm.io/gorm"
+)
+
+func _202509171710_wallet_assignments_cascade() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "202509171710",
+		Migrate: func(tx *gorm.DB) error {
+			if tx.Dialector.Name() == "postgres" {
+				if err := tx.Exec("ALTER TABLE wallet_assignments DROP CONSTRAINT IF EXISTS fk_wallet_assignments_preparation").Error; err != nil {
+					return errors.Wrap(err, "drop fk_wallet_assignments_preparation")
+				}
+				if err := tx.Exec("ALTER TABLE wallet_assignments ADD CONSTRAINT fk_wallet_assignments_preparation FOREIGN KEY (preparation_id) REFERENCES preparations(id) ON DELETE CASCADE").Error; err != nil {
+					return errors.Wrap(err, "add fk_wallet_assignments_preparation cascade")
+				}
+				if err := tx.Exec("ALTER TABLE wallet_assignments DROP CONSTRAINT IF EXISTS fk_wallet_assignments_wallet").Error; err != nil {
+					return errors.Wrap(err, "drop fk_wallet_assignments_wallet")
+				}
+				if err := tx.Exec("ALTER TABLE wallet_assignments ADD CONSTRAINT fk_wallet_assignments_wallet FOREIGN KEY (wallet_id) REFERENCES wallets(id) ON DELETE CASCADE").Error; err != nil {
+					return errors.Wrap(err, "add fk_wallet_assignments_wallet cascade")
+				}
+				return nil
+			}
+			if tx.Dialector.Name() == "mysql" {
+				if err := tx.Exec("ALTER TABLE wallet_assignments DROP FOREIGN KEY fk_wallet_assignments_preparation").Error; err != nil {
+				}
+				if err := tx.Exec("ALTER TABLE wallet_assignments ADD CONSTRAINT fk_wallet_assignments_preparation FOREIGN KEY (preparation_id) REFERENCES preparations(id) ON DELETE CASCADE").Error; err != nil {
+					return errors.Wrap(err, "add fk_wallet_assignments_preparation cascade (mysql)")
+				}
+				if err := tx.Exec("ALTER TABLE wallet_assignments DROP FOREIGN KEY fk_wallet_assignments_wallet").Error; err != nil {
+				}
+				if err := tx.Exec("ALTER TABLE wallet_assignments ADD CONSTRAINT fk_wallet_assignments_wallet FOREIGN KEY (wallet_id) REFERENCES wallets(id) ON DELETE CASCADE").Error; err != nil {
+					return errors.Wrap(err, "add fk_wallet_assignments_wallet cascade (mysql)")
+				}
+				return nil
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			if tx.Dialector.Name() == "postgres" {
+				if err := tx.Exec("ALTER TABLE wallet_assignments DROP CONSTRAINT IF EXISTS fk_wallet_assignments_preparation").Error; err != nil {
+					return errors.Wrap(err, "drop fk_wallet_assignments_preparation (rollback)")
+				}
+				if err := tx.Exec("ALTER TABLE wallet_assignments ADD CONSTRAINT fk_wallet_assignments_preparation FOREIGN KEY (preparation_id) REFERENCES preparations(id) ON DELETE NO ACTION").Error; err != nil {
+					return errors.Wrap(err, "add fk_wallet_assignments_preparation no action (rollback)")
+				}
+				if err := tx.Exec("ALTER TABLE wallet_assignments DROP CONSTRAINT IF EXISTS fk_wallet_assignments_wallet").Error; err != nil {
+					return errors.Wrap(err, "drop fk_wallet_assignments_wallet (rollback)")
+				}
+				if err := tx.Exec("ALTER TABLE wallet_assignments ADD CONSTRAINT fk_wallet_assignments_wallet FOREIGN KEY (wallet_id) REFERENCES wallets(id) ON DELETE NO ACTION").Error; err != nil {
+					return errors.Wrap(err, "add fk_wallet_assignments_wallet no action (rollback)")
+				}
+				return nil
+			}
+			if tx.Dialector.Name() == "mysql" {
+				if err := tx.Exec("ALTER TABLE wallet_assignments DROP FOREIGN KEY fk_wallet_assignments_preparation").Error; err != nil {
+				}
+				if err := tx.Exec("ALTER TABLE wallet_assignments ADD CONSTRAINT fk_wallet_assignments_preparation FOREIGN KEY (preparation_id) REFERENCES preparations(id)").Error; err != nil {
+					return errors.Wrap(err, "add fk_wallet_assignments_preparation no action (mysql rollback)")
+				}
+				if err := tx.Exec("ALTER TABLE wallet_assignments DROP FOREIGN KEY fk_wallet_assignments_wallet").Error; err != nil {
+				}
+				if err := tx.Exec("ALTER TABLE wallet_assignments ADD CONSTRAINT fk_wallet_assignments_wallet FOREIGN KEY (wallet_id) REFERENCES wallets(id)").Error; err != nil {
+					return errors.Wrap(err, "add fk_wallet_assignments_wallet no action (mysql rollback)")
+				}
+				return nil
+			}
+			return nil
+		},
+	}
+}

--- a/migrate/migrations/202509171710_wallet_assignments_cascade.go
+++ b/migrate/migrations/202509171710_wallet_assignments_cascade.go
@@ -7,10 +7,12 @@ import (
 )
 
 func _202509171710_wallet_assignments_cascade() *gormigrate.Migration {
+	// set wallet_assignments fks to cascade on delete, otherwise preparations with wallets cannot be deleted
 	return &gormigrate.Migration{
 		ID: "202509171710",
 		Migrate: func(tx *gorm.DB) error {
 			if tx.Dialector.Name() == "postgres" {
+				// switch to cascade for preparation and wallet fks in postgres
 				if err := tx.Exec("ALTER TABLE wallet_assignments DROP CONSTRAINT IF EXISTS fk_wallet_assignments_preparation").Error; err != nil {
 					return errors.Wrap(err, "drop fk_wallet_assignments_preparation")
 				}
@@ -26,6 +28,7 @@ func _202509171710_wallet_assignments_cascade() *gormigrate.Migration {
 				return nil
 			}
 			if tx.Dialector.Name() == "mysql" {
+				// align mysql fks to cascade semantics
 				if err := tx.Exec("ALTER TABLE wallet_assignments DROP FOREIGN KEY fk_wallet_assignments_preparation").Error; err != nil {
 				}
 				if err := tx.Exec("ALTER TABLE wallet_assignments ADD CONSTRAINT fk_wallet_assignments_preparation FOREIGN KEY (preparation_id) REFERENCES preparations(id) ON DELETE CASCADE").Error; err != nil {
@@ -42,6 +45,7 @@ func _202509171710_wallet_assignments_cascade() *gormigrate.Migration {
 		},
 		Rollback: func(tx *gorm.DB) error {
 			if tx.Dialector.Name() == "postgres" {
+				// revert to no action to match previous behavior
 				if err := tx.Exec("ALTER TABLE wallet_assignments DROP CONSTRAINT IF EXISTS fk_wallet_assignments_preparation").Error; err != nil {
 					return errors.Wrap(err, "drop fk_wallet_assignments_preparation (rollback)")
 				}
@@ -57,6 +61,7 @@ func _202509171710_wallet_assignments_cascade() *gormigrate.Migration {
 				return nil
 			}
 			if tx.Dialector.Name() == "mysql" {
+				// revert mysql fks back to no action equivalent
 				if err := tx.Exec("ALTER TABLE wallet_assignments DROP FOREIGN KEY fk_wallet_assignments_preparation").Error; err != nil {
 				}
 				if err := tx.Exec("ALTER TABLE wallet_assignments ADD CONSTRAINT fk_wallet_assignments_preparation FOREIGN KEY (preparation_id) REFERENCES preparations(id)").Error; err != nil {

--- a/migrate/migrations/202509171745_files_attachment_no_cascade.go
+++ b/migrate/migrations/202509171745_files_attachment_no_cascade.go
@@ -1,56 +1,53 @@
 package migrations
 
 import (
-    "github.com/go-gormigrate/gormigrate/v2"
-    "github.com/pkg/errors"
-    "gorm.io/gorm"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/pkg/errors"
+	"gorm.io/gorm"
 )
 
 func _202509171745_files_attachment_no_cascade() *gormigrate.Migration {
-    return &gormigrate.Migration{
-        ID: "202509171745",
-        Migrate: func(tx *gorm.DB) error {
-            if tx.Dialector.Name() == "postgres" {
-                if err := tx.Exec("ALTER TABLE files DROP CONSTRAINT IF EXISTS fk_files_attachment").Error; err != nil {
-                    return errors.Wrap(err, "drop fk_files_attachment")
-                }
-                if err := tx.Exec("ALTER TABLE files ADD CONSTRAINT fk_files_attachment FOREIGN KEY (attachment_id) REFERENCES source_attachments(id) ON DELETE NO ACTION").Error; err != nil {
-                    return errors.Wrap(err, "add fk_files_attachment no action")
-                }
-                return nil
-            }
-            if tx.Dialector.Name() == "mysql" {
-                // MySQL treats NO ACTION as RESTRICT; omit ON DELETE to use default (RESTRICT)
-                if err := tx.Exec("ALTER TABLE files DROP FOREIGN KEY fk_files_attachment").Error; err != nil {
-                }
-                if err := tx.Exec("ALTER TABLE files ADD CONSTRAINT fk_files_attachment FOREIGN KEY (attachment_id) REFERENCES source_attachments(id)").Error; err != nil {
-                    return errors.Wrap(err, "add fk_files_attachment restrict (mysql)")
-                }
-                return nil
-            }
-            return nil
-        },
-        Rollback: func(tx *gorm.DB) error {
-            if tx.Dialector.Name() == "postgres" {
-                if err := tx.Exec("ALTER TABLE files DROP CONSTRAINT IF EXISTS fk_files_attachment").Error; err != nil {
-                    return errors.Wrap(err, "drop fk_files_attachment (rollback)")
-                }
-                if err := tx.Exec("ALTER TABLE files ADD CONSTRAINT fk_files_attachment FOREIGN KEY (attachment_id) REFERENCES source_attachments(id) ON DELETE CASCADE").Error; err != nil {
-                    return errors.Wrap(err, "add fk_files_attachment cascade (rollback)")
-                }
-                return nil
-            }
-            if tx.Dialector.Name() == "mysql" {
-                if err := tx.Exec("ALTER TABLE files DROP FOREIGN KEY fk_files_attachment").Error; err != nil {
-                }
-                if err := tx.Exec("ALTER TABLE files ADD CONSTRAINT fk_files_attachment FOREIGN KEY (attachment_id) REFERENCES source_attachments(id) ON DELETE CASCADE").Error; err != nil {
-                    return errors.Wrap(err, "add fk_files_attachment cascade (mysql rollback)")
-                }
-                return nil
-            }
-            return nil
-        },
-    }
+	return &gormigrate.Migration{
+		ID: "202509171745",
+		Migrate: func(tx *gorm.DB) error {
+			if tx.Dialector.Name() == "postgres" {
+				if err := tx.Exec("ALTER TABLE files DROP CONSTRAINT IF EXISTS fk_files_attachment").Error; err != nil {
+					return errors.Wrap(err, "drop fk_files_attachment")
+				}
+				if err := tx.Exec("ALTER TABLE files ADD CONSTRAINT fk_files_attachment FOREIGN KEY (attachment_id) REFERENCES source_attachments(id) ON DELETE NO ACTION").Error; err != nil {
+					return errors.Wrap(err, "add fk_files_attachment no action")
+				}
+				return nil
+			}
+			if tx.Dialector.Name() == "mysql" {
+				if err := tx.Exec("ALTER TABLE files DROP FOREIGN KEY fk_files_attachment").Error; err != nil {
+				}
+				if err := tx.Exec("ALTER TABLE files ADD CONSTRAINT fk_files_attachment FOREIGN KEY (attachment_id) REFERENCES source_attachments(id) ON DELETE RESTRICT").Error; err != nil {
+					return errors.Wrap(err, "add fk_files_attachment restrict (mysql)")
+				}
+				return nil
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			if tx.Dialector.Name() == "postgres" {
+				if err := tx.Exec("ALTER TABLE files DROP CONSTRAINT IF EXISTS fk_files_attachment").Error; err != nil {
+					return errors.Wrap(err, "drop fk_files_attachment (rollback)")
+				}
+				if err := tx.Exec("ALTER TABLE files ADD CONSTRAINT fk_files_attachment FOREIGN KEY (attachment_id) REFERENCES source_attachments(id) ON DELETE CASCADE").Error; err != nil {
+					return errors.Wrap(err, "add fk_files_attachment cascade (rollback)")
+				}
+				return nil
+			}
+			if tx.Dialector.Name() == "mysql" {
+				if err := tx.Exec("ALTER TABLE files DROP FOREIGN KEY fk_files_attachment").Error; err != nil {
+				}
+				if err := tx.Exec("ALTER TABLE files ADD CONSTRAINT fk_files_attachment FOREIGN KEY (attachment_id) REFERENCES source_attachments(id) ON DELETE CASCADE").Error; err != nil {
+					return errors.Wrap(err, "add fk_files_attachment cascade (mysql rollback)")
+				}
+				return nil
+			}
+			return nil
+		},
+	}
 }
-
-

--- a/migrate/migrations/202509171745_files_attachment_no_cascade.go
+++ b/migrate/migrations/202509171745_files_attachment_no_cascade.go
@@ -1,0 +1,56 @@
+package migrations
+
+import (
+    "github.com/go-gormigrate/gormigrate/v2"
+    "github.com/pkg/errors"
+    "gorm.io/gorm"
+)
+
+func _202509171745_files_attachment_no_cascade() *gormigrate.Migration {
+    return &gormigrate.Migration{
+        ID: "202509171745",
+        Migrate: func(tx *gorm.DB) error {
+            if tx.Dialector.Name() == "postgres" {
+                if err := tx.Exec("ALTER TABLE files DROP CONSTRAINT IF EXISTS fk_files_attachment").Error; err != nil {
+                    return errors.Wrap(err, "drop fk_files_attachment")
+                }
+                if err := tx.Exec("ALTER TABLE files ADD CONSTRAINT fk_files_attachment FOREIGN KEY (attachment_id) REFERENCES source_attachments(id) ON DELETE NO ACTION").Error; err != nil {
+                    return errors.Wrap(err, "add fk_files_attachment no action")
+                }
+                return nil
+            }
+            if tx.Dialector.Name() == "mysql" {
+                // MySQL treats NO ACTION as RESTRICT; omit ON DELETE to use default (RESTRICT)
+                if err := tx.Exec("ALTER TABLE files DROP FOREIGN KEY fk_files_attachment").Error; err != nil {
+                }
+                if err := tx.Exec("ALTER TABLE files ADD CONSTRAINT fk_files_attachment FOREIGN KEY (attachment_id) REFERENCES source_attachments(id)").Error; err != nil {
+                    return errors.Wrap(err, "add fk_files_attachment restrict (mysql)")
+                }
+                return nil
+            }
+            return nil
+        },
+        Rollback: func(tx *gorm.DB) error {
+            if tx.Dialector.Name() == "postgres" {
+                if err := tx.Exec("ALTER TABLE files DROP CONSTRAINT IF EXISTS fk_files_attachment").Error; err != nil {
+                    return errors.Wrap(err, "drop fk_files_attachment (rollback)")
+                }
+                if err := tx.Exec("ALTER TABLE files ADD CONSTRAINT fk_files_attachment FOREIGN KEY (attachment_id) REFERENCES source_attachments(id) ON DELETE CASCADE").Error; err != nil {
+                    return errors.Wrap(err, "add fk_files_attachment cascade (rollback)")
+                }
+                return nil
+            }
+            if tx.Dialector.Name() == "mysql" {
+                if err := tx.Exec("ALTER TABLE files DROP FOREIGN KEY fk_files_attachment").Error; err != nil {
+                }
+                if err := tx.Exec("ALTER TABLE files ADD CONSTRAINT fk_files_attachment FOREIGN KEY (attachment_id) REFERENCES source_attachments(id) ON DELETE CASCADE").Error; err != nil {
+                    return errors.Wrap(err, "add fk_files_attachment cascade (mysql rollback)")
+                }
+                return nil
+            }
+            return nil
+        },
+    }
+}
+
+

--- a/migrate/migrations/202509171745_files_attachment_no_cascade.go
+++ b/migrate/migrations/202509171745_files_attachment_no_cascade.go
@@ -7,10 +7,14 @@ import (
 )
 
 func _202509171745_files_attachment_no_cascade() *gormigrate.Migration {
+	// fixes deadlock that occurs when deleting preparation due to multiple cascade paths
+	// we do this instead of making files.attachment_id nullable to keep value types (NULLABLE implies pointer in gorm)
 	return &gormigrate.Migration{
 		ID: "202509171745",
 		Migrate: func(tx *gorm.DB) error {
 			if tx.Dialector.Name() == "postgres" {
+				//  set null on fk then rely on trigger to clean up orphans
+				// postgres is more restrictive than InnoDB so we have to do this manually
 				if err := tx.Exec("ALTER TABLE files ALTER COLUMN attachment_id DROP NOT NULL").Error; err != nil {
 					return errors.Wrap(err, "make files.attachment_id nullable")
 				}
@@ -20,7 +24,7 @@ func _202509171745_files_attachment_no_cascade() *gormigrate.Migration {
 				if err := tx.Exec("ALTER TABLE files ADD CONSTRAINT fk_files_attachment FOREIGN KEY (attachment_id) REFERENCES source_attachments(id) ON DELETE SET NULL").Error; err != nil {
 					return errors.Wrap(err, "add fk_files_attachment set null")
 				}
-				
+
 				if err := tx.Exec(`
 					CREATE OR REPLACE FUNCTION delete_orphan_files() RETURNS trigger AS $$
 					BEGIN
@@ -32,11 +36,11 @@ func _202509171745_files_attachment_no_cascade() *gormigrate.Migration {
 				`).Error; err != nil {
 					return errors.Wrap(err, "create delete_orphan_files function")
 				}
-				
+
 				if err := tx.Exec("DROP TRIGGER IF EXISTS trg_delete_orphan_files ON files").Error; err != nil {
 					return errors.Wrap(err, "drop existing trigger")
 				}
-				
+
 				if err := tx.Exec(`
 					CREATE TRIGGER trg_delete_orphan_files
 					AFTER UPDATE OF attachment_id ON files
@@ -46,10 +50,11 @@ func _202509171745_files_attachment_no_cascade() *gormigrate.Migration {
 				`).Error; err != nil {
 					return errors.Wrap(err, "create trigger")
 				}
-				
+
 				return nil
 			}
 			if tx.Dialector.Name() == "mysql" {
+				// mysql uses restrict to emulate no cascade behavior here
 				if err := tx.Exec("ALTER TABLE files DROP FOREIGN KEY fk_files_attachment").Error; err != nil {
 				}
 				if err := tx.Exec("ALTER TABLE files ADD CONSTRAINT fk_files_attachment FOREIGN KEY (attachment_id) REFERENCES source_attachments(id) ON DELETE RESTRICT").Error; err != nil {
@@ -61,6 +66,7 @@ func _202509171745_files_attachment_no_cascade() *gormigrate.Migration {
 		},
 		Rollback: func(tx *gorm.DB) error {
 			if tx.Dialector.Name() == "postgres" {
+				// remove trigger and function then restore previous not null and no action fk
 				if err := tx.Exec("DROP TRIGGER IF EXISTS trg_delete_orphan_files ON files").Error; err != nil {
 					return errors.Wrap(err, "drop trigger (rollback)")
 				}
@@ -79,6 +85,7 @@ func _202509171745_files_attachment_no_cascade() *gormigrate.Migration {
 				return nil
 			}
 			if tx.Dialector.Name() == "mysql" {
+				// restore mysql cascade to match previous behavior on rollback
 				if err := tx.Exec("ALTER TABLE files DROP FOREIGN KEY fk_files_attachment").Error; err != nil {
 				}
 				if err := tx.Exec("ALTER TABLE files ADD CONSTRAINT fk_files_attachment FOREIGN KEY (attachment_id) REFERENCES source_attachments(id) ON DELETE CASCADE").Error; err != nil {

--- a/migrate/migrations/migrations.go
+++ b/migrate/migrations/migrations.go
@@ -17,5 +17,6 @@ func GetMigrations() []*gormigrate.Migration {
 		_202507091100_add_tracked_wallet_type(),
 		_202507180900_create_deal_state_changes(),
 		_202507180930_create_error_logs(),
+		_202509171710_wallet_assignments_cascade(),
 	}
 }

--- a/migrate/migrations/migrations.go
+++ b/migrate/migrations/migrations.go
@@ -18,5 +18,6 @@ func GetMigrations() []*gormigrate.Migration {
 		_202507180900_create_deal_state_changes(),
 		_202507180930_create_error_logs(),
 		_202509171710_wallet_assignments_cascade(),
+        _202509171745_files_attachment_no_cascade(),
 	}
 }

--- a/model/preparation.go
+++ b/model/preparation.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"encoding/json"
+
 	"github.com/cockroachdb/errors"
 	"github.com/ipfs/go-cid"
 	"gorm.io/gorm"
@@ -142,7 +143,7 @@ type Preparation struct {
 
 	// Associations
 	DealTemplate   *DealTemplate `gorm:"foreignKey:DealTemplateID;constraint:OnDelete:SET NULL" json:"dealTemplate,omitempty"   swaggerignore:"true"                   table:"expand"`
-	Wallets        []Wallet      `gorm:"many2many:wallet_assignments"                             json:"wallets,omitempty"        swaggerignore:"true"                   table:"expand"`
+	Wallets        []Wallet      `gorm:"many2many:wallet_assignments;constraint:OnDelete:CASCADE" json:"wallets,omitempty"        swaggerignore:"true"                   table:"expand"`
 	SourceStorages []Storage     `gorm:"many2many:source_attachments;constraint:OnDelete:CASCADE" json:"sourceStorages,omitempty" table:"expand;header:Source Storages:"`
 	OutputStorages []Storage     `gorm:"many2many:output_attachments;constraint:OnDelete:CASCADE" json:"outputStorages,omitempty" table:"expand;header:Output Storages:"`
 }

--- a/model/preparation.go
+++ b/model/preparation.go
@@ -302,7 +302,7 @@ type File struct {
 
 	// Associations
 	AttachmentID SourceAttachmentID `cbor:"-" json:"attachmentId"`
-	Attachment   *SourceAttachment  `cbor:"-" gorm:"foreignKey:AttachmentID;constraint:OnDelete:CASCADE" json:"attachment,omitempty" swaggerignore:"true"`
+	Attachment   *SourceAttachment  `cbor:"-" gorm:"foreignKey:AttachmentID" json:"attachment,omitempty" swaggerignore:"true"`
 	DirectoryID  *DirectoryID       `cbor:"-" gorm:"index"                                               json:"directoryId"`
 	Directory    *Directory         `cbor:"-" gorm:"foreignKey:DirectoryID;constraint:OnDelete:CASCADE"  json:"directory,omitempty"  swaggerignore:"true"`
 	FileRanges   []FileRange        `cbor:"-" gorm:"constraint:OnDelete:CASCADE"                         json:"fileRanges,omitempty"`

--- a/model/preparation.go
+++ b/model/preparation.go
@@ -303,9 +303,9 @@ type File struct {
 	// Associations
 	AttachmentID SourceAttachmentID `cbor:"-" json:"attachmentId"`
 	Attachment   *SourceAttachment  `cbor:"-" gorm:"foreignKey:AttachmentID" json:"attachment,omitempty" swaggerignore:"true"`
-	DirectoryID  *DirectoryID       `cbor:"-" gorm:"index"                                               json:"directoryId"`
-	Directory    *Directory         `cbor:"-" gorm:"foreignKey:DirectoryID;constraint:OnDelete:CASCADE"  json:"directory,omitempty"  swaggerignore:"true"`
-	FileRanges   []FileRange        `cbor:"-" gorm:"constraint:OnDelete:CASCADE"                         json:"fileRanges,omitempty"`
+	DirectoryID  *DirectoryID        `cbor:"-" gorm:"index"                                               json:"directoryId"`
+	Directory    *Directory          `cbor:"-" gorm:"foreignKey:DirectoryID;constraint:OnDelete:CASCADE"  json:"directory,omitempty"  swaggerignore:"true"`
+	FileRanges   []FileRange         `cbor:"-" gorm:"constraint:OnDelete:CASCADE"                         json:"fileRanges,omitempty"`
 }
 
 func (i File) FileName() string {


### PR DESCRIPTION
fix postgres fk cascade deadlocks with set null + trigger approach
this addresses the postgres-specific foreign key constraint violations when deleting
preparations by implementing a database-level solution that:

1. makes files.attachment_id nullable
2. changes the fk constraint to ON DELETE SET NULL instead of restrict/no action
3. adds a postgres trigger that immediately deletes files when attachment_id becomes null

this approach keeps the application model unchanged (no pointer types) while solving
the constraint violation. the trigger ensures the app never sees null attachment_id
values so behavior stays consistent.

the solution is postgres-specific because:
- postgres has stricter fk enforcement that causes the deadlock/violation issues
- mysql tests were already passing with the existing restrict behavior
- we removed cascade deletes in https://github.com/data-preservation-programs/singularity/commit/640154ea7370989023d74a04d5692a8065f4e49a to avoid deadlocks, but that created
  the constraint violation when deleting preparations

longer term consideration: files conceptually belong to storages not preparations.
attachments are just prep<->storage associations. we might want to remove this fk
entirely since files should be storage-scoped and reusable across preparations
(expensive to re-scan). this would eliminate the cascade issues entirely while
enabling file reuse when recreating preparations with the same storage.

this resolves two issues that prevent deletion of preparations. fixes #465 