### PR TITLE
devcontainer: add forge alongside anvil

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,6 +25,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=ghcr.io/foundry-rs/foundry:latest /usr/local/bin/anvil /usr/local/bin/anvil
+# forge is needed by `go generate ./...` via util/testutil/sol/Makefile
+# (fvm_precompiles.go go:generate rebuilds the mock bytecode .txt files)
+COPY --from=ghcr.io/foundry-rs/foundry:latest /usr/local/bin/forge /usr/local/bin/forge
 
 # prepare user-owned data dirs for rootless startup
 RUN mkdir -p /home/vscode/.local/share/pg/pgdata \


### PR DESCRIPTION
## Summary
PR #669 added \`//go:generate make -C sol bytecode\` to \`util/testutil/fvm_precompiles.go\`, which calls \`forge build\` + \`forge inspect\`. The devcontainer's Dockerfile only copied \`anvil\` from the Foundry image, not \`forge\`.

Effect: CI's \"Generate swagger code\" step runs \`go generate ./...\` whenever codegen-gated paths (\`api/\`, \`handler/\`, \`cmd/\`, \`storagesystem/\`, \`docs/gen/\`, \`model/\`, \`singularity.go\`, \`docgen.sh\`) change. On those PRs, \`make -C sol bytecode\` fails with \`forge: No such file or directory\`.

Currently blocks #670, #673, #674.

## Test plan
- [ ] CI devcontainer build includes \`/usr/local/bin/forge\`
- [ ] \`go generate ./...\` succeeds inside the devcontainer