### PR TITLE
update runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,7 @@ COPY go.* ./
 RUN go mod download
 COPY . ./
 RUN go build -o singularity .
-FROM debian:bookworm-slim
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl && \
-    rm -rf /var/lib/apt/lists/*
+FROM gcr.io/distroless/cc-debian12
 
 COPY --from=builder /app/singularity /app/singularity
 ENTRYPOINT ["/app/singularity"]


### PR DESCRIPTION
we upgraded the builder image but the runner has older glibc, need to bump to same debian release

while we're at it I'm going to switch us to distroless to slim the image further and hopefully make the builds slightly less glacial in speed