### PR TITLE
dataprep: fix err order and %d/string in ListPiecesHandler

### DIFF
--- a/handler/dataprep/piece.go
+++ b/handler/dataprep/piece.go
@@ -63,11 +63,11 @@ func (DefaultHandler) ListPiecesHandler(
 	}
 	var sourceAttachments []model.SourceAttachment
 	err = db.Preload("Storage").Where("preparation_id = ?", preparation.ID).Find(&sourceAttachments).Error
-	if len(sourceAttachments) == 0 {
-		return nil, errors.Wrapf(handlererror.ErrNotFound, "preparation %d not found", id)
-	}
 	if err != nil {
 		return nil, errors.WithStack(err)
+	}
+	if len(sourceAttachments) == 0 {
+		return nil, errors.Wrapf(handlererror.ErrNotFound, "preparation %s not found", id)
 	}
 
 	var pieceLists []PieceList


### PR DESCRIPTION
## Summary
Two small bugs in \`ListPiecesHandler\`, both in the same block:

1. The \`Find(&sourceAttachments)\` error was checked after the \`len == 0\` guard. A DB failure (connection lost, timeout) yielded an empty slice which the handler then reported as 404 \"preparation not found\" -- masking 500s as missing data.

2. The not-found format string used \`%d\` against the \`id string\` argument, producing messages like \`preparation %!d(string=foo) not found\`.

Fix: check err first; format the id with \`%s\`.

## Test plan
- [x] \`go test ./handler/dataprep/...\`
- [x] CI