### PR TITLE
datasetworker: skip pack jobs orphaned by deleted preparation

### DIFF
--- a/pack/pack.go
+++ b/pack/pack.go
@@ -88,6 +88,11 @@ func Pack(
 	job model.Job,
 ) (*model.Car, error) {
 	db = db.WithContext(ctx)
+	// Attachment is nil when the job was orphaned by a deleted preparation; guard
+	// against the SET NULL cascade racing the reaper rather than panicking.
+	if job.Attachment == nil || job.Attachment.Preparation == nil {
+		return nil, errors.Errorf("job %d has no attachment, likely orphaned by a deleted preparation", job.ID)
+	}
 	pieceSize := job.Attachment.Preparation.GetMinPieceSize()
 	// storageWriter can be nil for inline preparation
 	storageID, storageWriter, err := storagesystem.GetRandomOutputWriter(ctx, job.Attachment.Preparation.OutputStorages)

--- a/service/datasetworker/find.go
+++ b/service/datasetworker/find.go
@@ -38,7 +38,9 @@ func (w *Thread) findJob(ctx context.Context, typesOrdered []model.JobType) (*mo
 					Strength: "UPDATE",
 					Options:  "SKIP LOCKED",
 				}).
-					Where("type = ? AND (state = ? OR (state = ? AND worker_id IS NULL))", jobType, model.Ready, model.Processing).
+					// attachment_id IS NOT NULL skips jobs orphaned by a deleted
+					// preparation (SET NULL cascade); the reaper deletes those.
+					Where("type = ? AND attachment_id IS NOT NULL AND (state = ? OR (state = ? AND worker_id IS NULL))", jobType, model.Ready, model.Processing).
 					First(&job).Error
 				if err != nil {
 					if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/service/datasetworker/find_test.go
+++ b/service/datasetworker/find_test.go
@@ -67,3 +67,30 @@ func TestFindPackWork(t *testing.T) {
 		require.Equal(t, thread.id.String(), *existing.WorkerID)
 	})
 }
+
+// A job orphaned by a deleted preparation (attachment_id NULL via SET NULL
+// cascade) must be skipped, not claimed, so it never reaches pack.Pack.
+func TestFindPackWorkSkipsOrphanedJob(t *testing.T) {
+	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
+		thread := &Thread{
+			dbNoContext: db,
+			config:      Config{EnablePack: true},
+			logger:      logger.With("test", true),
+			id:          uuid.New(),
+		}
+
+		_, err := healthcheck.Register(ctx, thread.dbNoContext, thread.id, model.DatasetWorker, true)
+		require.NoError(t, err)
+
+		err = db.Create(&model.Job{
+			AttachmentID: nil,
+			State:        model.Ready,
+			Type:         model.Pack,
+		}).Error
+		require.NoError(t, err)
+
+		found, err := thread.findJob(ctx, []model.JobType{model.Pack})
+		require.NoError(t, err)
+		require.Nil(t, found)
+	})
+}


### PR DESCRIPTION
## Problem

A pack worker reliably panics with a nil-pointer dereference at `pack/pack.go:91` (`job.Attachment.Preparation.GetMinPieceSize()`), taking down the whole `dataset-worker` service. With `--exit-on-error` it becomes a crash loop: the panic unwinds past the normal error handler so the job's state is never set to `Error`, and on restart the healthcheck resets the dead worker's claimed job back to `Ready`, so the same job is picked and panics again.

## Root cause

All job/file/car associations use `OnDelete:SET NULL` "for fast prep deletion, async cleanup". When a preparation (or attachment) is deleted, the DB sets `jobs.attachment_id` to `NULL` and leaves the healthcheck reaper to delete those orphaned rows later, in batches of 100 every 5 minutes.

`findJob` claims pack jobs with:

```go
Where("type = ? AND (state = ? OR (state = ? AND worker_id IS NULL))", ...)
```

There is no `attachment_id IS NOT NULL` guard, so an orphaned job whose attachment was nulled — but not yet reaped — gets claimed. The preload then leaves `job.Attachment` nil and `pack.Pack` dereferences it.

This is data-state dependent, not DB-engine dependent (it reproduces on both sqlite and postgres); a fresh DB just hides it until the next preparation deletion.

## Fix

- `findJob`: add `attachment_id IS NOT NULL` so orphaned jobs are skipped and left for the reaper.
- `pack.Pack`: guard defensively against a nil `Attachment`/`Preparation` (returns an error instead of panicking) to cover the SET-NULL-vs-reaper race.
- Test: `TestFindPackWorkSkipsOrphanedJob` asserts an orphaned pack job is not claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)