### PR TITLE
datasetworker: skip jobs orphaned by deleted preparations

### DIFF
--- a/service/datasetworker/datasetworker.go
+++ b/service/datasetworker/datasetworker.go
@@ -299,13 +299,20 @@ func (w *Thread) run(ctx context.Context) (retErr error) {
 		}
 
 		w.stateMonitor.AddJob(job.ID, workCancel)
-		switch job.Type {
-		case model.Scan:
-			err = w.scan(workCtx, *job.Attachment)
-		case model.Pack:
-			err = w.pack(workCtx, *job)
-		case model.DagGen:
-			err = w.ExportDag(workCtx, *job)
+		// belt-and-suspenders: findJob filters attachment_id IS NOT NULL, but if a job slips through
+		// without its Attachment preloaded (e.g. row was orphaned between claim and preload) we'd
+		// otherwise nil-deref *job.Attachment below. Mark it errored and move on.
+		if job.Attachment == nil {
+			err = errors.Errorf("job %d has no attachment (orphaned by prep deletion)", job.ID)
+		} else {
+			switch job.Type {
+			case model.Scan:
+				err = w.scan(workCtx, *job.Attachment)
+			case model.Pack:
+				err = w.pack(workCtx, *job)
+			case model.DagGen:
+				err = w.ExportDag(workCtx, *job)
+			}
 		}
 		w.stateMonitor.RemoveJob(job.ID)
 		if workCtx.Err() != nil && ctx.Err() == nil {

--- a/service/datasetworker/find.go
+++ b/service/datasetworker/find.go
@@ -33,12 +33,16 @@ func (w *Thread) findJob(ctx context.Context, typesOrdered []model.JobType) (*mo
 	for _, jobType := range typesOrdered {
 		err := database.DoRetry(ctx, func() error {
 			return db.Transaction(func(db *gorm.DB) error {
-				// First, lock and claim the job without preloading (preload can interfere with locking)
+				// First, lock and claim the job without preloading (preload can interfere with locking).
+				// attachment_id IS NOT NULL skips orphans: jobs.attachment_id is ON DELETE SET NULL, so
+				// deleting a prep leaves its jobs behind with state=ready and a null FK. Claiming one
+				// would nil-deref *job.Attachment in the run loop. The healthcheck sweep deletes these
+				// eventually but it races worker pickup -- filter here too.
 				err := db.Clauses(clause.Locking{
 					Strength: "UPDATE",
 					Options:  "SKIP LOCKED",
 				}).
-					Where("type = ? AND (state = ? OR (state = ? AND worker_id IS NULL))", jobType, model.Ready, model.Processing).
+					Where("type = ? AND attachment_id IS NOT NULL AND (state = ? OR (state = ? AND worker_id IS NULL))", jobType, model.Ready, model.Processing).
 					First(&job).Error
 				if err != nil {
 					if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/service/datasetworker/find_test.go
+++ b/service/datasetworker/find_test.go
@@ -13,6 +13,38 @@ import (
 	"gorm.io/gorm"
 )
 
+// A job whose preparation was deleted has attachment_id NULL (SET NULL cascade)
+// and stays Ready until the healthcheck reaper sweeps it. findJob must skip these
+// rather than claim them and nil-deref *job.Attachment downstream.
+func TestFindWorkSkipsOrphanedJob(t *testing.T) {
+	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
+		thread := &Thread{
+			dbNoContext: db,
+			config:      Config{EnableScan: true, EnablePack: true, EnableDag: true},
+			logger:      logger.With("test", true),
+			id:          uuid.New(),
+		}
+
+		_, err := healthcheck.Register(ctx, thread.dbNoContext, thread.id, model.DatasetWorker, true)
+		require.NoError(t, err)
+
+		for _, jt := range []model.JobType{model.Scan, model.Pack, model.DagGen} {
+			err = db.Create(&model.Job{
+				AttachmentID: nil,
+				State:        model.Ready,
+				Type:         jt,
+			}).Error
+			require.NoError(t, err)
+		}
+
+		for _, jt := range []model.JobType{model.Scan, model.Pack, model.DagGen} {
+			found, err := thread.findJob(ctx, []model.JobType{jt})
+			require.NoError(t, err)
+			require.Nil(t, found, "orphaned %s job must not be claimed", jt)
+		}
+	})
+}
+
 func TestFindPackWork(t *testing.T) {
 	testutil.All(t, func(ctx context.Context, t *testing.T, db *gorm.DB) {
 		thread := &Thread{


### PR DESCRIPTION
## Problem

A dataset worker can nil-deref `*job.Attachment` and panic, taking down the service. Reported as a pack-side panic at `pack/pack.go:91` (`job.Attachment.Preparation.GetMinPieceSize()`), but the same shape exists at the run-loop dispatch in `datasetworker.go` for all three job types -- a `unified.db` from a user's `prep start-scan` run shows the scan path panicking with the same root cause.

With `--exit-on-error` it becomes a crash loop: the panic unwinds past the normal error handler so the job's state is never written to `Error`, and on restart the healthcheck resets the dead worker's claimed job back to `Ready`. Same job, same panic, again.

## Root cause

Job/file/car associations use `OnDelete: SET NULL` for fast prep deletion with async reaping. When a preparation (or attachment) is deleted, `jobs.attachment_id` is nulled and the healthcheck reaper deletes those rows later, in batches of 100 every 5 minutes.

`findJob` claims jobs with:

\`\`\`go
Where("type = ? AND (state = ? OR (state = ? AND worker_id IS NULL))", ...)
\`\`\`

No `attachment_id IS NOT NULL` guard, so an orphaned job whose attachment was nulled but not yet reaped gets claimed. The preload then leaves `job.Attachment` nil and the dispatch -- `case model.Scan: w.scan(workCtx, *job.Attachment)` and the equivalents for `Pack`/`DagGen` -- nil-derefs.

Data-state dependent, not engine dependent: reproduces on sqlite and postgres alike. A fresh DB just hides it until the next preparation deletion.

## Fix

- `find.go`: add `attachment_id IS NOT NULL` so orphaned jobs are skipped and left for the reaper. This is the primary fix.
- `datasetworker.go`: defensive nil guard at the run-loop dispatch, covering Scan/Pack/DagGen uniformly. Belt-and-suspenders for any race between the SET NULL cascade and the claim+preload window.
- `find_test.go`: `TestFindWorkSkipsOrphanedJob` asserts orphaned jobs of all three types are not claimed.

Supersedes #679 -- same primary fix, with the defensive guard moved one frame up so Scan and DagGen are covered by the same code path, not just Pack.