### PR TITLE
index car_blocks.file_id to fix FK cascade scans

### DIFF
--- a/model/migrate_test.go
+++ b/model/migrate_test.go
@@ -77,9 +77,6 @@ func TestFKSetNullOnDelete(t *testing.T) {
 	})
 }
 
-// indexes on CarBlock FK columns must exist or SET NULL cascades from parent
-// deletion fall back to seq scans of the entire car_blocks table. this has bit
-// us before -- the reaper wedged for months because file_id was unindexed.
 func TestCarBlockFKIndexes(t *testing.T) {
 	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
 		require.True(t, db.Migrator().HasIndex(&model.CarBlock{}, "CarID"),

--- a/model/migrate_test.go
+++ b/model/migrate_test.go
@@ -77,6 +77,20 @@ func TestFKSetNullOnDelete(t *testing.T) {
 	})
 }
 
+// indexes on CarBlock FK columns must exist or SET NULL cascades from parent
+// deletion fall back to seq scans of the entire car_blocks table. this has bit
+// us before -- the reaper wedged for months because file_id was unindexed.
+func TestCarBlockFKIndexes(t *testing.T) {
+	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
+		require.True(t, db.Migrator().HasIndex(&model.CarBlock{}, "CarID"),
+			"car_blocks.car_id must be indexed for FK cascade performance")
+		require.True(t, db.Migrator().HasIndex(&model.CarBlock{}, "FileID"),
+			"car_blocks.file_id must be indexed for FK cascade performance")
+		require.True(t, db.Migrator().HasIndex(&model.CarBlock{}, "CID"),
+			"car_blocks.cid must be indexed for gateway lookups")
+	})
+}
+
 func TestInferPieceTypes(t *testing.T) {
 	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
 		prep := model.Preparation{Name: "test", MaxSize: 1024, PieceSize: 1024}

--- a/model/preparation.go
+++ b/model/preparation.go
@@ -304,7 +304,7 @@ type CarBlock struct {
 	// Associations - SET NULL for fast prep deletion, async cleanup
 	CarID  *CarID  `cbor:"-"                    gorm:"index"                                          json:"carId"`
 	Car    *Car    `cbor:"-"                    gorm:"foreignKey:CarID;constraint:OnDelete:SET NULL"  json:"car,omitempty"  swaggerignore:"true"`
-	FileID *FileID `cbor:"7,keyasint,omitempty" json:"fileId"`
+	FileID *FileID `cbor:"7,keyasint,omitempty" gorm:"index"                                         json:"fileId"`
 	File   *File   `cbor:"-"                    gorm:"foreignKey:FileID;constraint:OnDelete:SET NULL" json:"file,omitempty" swaggerignore:"true"`
 }
 


### PR DESCRIPTION
`CarBlock.FileID` was unindexed, so `ON DELETE SET NULL` from `files.id` triggered a full seq scan of `car_blocks` per deleted file. At ~1.5B rows this wedged the reaper's files phase for months.

- add `gorm:"index"` on `CarBlock.FileID` (matching `CarID`)
- regression test asserting `CarID`, `FileID`, `CID` are all indexed