### PR TITLE
api: fix out-of-bounds on lone-error handler returns

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -281,7 +281,7 @@ func (s *Server) toEchoHandler(handlerFunc any) echo.HandlerFunc {
 		if len(results) == 1 {
 			// Handle the returned error
 			if results[0].Interface() != nil {
-				err, ok := results[1].Interface().(error)
+				err, ok := results[0].Interface().(error)
 				if !ok {
 					return c.JSON(http.StatusInternalServerError, HTTPError{Err: "invalid handler function signature"})
 				}


### PR DESCRIPTION
## Summary
- `api/api.go` dispatch had `results[1]` in the `len(results) == 1` branch, which indexes past the end for any handler whose signature is just `error` (e.g. `ResetHandler`, `InitHandler`, `RemovePreparationHandler`, every `RemoveHandler`, etc.).
- Any non-nil error return on those handlers panicked the Echo request goroutine instead of producing an HTTP error response.
- Fix: read `results[0]` -- the only result value is the error itself.

## Test plan
- [x] `go test ./api/...`
- [x] CI