### PR TITLE
improve lotus API test survivability

### DIFF
--- a/handler/wallet/import_test.go
+++ b/handler/wallet/import_test.go
@@ -13,8 +13,9 @@ import (
 )
 
 func TestImportHandler(t *testing.T) {
+	testutil.SkipIfNotExternalAPI(t)
 	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
-		lotusClient := util.NewLotusClient("https://api.node.glif.io/rpc/v0", "")
+		lotusClient := util.NewLotusClient(testutil.TestLotusAPI, "")
 
 		t.Run("success", func(t *testing.T) {
 			w, err := Default.ImportHandler(ctx, db, lotusClient, ImportRequest{

--- a/service/dealpusher/dealpusher_test.go
+++ b/service/dealpusher/dealpusher_test.go
@@ -64,7 +64,7 @@ func (m *MockDealMaker) MakeDeal(ctx context.Context, walletObj model.Wallet, ca
 
 func TestDealMakerService_Start(t *testing.T) {
 	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
-		service, err := NewDealPusher(db, "https://api.node.glif.io", "", 1, 10)
+		service, err := NewDealPusher(db, testutil.TestLotusAPI, "", 1, 10)
 		require.NoError(t, err)
 		ctx, cancel := context.WithCancel(ctx)
 		exitErr := make(chan error, 1)
@@ -78,9 +78,9 @@ func TestDealMakerService_Start(t *testing.T) {
 
 func TestDealMakerService_MultipleInstances(t *testing.T) {
 	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
-		service1, err := NewDealPusher(db, "https://api.node.glif.io", "", 1, 10)
+		service1, err := NewDealPusher(db, testutil.TestLotusAPI, "", 1, 10)
 		require.NoError(t, err)
-		service2, err := NewDealPusher(db, "https://api.node.glif.io", "", 1, 10)
+		service2, err := NewDealPusher(db, testutil.TestLotusAPI, "", 1, 10)
 		require.NoError(t, err)
 		ctx, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
@@ -99,7 +99,7 @@ func TestDealMakerService_FailtoSend(t *testing.T) {
 		waitPendingInterval = time.Minute
 	}()
 	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
-		service, err := NewDealPusher(db, "https://api.node.glif.io", "", 2, 0)
+		service, err := NewDealPusher(db, testutil.TestLotusAPI, "", 2, 0)
 		require.NoError(t, err)
 		mockDealmaker := new(MockDealMaker)
 		service.dealMaker = mockDealmaker
@@ -153,7 +153,7 @@ func TestDealMakerService_Cron(t *testing.T) {
 		waitPendingInterval = time.Minute
 	}()
 	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
-		service, err := NewDealPusher(db, "https://api.node.glif.io", "", 1, 10)
+		service, err := NewDealPusher(db, testutil.TestLotusAPI, "", 1, 10)
 		require.NoError(t, err)
 		mockDealmaker := new(MockDealMaker)
 		service.dealMaker = mockDealmaker
@@ -250,7 +250,7 @@ func TestDealMakerService_ScheduleWithConstraints(t *testing.T) {
 		waitPendingInterval = time.Minute
 	}()
 	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
-		service, err := NewDealPusher(db, "https://api.node.glif.io", "", 1, 10)
+		service, err := NewDealPusher(db, testutil.TestLotusAPI, "", 1, 10)
 		require.NoError(t, err)
 		mockDealmaker := new(MockDealMaker)
 		service.dealMaker = mockDealmaker
@@ -359,7 +359,7 @@ func TestDealMakerService_ScheduleWithConstraints(t *testing.T) {
 
 func TestDealmakerService_Force(t *testing.T) {
 	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
-		service, err := NewDealPusher(db, "https://api.node.glif.io", "", 1, 10)
+		service, err := NewDealPusher(db, testutil.TestLotusAPI, "", 1, 10)
 		require.NoError(t, err)
 		mockDealmaker := new(MockDealMaker)
 		service.dealMaker = mockDealmaker
@@ -418,7 +418,7 @@ func TestDealmakerService_Force(t *testing.T) {
 
 func TestDealMakerService_MaxReplica(t *testing.T) {
 	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
-		service, err := NewDealPusher(db, "https://api.node.glif.io", "", 1, 1)
+		service, err := NewDealPusher(db, testutil.TestLotusAPI, "", 1, 1)
 		require.NoError(t, err)
 		mockDealmaker := new(MockDealMaker)
 		service.dealMaker = mockDealmaker
@@ -475,7 +475,7 @@ func TestDealMakerService_MaxReplica(t *testing.T) {
 
 func TestDealMakerService_NewScheduleOneOff(t *testing.T) {
 	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
-		service, err := NewDealPusher(db, "https://api.node.glif.io", "", 1, 10)
+		service, err := NewDealPusher(db, testutil.TestLotusAPI, "", 1, 10)
 		require.NoError(t, err)
 		mockDealmaker := new(MockDealMaker)
 		service.dealMaker = mockDealmaker

--- a/service/dealtracker/dealtracker_test.go
+++ b/service/dealtracker/dealtracker_test.go
@@ -150,6 +150,7 @@ func TestTrackDeal(t *testing.T) {
 }
 
 func TestRunOnce(t *testing.T) {
+	testutil.SkipIfNotExternalAPI(t)
 	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
 		err := db.Create(&model.Wallet{
 			ID:      "t0100",
@@ -337,7 +338,7 @@ func TestRunOnce(t *testing.T) {
 		url, server := setupTestServerWithBody(t, string(body))
 		defer server.Close()
 		require.NoError(t, err)
-		tracker := NewDealTracker(db, time.Minute, url, "https://api.node.glif.io/", "", true)
+		tracker := NewDealTracker(db, time.Minute, url, testutil.TestLotusAPI, "", true)
 		err = tracker.runOnce(context.Background())
 		require.NoError(t, err)
 		var allDeals []model.Deal

--- a/service/epochutil/epoch_test.go
+++ b/service/epochutil/epoch_test.go
@@ -4,24 +4,25 @@ import (
 	"context"
 	"testing"
 
+	"github.com/data-preservation-programs/singularity/util/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultValue(t *testing.T) {
-	err := Initialize(context.Background(), "https://api.node.glif.io/rpc/v0", "")
+	err := Initialize(context.Background(), testutil.TestLotusAPI, "")
 	require.NoError(t, err)
 	require.EqualValues(t, 1598306400, GenesisTimestamp)
 }
 
 func TestCalibNet(t *testing.T) {
 	// This test may fail when calibnet resets
-	err := Initialize(context.Background(), "https://api.calibration.node.glif.io/rpc/v0", "")
+	err := Initialize(context.Background(), "https://api.calibration.node.glif.io/rpc/v1", "")
 	require.NoError(t, err)
 	require.EqualValues(t, 1667326380, GenesisTimestamp)
 }
 
 func TestEpochToTime(t *testing.T) {
-	err := Initialize(context.Background(), "https://api.node.glif.io/rpc/v0", "")
+	err := Initialize(context.Background(), testutil.TestLotusAPI, "")
 	require.NoError(t, err)
 	require.EqualValues(t, 1598306400, GenesisTimestamp)
 	require.EqualValues(t, 1598306400, EpochToTime(0).Unix())
@@ -29,7 +30,7 @@ func TestEpochToTime(t *testing.T) {
 }
 
 func TestUnixToEpoch(t *testing.T) {
-	err := Initialize(context.Background(), "https://api.node.glif.io/rpc/v0", "")
+	err := Initialize(context.Background(), testutil.TestLotusAPI, "")
 	require.NoError(t, err)
 	require.EqualValues(t, 1598306400, GenesisTimestamp)
 	require.EqualValues(t, 0, UnixToEpoch(1598306400))
@@ -37,7 +38,7 @@ func TestUnixToEpoch(t *testing.T) {
 }
 
 func TestTimeToEpoch(t *testing.T) {
-	err := Initialize(context.Background(), "https://api.node.glif.io/rpc/v0", "")
+	err := Initialize(context.Background(), testutil.TestLotusAPI, "")
 	require.NoError(t, err)
 	require.EqualValues(t, 1598306400, GenesisTimestamp)
 	require.EqualValues(t, 0, TimeToEpoch(EpochToTime(0)))

--- a/util/testutil/testutils.go
+++ b/util/testutil/testutils.go
@@ -55,6 +55,20 @@ const TestWalletAddr = "f1fib3pv7jua2ockdugtz7viz3cyy6lkhh7rfx3sa"
 
 const TestPrivateKeyHex = "7b2254797065223a22736563703235366b31222c22507269766174654b6579223a226b35507976337148327349586343595a58594f5775453149326e32554539436861556b6c4e36695a5763453d227d"
 
+// TestLotusAPI is the Lotus API endpoint to use for tests
+// Using /rpc/v1 (stable) instead of deprecated /rpc/v0
+const TestLotusAPI = "https://api.node.glif.io/rpc/v1"
+
+// SkipIfNotExternalAPI skips the test if SINGULARITY_TEST_EXTERNAL_API is not set
+// Use this for tests that make external API calls (e.g., Lotus/Filecoin APIs)
+// These are skipped by default because external APIs may be unreliable or rate-limited
+func SkipIfNotExternalAPI(t *testing.T) {
+	t.Helper()
+	if os.Getenv("SINGULARITY_TEST_EXTERNAL_API") == "" {
+		t.Skip("Skipping external API test. Set SINGULARITY_TEST_EXTERNAL_API=true to run")
+	}
+}
+
 func EscapePath(p string) string {
 	return "'" + strings.ReplaceAll(p, `\`, `\\`) + "'"
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/data-preservation-programs/singularity/util/testutil"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/rjNemo/underscore"
 	"github.com/stretchr/testify/require"
@@ -23,9 +24,10 @@ func TestNextPowerOfTwo(t *testing.T) {
 }
 
 func TestNewLotusClient(t *testing.T) {
+	testutil.SkipIfNotExternalAPI(t)
 	for _, token := range []string{""} {
 		t.Run(token, func(t *testing.T) {
-			client := NewLotusClient("https://api.node.glif.io/", token)
+			client := NewLotusClient(testutil.TestLotusAPI, token)
 			resp, err := client.Call(context.Background(), "Filecoin.Version")
 			if token != "" {
 				require.Error(t, err)
@@ -39,7 +41,8 @@ func TestNewLotusClient(t *testing.T) {
 }
 
 func TestGetLotusHeadTime(t *testing.T) {
-	headTime, err := GetLotusHeadTime(context.Background(), "https://api.node.glif.io/", "")
+	testutil.SkipIfNotExternalAPI(t)
+	headTime, err := GetLotusHeadTime(context.Background(), testutil.TestLotusAPI, "")
 	require.NoError(t, err)
 	require.NotZero(t, headTime)
 }


### PR DESCRIPTION
- consolidate external testing API url in one var
- use supported API version
- explicitly skip tests unless enabled

after updating the node url these pass intermittently but we really shouldn't rely on it, real fix is a mock service 