### PR TITLE
datasetworker: apply MaxInterval default to the right field

### DIFF
--- a/service/datasetworker/datasetworker.go
+++ b/service/datasetworker/datasetworker.go
@@ -52,7 +52,7 @@ func NewWorker(db *gorm.DB, config Config) *Worker {
 		config.MinInterval = defaultMinInterval
 	}
 	if config.MaxInterval == 0 {
-		config.MinInterval = defaultMaxInterval
+		config.MaxInterval = defaultMaxInterval
 	}
 	stateMonitor := NewStateMonitor(db)
 	return &Worker{


### PR DESCRIPTION
## Summary
- \`NewWorker\`'s \`MaxInterval == 0\` guard was assigning the default to \`MinInterval\`, so \`MaxInterval\` stayed zero when unset.
- Consequence: the upper bound on exponential backoff between empty work checks never kicks in; workers keep polling at \`MinInterval\` regardless of the intended cap.
- One-line fix; clean copy-paste bug from the \`MinInterval\` branch two lines above.

## Test plan
- [x] \`go test ./service/datasetworker/...\`
- [x] CI