### PR TITLE
log wallet_assignments migration progress in export-keys

### DIFF
--- a/handler/wallet/export_keys.go
+++ b/handler/wallet/export_keys.go
@@ -81,6 +81,10 @@ func migrateWalletAssignments(db *gorm.DB) error {
 		return errors.Wrap(err, "failed to read wallet_assignments")
 	}
 
+	if len(rows) > 0 {
+		logger.Infow("migrating wallet_assignments to preparation.wallet_id", "count", len(rows))
+	}
+
 	migrated := 0
 	for _, r := range rows {
 		// find the new wallet by actor_id


### PR DESCRIPTION
With large wallet_assignments tables (observed 719 rows in production), migrateWalletAssignments runs long enough that users wonder if the command is hung. Emit an info log at the start of the migration showing the row count, so users see progress between the per-key export logs and the final 'migrated N' summary.