### PR TITLE
Add explicit deal type support for schedules

### DIFF
--- a/client/swagger/models/model_schedule.go
+++ b/client/swagger/models/model_schedule.go
@@ -28,6 +28,9 @@ type ModelSchedule struct {
 	// created at
 	CreatedAt string `json:"createdAt,omitempty"`
 
+	// deal type
+	DealType ModelDealType `json:"dealType,omitempty"`
+
 	// duration
 	Duration int64 `json:"duration,omitempty"`
 
@@ -108,6 +111,10 @@ type ModelSchedule struct {
 func (m *ModelSchedule) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateDealType(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateHTTPHeaders(formats); err != nil {
 		res = append(res, err)
 	}
@@ -119,6 +126,27 @@ func (m *ModelSchedule) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *ModelSchedule) validateDealType(formats strfmt.Registry) error {
+	if swag.IsZero(m.DealType) { // not required
+		return nil
+	}
+
+	if err := m.DealType.Validate(formats); err != nil {
+		ve := new(errors.Validation)
+		if stderrors.As(err, &ve) {
+			return ve.ValidateName("dealType")
+		}
+		ce := new(errors.CompositeError)
+		if stderrors.As(err, &ce) {
+			return ce.ValidateName("dealType")
+		}
+
+		return err
+	}
+
 	return nil
 }
 
@@ -170,6 +198,10 @@ func (m *ModelSchedule) validateState(formats strfmt.Registry) error {
 func (m *ModelSchedule) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.contextValidateDealType(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateHTTPHeaders(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -181,6 +213,28 @@ func (m *ModelSchedule) ContextValidate(ctx context.Context, formats strfmt.Regi
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *ModelSchedule) contextValidateDealType(ctx context.Context, formats strfmt.Registry) error {
+
+	if swag.IsZero(m.DealType) { // not required
+		return nil
+	}
+
+	if err := m.DealType.ContextValidate(ctx, formats); err != nil {
+		ve := new(errors.Validation)
+		if stderrors.As(err, &ve) {
+			return ve.ValidateName("dealType")
+		}
+		ce := new(errors.CompositeError)
+		if stderrors.As(err, &ce) {
+			return ce.ValidateName("dealType")
+		}
+
+		return err
+	}
+
 	return nil
 }
 

--- a/client/swagger/models/schedule_create_request.go
+++ b/client/swagger/models/schedule_create_request.go
@@ -20,6 +20,9 @@ type ScheduleCreateRequest struct {
 	// Allowed piece CIDs in this schedule
 	AllowedPieceCids []string `json:"allowedPieceCids"`
 
+	// Deal type: market (f05) or pdp (f41)
+	DealType string `json:"dealType,omitempty"`
+
 	// Duration in epoch or in duration format, i.e. 1500000, 2400h
 	Duration *string `json:"duration,omitempty"`
 

--- a/client/swagger/models/schedule_update_request.go
+++ b/client/swagger/models/schedule_update_request.go
@@ -20,6 +20,9 @@ type ScheduleUpdateRequest struct {
 	// Allowed piece CIDs in this schedule
 	AllowedPieceCids []string `json:"allowedPieceCids"`
 
+	// Deal type: market (f05) or pdp (f41)
+	DealType string `json:"dealType,omitempty"`
+
 	// Duration in epoch or in duration format, i.e. 1500000, 2400h
 	Duration *string `json:"duration,omitempty"`
 

--- a/cmd/deal/schedule/create.go
+++ b/cmd/deal/schedule/create.go
@@ -9,6 +9,7 @@ import (
 	"github.com/data-preservation-programs/singularity/cmd/cliutil"
 	"github.com/data-preservation-programs/singularity/database"
 	"github.com/data-preservation-programs/singularity/handler/deal/schedule"
+	"github.com/data-preservation-programs/singularity/model"
 	"github.com/data-preservation-programs/singularity/util"
 	"github.com/urfave/cli/v2"
 )
@@ -57,6 +58,12 @@ var CreateCmd = &cli.Command{
 			Name:     "provider",
 			Usage:    "Storage Provider ID to send deals to",
 			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "deal-type",
+			Category: "Deal Proposal",
+			Usage:    "Deal type: market (legacy f05) or pdp (f41)",
+			Value:    string(model.DealTypeMarket),
 		},
 		&cli.StringSliceFlag{
 			Name:     "http-header",
@@ -219,6 +226,7 @@ var CreateCmd = &cli.Command{
 		request := schedule.CreateRequest{
 			Preparation:          c.String("preparation"),
 			Provider:             c.String("provider"),
+			DealType:             c.String("deal-type"),
 			HTTPHeaders:          c.StringSlice("http-header"),
 			URLTemplate:          c.String("url-template"),
 			PricePerGBEpoch:      c.Float64("price-per-gb-epoch"),

--- a/cmd/deal/schedule/update.go
+++ b/cmd/deal/schedule/update.go
@@ -83,6 +83,11 @@ var UpdateCmd = &cli.Command{
 			Usage:    "Whether to propose deals as verified",
 			Value:    true,
 		},
+		&cli.StringFlag{
+			Name:     "deal-type",
+			Category: "Deal Proposal",
+			Usage:    "Deal type: market (legacy f05) or pdp (f41)",
+		},
 		&cli.BoolFlag{
 			Name:     "ipni",
 			Category: "Boost Only",
@@ -207,6 +212,9 @@ var UpdateCmd = &cli.Command{
 		}
 		if c.IsSet("verified") {
 			request.Verified = ptr.Of(c.Bool("verified"))
+		}
+		if c.IsSet("deal-type") {
+			request.DealType = ptr.Of(c.String("deal-type"))
 		}
 		if c.IsSet("ipni") {
 			request.IPNI = ptr.Of(c.Bool("ipni"))

--- a/docs/en/cli-reference/deal/schedule/create.md
+++ b/docs/en/cli-reference/deal/schedule/create.md
@@ -52,6 +52,7 @@ OPTIONS:
 
    Deal Proposal
 
+   --deal-type value              Deal type: market (legacy f05) or pdp (f41) (default: "market")
    --duration value, -d value     Duration in epoch or in duration format, i.e. 1500000, 2400h (default: 12840h[535 days])
    --keep-unsealed                Whether to keep unsealed copy (default: true)
    --price-per-deal value         Price in FIL per deal (default: 0)

--- a/docs/en/cli-reference/deal/schedule/update.md
+++ b/docs/en/cli-reference/deal/schedule/update.md
@@ -50,6 +50,7 @@ OPTIONS:
 
    Deal Proposal
 
+   --deal-type value              Deal type: market (legacy f05) or pdp (f41)
    --duration value, -d value     Duration in epoch or in duration format, i.e. 1500000, 2400h
    --keep-unsealed                Whether to keep unsealed copy (default: true)
    --price-per-deal value         Price in FIL per deal (default: 0)

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -6790,6 +6790,9 @@ const docTemplate = `{
                 "createdAt": {
                     "type": "string"
                 },
+                "dealType": {
+                    "$ref": "#/definitions/model.DealType"
+                },
                 "duration": {
                     "type": "integer"
                 },
@@ -6974,6 +6977,10 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "dealType": {
+                    "description": "Deal type: market (f05) or pdp (f41)",
+                    "type": "string"
+                },
                 "duration": {
                     "description": "Duration in epoch or in duration format, i.e. 1500000, 2400h",
                     "type": "string",
@@ -7084,6 +7091,10 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                },
+                "dealType": {
+                    "description": "Deal type: market (f05) or pdp (f41)",
+                    "type": "string"
                 },
                 "duration": {
                     "description": "Duration in epoch or in duration format, i.e. 1500000, 2400h",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -6783,6 +6783,9 @@
                 "createdAt": {
                     "type": "string"
                 },
+                "dealType": {
+                    "$ref": "#/definitions/model.DealType"
+                },
                 "duration": {
                     "type": "integer"
                 },
@@ -6967,6 +6970,10 @@
                         "type": "string"
                     }
                 },
+                "dealType": {
+                    "description": "Deal type: market (f05) or pdp (f41)",
+                    "type": "string"
+                },
                 "duration": {
                     "description": "Duration in epoch or in duration format, i.e. 1500000, 2400h",
                     "type": "string",
@@ -7077,6 +7084,10 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "dealType": {
+                    "description": "Deal type: market (f05) or pdp (f41)",
+                    "type": "string"
                 },
                 "duration": {
                     "description": "Duration in epoch or in duration format, i.e. 1500000, 2400h",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -614,6 +614,8 @@ definitions:
         type: boolean
       createdAt:
         type: string
+      dealType:
+        $ref: '#/definitions/model.DealType'
       duration:
         type: integer
       errorMessage:
@@ -739,6 +741,9 @@ definitions:
         items:
           type: string
         type: array
+      dealType:
+        description: 'Deal type: market (f05) or pdp (f41)'
+        type: string
       duration:
         default: 12840h
         description: Duration in epoch or in duration format, i.e. 1500000, 2400h
@@ -825,6 +830,9 @@ definitions:
         items:
           type: string
         type: array
+      dealType:
+        description: 'Deal type: market (f05) or pdp (f41)'
+        type: string
       duration:
         default: 12840h
         description: Duration in epoch or in duration format, i.e. 1500000, 2400h

--- a/handler/deal/schedule/create_test.go
+++ b/handler/deal/schedule/create_test.go
@@ -53,6 +53,7 @@ func getMockLotusClient() jsonrpc.RPCClient {
 var createRequest = CreateRequest{
 	Preparation:           "1",
 	Provider:              "f01000",
+	DealType:              string(model.DealTypeMarket),
 	HTTPHeaders:           []string{"a=b"},
 	URLTemplate:           "http://127.0.0.1",
 	PricePerGBEpoch:       0,
@@ -186,6 +187,22 @@ func TestCreateHandler_NoAssociatedWallet(t *testing.T) {
 	})
 }
 
+func TestCreateHandler_InvalidDealType(t *testing.T) {
+	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
+		err := db.Create(&model.Preparation{
+			Wallets: []model.Wallet{{
+				Address: "f01", KeyPath: "/tmp/key", KeyStore: "local",
+			}},
+		}).Error
+		require.NoError(t, err)
+		badRequest := createRequest
+		badRequest.DealType = "unknown"
+		_, err = Default.CreateHandler(ctx, db, getMockLotusClient(), badRequest)
+		require.ErrorIs(t, err, handlererror.ErrInvalidParameter)
+		require.ErrorContains(t, err, "invalid deal type")
+	})
+}
+
 func TestCreateHandler_InvalidProvider(t *testing.T) {
 	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
 		err := db.Create(&model.Preparation{
@@ -260,6 +277,7 @@ func TestCreateHandler_Success(t *testing.T) {
 				schedule, err := Default.CreateHandler(ctx, db, getMockLotusClient(), createRequest)
 				require.NoError(t, err)
 				require.NotNil(t, schedule)
+				require.Equal(t, model.DealTypeMarket, schedule.DealType)
 				require.True(t, createRequest.Force)
 			})
 		})

--- a/model/replication.go
+++ b/model/replication.go
@@ -162,6 +162,7 @@ type Schedule struct {
 	ErrorMessage          string        `json:"errorMessage"                        table:"verbose"`
 	AllowedPieceCIDs      StringSlice   `gorm:"type:JSON;column:allowed_piece_cids" json:"allowedPieceCids"                    table:"verbose"`
 	Force                 bool          `json:"force"`
+	DealType              DealType      `gorm:"index;default:'market'"                json:"dealType"`
 
 	// Associations
 	PreparationID PreparationID `json:"preparationId"`

--- a/service/dealpusher/dealpusher.go
+++ b/service/dealpusher/dealpusher.go
@@ -453,6 +453,12 @@ func (d *DealPusher) runSchedule(ctx context.Context, schedule *model.Schedule) 
 
 func (d *DealPusher) resolveScheduleDealType(schedule *model.Schedule) model.DealType {
 	if d.scheduleDealTypeResolver == nil {
+		if schedule != nil {
+			switch schedule.DealType {
+			case model.DealTypeMarket, model.DealTypePDP:
+				return schedule.DealType
+			}
+		}
 		return inferScheduleDealType(schedule)
 	}
 	return d.scheduleDealTypeResolver(schedule)

--- a/service/dealpusher/pdp_wiring_test.go
+++ b/service/dealpusher/pdp_wiring_test.go
@@ -60,6 +60,11 @@ func TestDealPusher_ResolveScheduleDealType_DelegatedProviderInfersPDP(t *testin
 	require.Equal(t, model.DealTypePDP, d.resolveScheduleDealType(&model.Schedule{Provider: providerAddr.String()}))
 }
 
+func TestDealPusher_ResolveScheduleDealType_UsesScheduleDealType(t *testing.T) {
+	d := &DealPusher{}
+	require.Equal(t, model.DealTypePDP, d.resolveScheduleDealType(&model.Schedule{DealType: model.DealTypePDP}))
+}
+
 func TestDealPusher_RunSchedule_PDPWithoutDependenciesReturnsConfiguredError(t *testing.T) {
 	d := &DealPusher{
 		scheduleDealTypeResolver: func(_ *model.Schedule) model.DealType {


### PR DESCRIPTION
## Summary
- add explicit `dealType` on schedule model (`market` or `pdp`)
- accept and validate `dealType` in schedule create/update handlers
- add CLI flags:
  - `singularity deal schedule create --deal-type`
  - `singularity deal schedule update --deal-type`
- make dealpusher honor `schedule.dealType` in default resolution (while keeping existing resolver override behavior)
- add tests for invalid deal type rejection and successful persistence

## Validation
- go test ./handler/deal/schedule
- go test ./service/dealpusher
- go test ./cmd