### PR TITLE
goreleaser: build with CGO+zig cross for linux/windows, native macos for darwin

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -29,10 +29,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      # zig cc provides the C cross-toolchain for linux/windows targets so CGO deps
-      # (blst) compile. darwin cross doesn't work with zig -- macOS SDK headers
-      # aren't shipped -- so darwin runs on macos-latest with native clang.
-      # curl the tarball directly; mlugg/setup-zig@v1's mirror pool was 404/503-ing.
+      # curl zig directly; setup-zig actions have unreliable mirror pools
       - name: Set up Zig
         if: matrix.needs_zig
         run: |
@@ -48,10 +45,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          # workflow_dispatch runs from a branch (no tag at HEAD); snapshot mode
-          # builds all targets without trying to publish, for CI iteration.
-          args: >-
-            release --clean --config ${{ matrix.config }}
-            ${{ github.event_name == 'workflow_dispatch' && '--snapshot' || '' }}
+          args: release --clean --config ${{ matrix.config }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -8,8 +8,18 @@ on:
     types: [completed]
 jobs:
   bin-releaser:
-    name: Release Binaries
-    runs-on: ubuntu-latest
+    name: Release Binaries (${{ matrix.runner }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            config: .goreleaser.yaml
+            needs_zig: true
+          - runner: macos-latest
+            config: .goreleaser.darwin.yaml
+            needs_zig: false
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -19,11 +29,29 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      # zig cc provides the C cross-toolchain for linux/windows targets so CGO deps
+      # (blst) compile. darwin cross doesn't work with zig -- macOS SDK headers
+      # aren't shipped -- so darwin runs on macos-latest with native clang.
+      # curl the tarball directly; mlugg/setup-zig@v1's mirror pool was 404/503-ing.
+      - name: Set up Zig
+        if: matrix.needs_zig
+        run: |
+          set -eu
+          ZV=0.14.1
+          curl -sL https://ziglang.org/download/${ZV}/zig-x86_64-linux-${ZV}.tar.xz -o /tmp/zig.tar.xz
+          mkdir -p "$HOME/zig-${ZV}"
+          tar -xJf /tmp/zig.tar.xz -C "$HOME/zig-${ZV}" --strip-components=1
+          echo "$HOME/zig-${ZV}" >> "$GITHUB_PATH"
+          "$HOME/zig-${ZV}/zig" version
       - name: Release Binaries
         uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
           version: latest
-          args: ${{ github.event_name == 'pull_request' && 'release --snapshot --skip-publish' || 'release --clean' }}
+          # workflow_dispatch runs from a branch (no tag at HEAD); snapshot mode
+          # builds all targets without trying to publish, for CI iteration.
+          args: >-
+            release --clean --config ${{ matrix.config }}
+            ${{ github.event_name == 'workflow_dispatch' && '--snapshot' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.darwin.yaml
+++ b/.goreleaser.darwin.yaml
@@ -1,0 +1,37 @@
+version: 2
+
+# darwin-only config; runs on macos-latest so native clang can find mach/mach_vm.h
+# and other macOS SDK headers that the ubuntu+zig setup can't provide.
+project_name: singularity
+
+builds:
+  - id: singularity-darwin
+    env:
+      - CGO_ENABLED=1
+    binary: singularity
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: '{{.CommitTimestamp}}'
+
+archives:
+  - format_overrides:
+      - goos: darwin
+        formats: [zip]
+    name_template: '{{ .ProjectName }}_{{ .Version }}_mac_os_{{ .Arch }}'
+    files:
+      - LICENSE
+      - README.md
+      - docs/*
+
+release:
+  mode: keep-existing
+
+changelog:
+  disable: true
+
+checksum:
+  name_template: 'checksums-darwin.txt'
+  disable: false

--- a/.goreleaser.darwin.yaml
+++ b/.goreleaser.darwin.yaml
@@ -1,7 +1,5 @@
 version: 2
 
-# darwin-only config; runs on macos-latest so native clang can find mach/mach_vm.h
-# and other macOS SDK headers that the ubuntu+zig setup can't provide.
 project_name: singularity
 
 builds:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,28 +1,48 @@
 version: 2
 
+# linux + windows only; darwin is built on a macos runner via .goreleaser.darwin.yaml
+# because zig's shipped libc has no mach/mach_vm.h header (prometheus/client_golang
+# CGO stub for macOS process metrics). native clang on macos-latest handles that.
 builds:
-  - env:
-      - CGO_ENABLED=0
+  - id: singularity-nixwin
+    env:
+      - CGO_ENABLED=1
     binary: singularity
     goos:
       - linux
       - windows
-      - darwin
     goarch:
       - amd64
       - arm64
+    overrides:
+      - goos: linux
+        goarch: amd64
+        env:
+          - CC=zig cc -target x86_64-linux-gnu
+          - CXX=zig c++ -target x86_64-linux-gnu
+      - goos: linux
+        goarch: arm64
+        env:
+          - CC=zig cc -target aarch64-linux-gnu
+          - CXX=zig c++ -target aarch64-linux-gnu
+      - goos: windows
+        goarch: amd64
+        env:
+          - CC=zig cc -target x86_64-windows-gnu
+          - CXX=zig c++ -target x86_64-windows-gnu
+      - goos: windows
+        goarch: arm64
+        env:
+          - CC=zig cc -target aarch64-windows-gnu
+          - CXX=zig c++ -target aarch64-windows-gnu
     mod_timestamp: '{{.CommitTimestamp}}'
 
 archives:
   - format_overrides:
       - goos: windows
-        format: zip
-      - goos: darwin
-        format: zip
+        formats: [zip]
     name_template: >-
-      {{ .ProjectName }}_{{ .Version }}_
-      {{- if eq .Os "darwin" }}mac_os
-      {{- else }}{{ .Os }}{{ end }}_{{ .Arch }}
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
     files:
       - LICENSE
       - README.md
@@ -34,7 +54,9 @@ release:
 changelog:
   disable: true
 
+# separate checksums file per runner so ubuntu and macos don't overwrite each other
 checksum:
+  name_template: 'checksums-nixwin.txt'
   disable: false
 
 nfpms:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,5 @@
 version: 2
 
-# linux + windows only; darwin is built on a macos runner via .goreleaser.darwin.yaml
-# because zig's shipped libc has no mach/mach_vm.h header (prometheus/client_golang
-# CGO stub for macOS process metrics). native clang on macos-latest handles that.
 builds:
   - id: singularity-nixwin
     env:
@@ -54,7 +51,6 @@ release:
 changelog:
   disable: true
 
-# separate checksums file per runner so ubuntu and macos don't overwrite each other
 checksum:
   name_template: 'checksums-nixwin.txt'
   disable: false


### PR DESCRIPTION
CGO_ENABLED=0 no longer compiles: cmd/wallet transitively pulls blst via go-synapse/signer, and blst's rb_tree.go needs the CGO-only Message symbol.

Matrix split: ubuntu-latest builds linux+windows via zig cc (single portable libc, no mingw needed); macos-latest builds darwin natively since zig doesn't ship the macOS SDK and prometheus/client_golang needs mach headers. Both runners write to the same release via `release.mode: keep-existing` with separate checksum filenames.